### PR TITLE
fix(session): deadlock in sync_player_registry_state (DashMap re-entrant get) (#68)

### DIFF
--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -25811,6 +25811,13 @@ impl WorldSession {
         let (Some(guid), Some(registry)) = (self.player_guid(), &self.player_registry) else {
             return;
         };
+        // Compute values that themselves read `player_registry` BEFORE locking the
+        // entry. `player_unit_state_for_registry_like_cpp` falls back to
+        // `registry.get(&guid)` when there is no canonical map manager (e.g. tests);
+        // calling it while holding `get_mut(&guid)` would re-lock the same DashMap
+        // shard on this thread → deadlock. It is the only sync-called helper that
+        // reads the registry, so hoisting just this one is sufficient.
+        let unit_state_for_registry = self.player_unit_state_for_registry_like_cpp();
         if let Some(mut info) = registry.get_mut(&guid) {
             info.is_in_world = self.player_is_in_world_for_registry_like_cpp();
             info.combat_reach = self.canonical_player_combat_reach_snapshot_like_cpp();
@@ -25864,7 +25871,7 @@ impl WorldSession {
             info.spec_id = self.loot_specialization_id_like_cpp();
             info.unit_flags = self.player_unit_flags_like_cpp.bits();
             info.unit_flags2 = self.canonical_player_unit_flags2_snapshot_like_cpp();
-            info.unit_state = self.player_unit_state_for_registry_like_cpp();
+            info.unit_state = unit_state_for_registry;
             info.is_game_master = self.player_game_master_like_cpp;
             info.dungeon_difficulty_id = self.represented_dungeon_difficulty_id_like_cpp;
             info.is_contested_pvp = self.canonical_player_contested_pvp_flag_like_cpp();


### PR DESCRIPTION
Closes #68

`sync_player_registry_state_like_cpp` held `player_registry.get_mut(&guid)` (a DashMap shard write guard) and, inside the guard, called `player_unit_state_for_registry_like_cpp()`. With no canonical map manager (e.g. unit tests) that helper falls back to `player_registry.get(&guid)` on the **same shard** → re-entrant DashMap lock → **deadlock** (`futex_wait`, 0% CPU). This hung the `Focused library tests` CI job indefinitely (surfaced via the dead-player chat tests).

**Fix:** compute the unit-state snapshot into a local *before* acquiring `get_mut`; it is the only sync-called helper that reads the registry.

**Verified:** `cargo test -p wow-world --lib` now runs to completion (was: hang); the 3 dead-player chat tests pass.

> ⚠ Running the full suite to completion also un-masked **3 pre-existing, unrelated test failures** (`handlers::loot::...personal_encounter_open_reads_player_money`, `session::...nearby_entry_destination_without_target_fails_bad_implicit_targets`, `session::...summon_object_live_spell_requires_focus...`) that the hang was hiding. Tracked separately; the `Focused library tests` check stays non-required until they're green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)