### PR TITLE
test(wow-world): fix 3 expectations unmasked by deadlock fix (#70)

### DIFF
--- a/crates/wow-world/src/handlers/loot.rs
+++ b/crates/wow-world/src/handlers/loot.rs
@@ -10078,7 +10078,10 @@ mod tests {
             recv_packet_with_opcode(&send_rx, wow_constants::ServerOpcodes::LootResponse);
         assert_eq!(response.read_packed_guid().unwrap(), gameobject_guid);
         assert_eq!(response.read_packed_guid().unwrap(), loot_object);
-        assert_eq!(response.read_uint8().unwrap(), 0);
+        // failure_reason: C++ LootResponse::FailureReason defaults to 17 (LOOT_ERROR_NO_LOOT,
+        // LootPackets.h:72 "Most common value") and is left unset on a successful loot — the
+        // client ignores it once the window opens. (Previously, wrongly asserted as 0.)
+        assert_eq!(response.read_uint8().unwrap(), 17);
         assert_eq!(response.read_uint8().unwrap(), LOOT_TYPE_CHEST_LIKE_CPP);
         assert_eq!(response.read_uint8().unwrap(), 0);
         assert_eq!(response.read_uint8().unwrap(), 2);

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -66820,7 +66820,13 @@ mod tests {
         let expected_cast_failed = wow_packet::packets::spell::CastFailed {
             cast_id: ObjectGuid::EMPTY,
             spell_id,
-            visual: wow_packet::packets::spell::SpellCastVisual::default(),
+            // C++ Spell::SendCastResult sets packet.Visual = m_SpellVisual (set in the
+            // Spell ctor, before target selection), so an early BAD_IMPLICIT_TARGETS
+            // failure still carries the spell's visual — not a default/empty one.
+            visual: wow_packet::packets::spell::SpellCastVisual {
+                spell_visual_id: 722,
+                script_visual_id: 0,
+            },
             reason: SpellCastResult::BadImplicitTargets as i32,
             fail_arg1: 0,
             fail_arg2: 0,
@@ -67761,7 +67767,12 @@ mod tests {
         let expected_cast_failed = wow_packet::packets::spell::CastFailed {
             cast_id: ObjectGuid::EMPTY,
             spell_id,
-            visual: wow_packet::packets::spell::SpellCastVisual::default(),
+            // C++ SendCastResult carries m_SpellVisual (set in the Spell ctor) even on an
+            // early REQUIRES_SPELL_FOCUS CheckCast failure — not a default/empty visual.
+            visual: wow_packet::packets::spell::SpellCastVisual {
+                spell_visual_id: 704,
+                script_visual_id: 0,
+            },
             reason: SpellCastResult::RequiresSpellFocus as i32,
             fail_arg1: 181,
             fail_arg2: 0,


### PR DESCRIPTION
Closes #70

The deadlock fix (#68) let `cargo test -p wow-world --lib` run to completion, unmasking **3 failing tests**. All three were **wrong test expectations** — the code already matches the C++ source of truth:

1. **loot personal-encounter** (`...open_reads_player_money`): `LootResponse::FailureReason` is the C++ struct default **17** (`LOOT_ERROR_NO_LOOT`, `LootPackets.h:72` "Most common value") and is left unset on a successful loot — the client ignores it once the window opens. Test asserted 0.
2. **spell `BAD_IMPLICIT_TARGETS`** + 3. **spell `REQUIRES_SPELL_FOCUS`**: C++ `Spell::SendCastResult` sets `packet.Visual = m_SpellVisual` (set in the `Spell` ctor, before target selection), so an early `CheckCast`/target-selection failure still carries the spell's visual. Tests asserted a default/empty visual.

**Result:** `cargo test -p wow-world --lib` → **2586 passed, 0 failed**. After this merges, `Focused library tests` can be re-added to the required status checks on `3.4.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)