### PR TITLE
[03][M0.2] Terrain height query + respawn ground-snap (#15)

### DIFF
--- a/crates/world-server/src/main.rs
+++ b/crates/world-server/src/main.rs
@@ -4150,7 +4150,13 @@ async fn main() -> Result<ExitCode> {
 
     // Shared world state (creatures/grids visible to every session on the same map).
     // Each session gets a clone of this Arc on creation.
-    let shared_map: SharedMapManager = Arc::new(std::sync::RwLock::new(LegacyMapManager::new()));
+    let mut legacy_map_manager = LegacyMapManager::new();
+    // Wire file-backed terrain so the live spawn/respawn path ground-snaps
+    // creatures with real `.map` heights (issue #15). DataDir-rooted, lazy.
+    legacy_map_manager.set_terrain(Arc::new(wow_world::map_manager::LiveTerrainHeights::new(
+        &data_dir,
+    )));
+    let shared_map: SharedMapManager = Arc::new(std::sync::RwLock::new(legacy_map_manager));
     let mut loaded_instance_lock_mgr = InstanceLockMgr::default();
     let instance_lock_load_issues = loaded_instance_lock_mgr
         .load_from_database_like_cpp(&char_db, |map_id, difficulty_id| {

--- a/crates/wow-entities/src/lib.rs
+++ b/crates/wow-entities/src/lib.rs
@@ -365,9 +365,10 @@ pub use vehicle::{
     vehicle_base_movement_flags_like_cpp, vehicle_immunity_plan_like_cpp,
 };
 pub use world_object::{
-    DEFAULT_HEIGHT_SEARCH, DEFAULT_VISIBILITY_DISTANCE, DEFAULT_VISIBILITY_INSTANCE,
-    INVALID_HEIGHT, LineOfSightEndpoint, LineOfSightOptions, LineOfSightQuery, MAPID_INVALID,
-    MAX_HEIGHT, MAX_VISIBILITY_DISTANCE, MapBindingError, PhaseShift, SIGHT_RANGE_UNIT,
-    SmoothPhasingInfoLikeCpp, SmoothPhasingLikeCpp, VisibilityDistanceTypeLikeCpp, WorldLocation,
-    WorldObject, WorldObjectEnvironment, WorldObjectHeightQuery, Z_OFFSET_FIND_HEIGHT,
+    AllowedPositionZCaps, DEFAULT_HEIGHT_SEARCH, DEFAULT_VISIBILITY_DISTANCE,
+    DEFAULT_VISIBILITY_INSTANCE, INVALID_HEIGHT, LineOfSightEndpoint, LineOfSightOptions,
+    LineOfSightQuery, MAPID_INVALID, MAX_HEIGHT, MAX_VISIBILITY_DISTANCE, MapBindingError,
+    PhaseShift, SIGHT_RANGE_UNIT, SmoothPhasingInfoLikeCpp, SmoothPhasingLikeCpp,
+    VisibilityDistanceTypeLikeCpp, WorldLocation, WorldObject, WorldObjectEnvironment,
+    WorldObjectHeightQuery, Z_OFFSET_FIND_HEIGHT, allowed_position_z_from_ground_like_cpp,
 };

--- a/crates/wow-entities/src/world_object.rs
+++ b/crates/wow-entities/src/world_object.rs
@@ -84,6 +84,65 @@ impl Default for WorldObjectHeightQuery {
     }
 }
 
+/// Movement capabilities `UpdateAllowedPositionZ` reads off the owning `Unit`.
+///
+/// In C++ these come from `ToUnit()->CanFly()/CanSwim()/GetHoverOffset()` and
+/// `GetTransport()`; `WorldObject` has no back-reference to its `Unit`, so the
+/// caller injects them (the live entity knows its own movement flags).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AllowedPositionZCaps {
+    /// `GetTransport() != nullptr`: a passenger's Z is left to the transport.
+    pub on_transport: bool,
+    /// `Unit::CanFly()` — when set, terrain only *raises* Z (never pulls down).
+    pub can_fly: bool,
+    /// `Unit::CanSwim()` — kept for fidelity; without a parsed liquid map the swim
+    /// branch folds to the ground branch.
+    pub can_swim: bool,
+    /// `Unit::GetHoverOffset()` (0 unless the unit is hovering).
+    pub hover_offset: f32,
+}
+
+/// Pure decision half of `WorldObject::UpdateAllowedPositionZ` (`Object.cpp:1411`),
+/// taking the already-resolved `GetMapHeight` result so it can be reused without a
+/// live `WorldObject`/environment (e.g. the global respawn driver).
+///
+/// `ground` is `GetMapHeight(x, y, z)` (the `Z_OFFSET_FIND_HEIGHT` probe offset is
+/// the caller's responsibility, matching `GetMapHeight`). `on_transport` is handled
+/// by the caller before this is reached.
+///
+/// The grounded clamp `[ground_z+hover, max_z+hover]` reduces to a single point
+/// (`ground+hover`) because, with no parsed liquid map, `GetMapWaterOrGroundLevel`
+/// has no water ceiling and `max_z == ground_z` — exactly C++ behaviour when liquid
+/// data is unavailable, so the swim case collapses to "sit on ground".
+#[must_use]
+pub fn allowed_position_z_from_ground_like_cpp(
+    is_unit: bool,
+    ground: f32,
+    z: f32,
+    caps: AllowedPositionZCaps,
+) -> f32 {
+    if caps.on_transport {
+        return z;
+    }
+    if ground <= INVALID_HEIGHT {
+        // No terrain under the probe: C++ leaves Z untouched in every branch.
+        return z;
+    }
+    if is_unit {
+        let target = ground + caps.hover_offset;
+        if caps.can_fly {
+            // Flying: only lift out of the ground, never pull down.
+            z.max(target)
+        } else {
+            // Grounded (and swim w/o liquid): clamp onto the surface.
+            target
+        }
+    } else {
+        // Non-unit (GameObject/etc.): snapped flat to the ground.
+        ground
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct LineOfSightOptions {
     pub check_dynamic: bool,
@@ -1361,6 +1420,32 @@ impl WorldObject {
         }
     }
 
+    /// Port of `WorldObject::UpdateAllowedPositionZ` (`Object.cpp:1411`).
+    ///
+    /// Returns the corrected Z. Branches:
+    /// - **on transport** → unchanged (transport owns the Z).
+    /// - **unit, can fly** → `max(z, ground + hover)` (only lift off below-ground).
+    /// - **unit, grounded** → clamp into `[ground+hover, max_z+hover]`. With no
+    ///   parsed liquid map `GetMapWaterOrGroundLevel` has no water ceiling, so
+    ///   `max_z == ground_z` (exactly C++ when liquid is unavailable) and the swim
+    ///   case collapses to "sit on ground". When `GetMapHeight` finds no terrain
+    ///   (`<= INVALID_HEIGHT`) the Z is left untouched.
+    /// - **non-unit** → snap to ground when terrain exists, else unchanged.
+    pub fn update_allowed_position_z_like_cpp(
+        &self,
+        environment: &impl WorldObjectEnvironment,
+        caps: AllowedPositionZCaps,
+        x: f32,
+        y: f32,
+        z: f32,
+    ) -> f32 {
+        if caps.on_transport {
+            return z;
+        }
+        let ground = self.get_map_height(environment, x, y, z, WorldObjectHeightQuery::default());
+        allowed_position_z_from_ground_like_cpp(self.is_unit(), ground, z, caps)
+    }
+
     pub fn get_floor_z(&self, environment: &impl WorldObjectEnvironment) -> f32 {
         if !self.object.is_in_world() || !self.is_in_environment(environment) {
             return self.static_floor_z;
@@ -2188,6 +2273,81 @@ mod tests {
             10.0
         );
         assert_eq!(unit.get_floor_z(&environment), 25.0);
+    }
+
+    #[test]
+    fn update_allowed_position_z_matches_cpp_branches() {
+        let environment = TestEnvironment {
+            height: 20.0,
+            ..TestEnvironment::default()
+        };
+        let mut unit = WorldObject::new(false, TypeId::Unit, TypeMask::UNIT);
+        unit.set_map(571, 1).unwrap();
+        unit.object_mut().add_to_world();
+        unit.relocate(Position::xyz(1.0, 2.0, 10.0));
+
+        // Grounded unit below ground (z=10 < ground=20): snap up to ground+hover.
+        let walk = AllowedPositionZCaps {
+            on_transport: false,
+            can_fly: false,
+            can_swim: false,
+            hover_offset: 1.25,
+        };
+        assert_eq!(
+            unit.update_allowed_position_z_like_cpp(&environment, walk, 1.0, 2.0, 10.0),
+            21.25
+        );
+
+        // On a transport: Z is owned by the transport, left untouched.
+        let on_transport = AllowedPositionZCaps {
+            on_transport: true,
+            ..walk
+        };
+        assert_eq!(
+            unit.update_allowed_position_z_like_cpp(&environment, on_transport, 1.0, 2.0, 10.0),
+            10.0
+        );
+
+        // Flying unit *above* ground stays put (raise-only). Ground here is 5.0.
+        let low_ground = TestEnvironment {
+            height: 5.0,
+            ..TestEnvironment::default()
+        };
+        let fly = AllowedPositionZCaps {
+            on_transport: false,
+            can_fly: true,
+            can_swim: false,
+            hover_offset: 0.0,
+        };
+        assert_eq!(
+            unit.update_allowed_position_z_like_cpp(&low_ground, fly, 1.0, 2.0, 10.0),
+            10.0
+        );
+        // Flying unit *below* ground is lifted to ground+hover.
+        assert_eq!(
+            unit.update_allowed_position_z_like_cpp(&environment, fly, 1.0, 2.0, 10.0),
+            20.0
+        );
+
+        // No terrain under the probe: Z unchanged.
+        let no_terrain = TestEnvironment {
+            height: INVALID_HEIGHT,
+            ..TestEnvironment::default()
+        };
+        assert_eq!(
+            unit.update_allowed_position_z_like_cpp(&no_terrain, walk, 1.0, 2.0, 10.0),
+            10.0
+        );
+
+        // Non-unit (GameObject): snapped flat to ground, no hover.
+        let mut gameobject = WorldObject::new(false, TypeId::GameObject, TypeMask::GAME_OBJECT);
+        gameobject.set_map(571, 1).unwrap();
+        gameobject.object_mut().add_to_world();
+        gameobject.relocate(Position::xyz(1.0, 2.0, 10.0));
+        assert_eq!(
+            gameobject.update_allowed_position_z_like_cpp(&environment, walk, 1.0, 2.0, 10.0),
+            20.0
+        );
     }
 
     #[test]

--- a/crates/wow-map/src/grid_map.rs
+++ b/crates/wow-map/src/grid_map.rs
@@ -32,6 +32,7 @@ const V8_SIZE: usize = 128 * 128;
 const HOLES_SIZE: usize = 16 * 16 * 8;
 
 /// Packed height storage, mirroring the three C++ on-disk encodings + the flat case.
+#[derive(Debug)]
 enum Heights {
     /// `NoHeight` flag: every query returns `grid_height`.
     Flat,
@@ -52,6 +53,7 @@ enum Heights {
 }
 
 /// One parsed `.map` terrain tile's height data.
+#[derive(Debug)]
 pub struct GridMap {
     grid_height: f32,
     heights: Heights,

--- a/crates/wow-map/src/grid_map.rs
+++ b/crates/wow-map/src/grid_map.rs
@@ -1,0 +1,411 @@
+//! GridMap — parser and height query for a single TrinityCore `.map` terrain tile.
+//!
+//! Faithful port of `GridMap::loadHeightData` + `getHeightFrom{Float,Uint16,Uint8,Flat}`
+//! and `isHole` from the legacy C++ (`src/server/game/Maps/GridMap.cpp`) for WoW 3.4.3.
+//! Tile files are `maps/{mapId:04}_{gridX:02}_{gridY:02}.map`, magic `"MAPS"` v10
+//! (`src/common/Collision/Maps/MapDefines.{h,cpp}`).
+//!
+//! Scope (issue [03]/#15, slice A): **grid terrain height only**. VMap, liquid,
+//! flight bounds, and the area map are intentionally not parsed here; only the
+//! `MHGT` height chunk (+ holes, which `getHeight` consults) is loaded.
+
+// C++ GridDefines.h
+const MAP_RESOLUTION: i32 = 128;
+const SIZE_OF_GRIDS: f32 = 533.333_3;
+const CENTER_GRID_ID: f32 = 32.0;
+
+/// C++ `INVALID_HEIGHT` sentinel (GridDefines.h) — "no terrain height here".
+pub const INVALID_HEIGHT: f32 = -100_000.0;
+
+const MAP_MAGIC: [u8; 4] = *b"MAPS";
+const MAP_VERSION_MAGIC: u32 = 10;
+const HEIGHT_MAGIC: [u8; 4] = *b"MHGT";
+
+// map_heightHeaderFlags (MapDefines.h)
+const FLAG_NO_HEIGHT: u32 = 0x0001;
+const FLAG_HEIGHT_AS_INT16: u32 = 0x0002;
+const FLAG_HEIGHT_AS_INT8: u32 = 0x0004;
+
+// V9 = 129x129 corner grid, V8 = 128x128 cell-center grid.
+const V9_SIZE: usize = 129 * 129;
+const V8_SIZE: usize = 128 * 128;
+const HOLES_SIZE: usize = 16 * 16 * 8;
+
+/// Packed height storage, mirroring the three C++ on-disk encodings + the flat case.
+enum Heights {
+    /// `NoHeight` flag: every query returns `grid_height`.
+    Flat,
+    Float {
+        v9: Vec<f32>,
+        v8: Vec<f32>,
+    },
+    Int16 {
+        v9: Vec<u16>,
+        v8: Vec<u16>,
+        mult: f32,
+    },
+    Int8 {
+        v9: Vec<u8>,
+        v8: Vec<u8>,
+        mult: f32,
+    },
+}
+
+/// One parsed `.map` terrain tile's height data.
+pub struct GridMap {
+    grid_height: f32,
+    heights: Heights,
+    /// 16*16*8 hole bitmask, when the tile has holes.
+    holes: Option<Vec<u8>>,
+}
+
+/// Minimal little-endian reader over the `.map` bytes.
+struct Reader<'a> {
+    buf: &'a [u8],
+}
+
+impl<'a> Reader<'a> {
+    fn u32_at(&self, off: usize) -> Option<u32> {
+        let b = self.buf.get(off..off + 4)?;
+        Some(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+    fn f32_at(&self, off: usize) -> Option<f32> {
+        Some(f32::from_bits(self.u32_at(off)?))
+    }
+    fn tag_at(&self, off: usize) -> Option<[u8; 4]> {
+        let b = self.buf.get(off..off + 4)?;
+        Some([b[0], b[1], b[2], b[3]])
+    }
+}
+
+impl GridMap {
+    /// Parse a `.map` tile from its raw bytes, loading only the height chunk.
+    ///
+    /// Returns `None` if the file magic/version is wrong, the height magic is
+    /// wrong, or the height arrays are truncated — mirroring C++ `loadData`
+    /// returning failure (the caller then treats the tile as "no terrain").
+    #[must_use]
+    pub fn parse(bytes: &[u8]) -> Option<GridMap> {
+        let r = Reader { buf: bytes };
+
+        // map_fileheader (MapDefines.h): magic[4], version, build, then 4 (offset,size)
+        // pairs (area, height, liquid, holes).
+        if r.tag_at(0)? != MAP_MAGIC || r.u32_at(4)? != MAP_VERSION_MAGIC {
+            return None;
+        }
+        let height_offset = r.u32_at(20)? as usize;
+        let holes_offset = r.u32_at(36)? as usize;
+        let holes_size = r.u32_at(40)? as usize;
+
+        // map_heightHeader: magic[4], flags(u32), gridHeight(f32), gridMaxHeight(f32).
+        if r.tag_at(height_offset)? != HEIGHT_MAGIC {
+            return None;
+        }
+        let flags = r.u32_at(height_offset + 4)?;
+        let grid_height = r.f32_at(height_offset + 8)?;
+        let grid_max_height = r.f32_at(height_offset + 12)?;
+        let data_off = height_offset + 16;
+
+        let heights = if flags & FLAG_NO_HEIGHT != 0 {
+            Heights::Flat
+        } else if flags & FLAG_HEIGHT_AS_INT16 != 0 {
+            let v9 = read_u16_array(&r, data_off, V9_SIZE)?;
+            let v8 = read_u16_array(&r, data_off + V9_SIZE * 2, V8_SIZE)?;
+            Heights::Int16 {
+                v9,
+                v8,
+                mult: (grid_max_height - grid_height) / 65535.0,
+            }
+        } else if flags & FLAG_HEIGHT_AS_INT8 != 0 {
+            let v9 = bytes.get(data_off..data_off + V9_SIZE)?.to_vec();
+            let v8 = bytes
+                .get(data_off + V9_SIZE..data_off + V9_SIZE + V8_SIZE)?
+                .to_vec();
+            Heights::Int8 {
+                v9,
+                v8,
+                mult: (grid_max_height - grid_height) / 255.0,
+            }
+        } else {
+            let v9 = read_f32_array(&r, data_off, V9_SIZE)?;
+            let v8 = read_f32_array(&r, data_off + V9_SIZE * 4, V8_SIZE)?;
+            Heights::Float { v9, v8 }
+        };
+
+        let holes = if holes_size != 0 {
+            Some(bytes.get(holes_offset..holes_offset + HOLES_SIZE)?.to_vec())
+        } else {
+            None
+        };
+
+        Some(GridMap {
+            grid_height,
+            heights,
+            holes,
+        })
+    }
+
+    /// Terrain height at world `(x, y)` for this tile, or [`INVALID_HEIGHT`] in a hole.
+    ///
+    /// Port of `GridMap::getHeightFrom*` (GridMap.cpp). The interpolation is
+    /// identical across encodings (triangle pick + linear solve); only the source
+    /// type and the int→world scale differ.
+    #[must_use]
+    pub fn get_height(&self, x: f32, y: f32) -> f32 {
+        if let Heights::Flat = self.heights {
+            return self.grid_height;
+        }
+
+        let gx = MAP_RESOLUTION as f32 * (CENTER_GRID_ID - x / SIZE_OF_GRIDS);
+        let gy = MAP_RESOLUTION as f32 * (CENTER_GRID_ID - y / SIZE_OF_GRIDS);
+        let xi_raw = gx as i32;
+        let yi_raw = gy as i32;
+        let fx = gx - xi_raw as f32;
+        let fy = gy - yi_raw as f32;
+        let xi = (xi_raw & (MAP_RESOLUTION - 1)) as usize;
+        let yi = (yi_raw & (MAP_RESOLUTION - 1)) as usize;
+
+        if self.is_hole(xi, yi) {
+            return INVALID_HEIGHT;
+        }
+
+        // h1..h4 = V9 corners, h5 = 2 * V8 cell center (C++ getHeightFromFloat).
+        let v9 = |dx: usize, dy: usize| -> f32 {
+            let idx = (xi + dx) * 129 + (yi + dy);
+            match &self.heights {
+                Heights::Float { v9, .. } => v9[idx],
+                Heights::Int16 { v9, .. } => f32::from(v9[idx]),
+                Heights::Int8 { v9, .. } => f32::from(v9[idx]),
+                Heights::Flat => unreachable!(),
+            }
+        };
+        let v8_center = || -> f32 {
+            let idx = xi * 128 + yi;
+            match &self.heights {
+                Heights::Float { v8, .. } => v8[idx],
+                Heights::Int16 { v8, .. } => f32::from(v8[idx]),
+                Heights::Int8 { v8, .. } => f32::from(v8[idx]),
+                Heights::Flat => unreachable!(),
+            }
+        };
+
+        let h1 = v9(0, 0);
+        let h2 = v9(1, 0);
+        let h3 = v9(0, 1);
+        let h4 = v9(1, 1);
+        let h5 = 2.0 * v8_center();
+
+        let (a, b, c) = if fx + fy < 1.0 {
+            if fx > fy {
+                (h2 - h1, h5 - h1 - h2, h1) // tri 1: h1,h2,h5
+            } else {
+                (h5 - h1 - h3, h3 - h1, h1) // tri 2: h1,h3,h5
+            }
+        } else if fx > fy {
+            (h2 + h4 - h5, h4 - h2, h5 - h4) // tri 3: h2,h4,h5
+        } else {
+            (h4 - h3, h3 + h4 - h5, h5 - h4) // tri 4: h3,h4,h5
+        };
+
+        let interpolated = a * fx + b * fy + c;
+        match &self.heights {
+            // Int variants store raw values; scale into world height (GridMap.cpp:461/531).
+            Heights::Int16 { mult, .. } | Heights::Int8 { mult, .. } => {
+                interpolated * *mult + self.grid_height
+            }
+            _ => interpolated,
+        }
+    }
+
+    /// Port of `GridMap::isHole` (GridMap.cpp:534): 8x8 sub-squares per cell.
+    fn is_hole(&self, row: usize, col: usize) -> bool {
+        let Some(holes) = &self.holes else {
+            return false;
+        };
+        let cell_row = row / 8;
+        let cell_col = col / 8;
+        let hole_row = row % 8;
+        let hole_col = col % 8;
+        (holes[cell_row * 16 * 8 + cell_col * 8 + hole_row] & (1 << hole_col)) != 0
+    }
+}
+
+fn read_f32_array(r: &Reader<'_>, off: usize, count: usize) -> Option<Vec<f32>> {
+    let mut out = Vec::with_capacity(count);
+    for i in 0..count {
+        out.push(r.f32_at(off + i * 4)?);
+    }
+    Some(out)
+}
+
+fn read_u16_array(r: &Reader<'_>, off: usize, count: usize) -> Option<Vec<u16>> {
+    let mut out = Vec::with_capacity(count);
+    for i in 0..count {
+        let b = r.buf.get(off + i * 2..off + i * 2 + 2)?;
+        out.push(u16::from_le_bytes([b[0], b[1]]));
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic float `.map` tile: V9/V8 filled by the given closures.
+    fn build_float_map(
+        grid_height: f32,
+        v9: impl Fn(usize, usize) -> f32,
+        v8: impl Fn(usize, usize) -> f32,
+        holes: Option<&[u8; HOLES_SIZE]>,
+    ) -> Vec<u8> {
+        // Layout: [fileheader 44][heightheader 16][V9][V8]([holes]).
+        let height_off = 44u32;
+        let data_off = height_off + 16;
+        let v9_bytes = V9_SIZE * 4;
+        let v8_bytes = V8_SIZE * 4;
+        let holes_off = data_off + v9_bytes as u32 + v8_bytes as u32;
+        let holes_size = if holes.is_some() {
+            HOLES_SIZE as u32
+        } else {
+            0
+        };
+
+        let mut b = Vec::new();
+        b.extend_from_slice(&MAP_MAGIC);
+        b.extend_from_slice(&MAP_VERSION_MAGIC.to_le_bytes());
+        b.extend_from_slice(&0u32.to_le_bytes()); // build
+        b.extend_from_slice(&0u32.to_le_bytes()); // areaMapOffset
+        b.extend_from_slice(&0u32.to_le_bytes()); // areaMapSize
+        b.extend_from_slice(&height_off.to_le_bytes()); // heightMapOffset
+        b.extend_from_slice(&0u32.to_le_bytes()); // heightMapSize
+        b.extend_from_slice(&0u32.to_le_bytes()); // liquidMapOffset
+        b.extend_from_slice(&0u32.to_le_bytes()); // liquidMapSize
+        b.extend_from_slice(&holes_off.to_le_bytes()); // holesOffset
+        b.extend_from_slice(&holes_size.to_le_bytes()); // holesSize
+
+        // height header
+        b.extend_from_slice(&HEIGHT_MAGIC);
+        b.extend_from_slice(&0u32.to_le_bytes()); // flags (float)
+        b.extend_from_slice(&grid_height.to_le_bytes());
+        b.extend_from_slice(&grid_height.to_le_bytes()); // gridMaxHeight (unused for float)
+        for r in 0..129 {
+            for c in 0..129 {
+                b.extend_from_slice(&v9(r, c).to_le_bytes());
+            }
+        }
+        for r in 0..128 {
+            for c in 0..128 {
+                b.extend_from_slice(&v8(r, c).to_le_bytes());
+            }
+        }
+        if let Some(h) = holes {
+            b.extend_from_slice(h);
+        }
+        b
+    }
+
+    #[test]
+    fn flat_tile_returns_grid_height() {
+        // NoHeight flag → getHeightFromFlat returns gridHeight everywhere.
+        let mut b = Vec::new();
+        b.extend_from_slice(&MAP_MAGIC);
+        b.extend_from_slice(&MAP_VERSION_MAGIC.to_le_bytes());
+        for _ in 0..9 {
+            b.extend_from_slice(&0u32.to_le_bytes());
+        }
+        // patch heightMapOffset (index 5 → byte 20) to 44
+        b[20..24].copy_from_slice(&44u32.to_le_bytes());
+        b.extend_from_slice(&HEIGHT_MAGIC);
+        b.extend_from_slice(&FLAG_NO_HEIGHT.to_le_bytes());
+        b.extend_from_slice(&123.5f32.to_le_bytes()); // gridHeight
+        b.extend_from_slice(&123.5f32.to_le_bytes());
+
+        let gm = GridMap::parse(&b).expect("flat map parses");
+        assert_eq!(gm.get_height(0.0, 0.0), 123.5);
+        assert_eq!(gm.get_height(100.0, -250.0), 123.5);
+    }
+
+    #[test]
+    fn constant_float_tile_returns_that_constant() {
+        let b = build_float_map(0.0, |_, _| 75.0, |_, _| 75.0, None);
+        let gm = GridMap::parse(&b).expect("parses");
+        // For a constant grid every triangle solves to the constant.
+        assert!((gm.get_height(0.0, 0.0) - 75.0).abs() < 1e-3);
+        assert!((gm.get_height(123.4, -456.7) - 75.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn planar_ramp_interpolates_like_cpp() {
+        // A grid that increases linearly with the V9 row index. At x=0 the world
+        // maps to V9 row 0 (gx = 128*32 = 4096 → x_int&127 = 0, frac 0); pick a y
+        // that lands mid-cell to exercise interpolation, and compare against the
+        // same triangle math computed here.
+        let v9 = |r: usize, _c: usize| r as f32; // height == row index
+        let v8 = |r: usize, _c: usize| r as f32 + 0.5; // cell-center between rows
+        let b = build_float_map(0.0, v9, v8, None);
+        let gm = GridMap::parse(&b).expect("parses");
+
+        // x=0 → row 0, frac 0; y chosen so gy frac is ~0 too (column boundary).
+        // At a corner (frac 0,0) the result is exactly h1 = V9[0,0] = 0.
+        assert!(gm.get_height(0.0, 0.0).abs() < 1e-3);
+
+        // One full V9 row south is +1 in height. x for row 1: gx=4097 → need
+        // x/SIZE_OF_GRIDS such that 128*(32 - x/533.3333) = 4097 → x = -SIZE/128.
+        let x_row1 = -SIZE_OF_GRIDS / 128.0;
+        assert!((gm.get_height(x_row1, 0.0) - 1.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn hole_cell_returns_invalid_height() {
+        let mut holes = [0u8; HOLES_SIZE];
+        // Mark sub-square (row 0, col 0): cell (0,0), holeRow 0, holeCol 0 → bit 0.
+        holes[0] = 0b0000_0001;
+        let b = build_float_map(0.0, |_, _| 10.0, |_, _| 10.0, Some(&holes));
+        let gm = GridMap::parse(&b).expect("parses");
+        // x=0,y=0 → x_int=0,y_int=0 → hole.
+        assert_eq!(gm.get_height(0.0, 0.0), INVALID_HEIGHT);
+    }
+
+    #[test]
+    fn int16_tile_scales_into_world_height() {
+        // gridHeight 0, gridMaxHeight 65535 → mult = 1.0, raw value == world height.
+        let height_off = 44u32;
+        let mut b = Vec::new();
+        b.extend_from_slice(&MAP_MAGIC);
+        b.extend_from_slice(&MAP_VERSION_MAGIC.to_le_bytes());
+        b.extend_from_slice(&0u32.to_le_bytes()); // build
+        b.extend_from_slice(&0u32.to_le_bytes()); // areaMapOffset
+        b.extend_from_slice(&0u32.to_le_bytes()); // areaMapSize
+        b.extend_from_slice(&height_off.to_le_bytes());
+        for _ in 0..5 {
+            b.extend_from_slice(&0u32.to_le_bytes()); // remaining offsets/sizes
+        }
+        b.extend_from_slice(&HEIGHT_MAGIC);
+        b.extend_from_slice(&FLAG_HEIGHT_AS_INT16.to_le_bytes());
+        b.extend_from_slice(&0.0f32.to_le_bytes()); // gridHeight
+        b.extend_from_slice(&65535.0f32.to_le_bytes()); // gridMaxHeight → mult 1.0
+        for _ in 0..V9_SIZE {
+            b.extend_from_slice(&500u16.to_le_bytes());
+        }
+        for _ in 0..V8_SIZE {
+            b.extend_from_slice(&500u16.to_le_bytes());
+        }
+        let gm = GridMap::parse(&b).expect("int16 parses");
+        // constant 500 raw * mult 1.0 + base 0 = 500.
+        assert!((gm.get_height(0.0, 0.0) - 500.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn rejects_bad_file_magic() {
+        let mut b = vec![0u8; 64];
+        b[0..4].copy_from_slice(b"XXXX");
+        assert!(GridMap::parse(&b).is_none());
+    }
+
+    #[test]
+    fn rejects_truncated_height_arrays() {
+        let mut b = build_float_map(0.0, |_, _| 1.0, |_, _| 1.0, None);
+        b.truncate(60); // header ok, arrays cut off
+        assert!(GridMap::parse(&b).is_none());
+    }
+}

--- a/crates/wow-map/src/lib.rs
+++ b/crates/wow-map/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cell;
 pub mod coords;
 pub mod grid;
+pub mod grid_map;
 pub mod grid_unload;
 pub mod manager;
 pub mod map;

--- a/crates/wow-map/src/lib.rs
+++ b/crates/wow-map/src/lib.rs
@@ -9,6 +9,7 @@ pub mod object_grid_loader;
 pub mod personal_phase;
 pub mod pool;
 pub mod spawn;
+pub mod terrain;
 
 use std::fmt;
 
@@ -76,6 +77,7 @@ pub use spawn::{
     SpawnGridLoadStateLikeCpp, SpawnGroupActiveChange, SpawnGroupFlags, SpawnGroupRuntimeState,
     SpawnGroupTemplateData, SpawnId, SpawnMapKey, SpawnObjectType, SpawnPosition, SpawnStore,
 };
+pub use terrain::{GridMapTerrain, VMAP_INVALID_HEIGHT_VALUE};
 
 /// Key used by `MapManager` for world and instance map lookup.
 ///

--- a/crates/wow-map/src/manager.rs
+++ b/crates/wow-map/src/manager.rs
@@ -3730,15 +3730,17 @@ mod tests {
             .unit_mut()
             .world_mut()
             .relocate(Position::xyz(10.0, 20.0, 30.0));
-        if in_world {
-            creature.unit_mut().world_mut().object_mut().add_to_world();
-        }
         let record = MapObjectRecord::new_creature(creature).unwrap();
         let map = manager.find_map_mut(1, 0).unwrap().map_mut();
-        if in_world {
-            map.add_map_object_record_to_map_like_cpp(record).unwrap();
-        } else {
-            map.insert_map_object_record(record).unwrap();
+        // Full C++ Map::AddToMap: creates the grid, inserts the guid into the cell,
+        // and calls the unit AddToWorld — so the cell-anchored ObjectUpdater can
+        // reach it. (Building the creature already in-world would trip the
+        // already-in-world early return that skips cell insertion.)
+        map.add_map_object_record_to_map_like_cpp(record).unwrap();
+        if !in_world {
+            // Keep the record cell-resident but flip it out of the world to
+            // exercise update_creature's NotInWorld skip (C++ RemoveFromWorld).
+            map.test_remove_creature_from_world_keep_cell_like_cpp(creature_guid);
         }
         creature_guid
     }

--- a/crates/wow-map/src/map.rs
+++ b/crates/wow-map/src/map.rs
@@ -2771,6 +2771,21 @@ where
         self.dynamic_tree_unbalanced_times_like_cpp = times;
     }
 
+    /// Test seam: flip a cell-resident creature to not-in-world (post C++
+    /// `RemoveFromWorld`) while leaving its record in the cell/store, so the
+    /// cell-anchored `ObjectUpdater` still visits it and exercises the
+    /// `NotInWorld` skip branch.
+    #[cfg(test)]
+    pub(crate) fn test_remove_creature_from_world_keep_cell_like_cpp(&mut self, guid: ObjectGuid) {
+        if let Some(creature) = self
+            .map_objects
+            .get_mut(&guid)
+            .and_then(MapObjectRecord::creature_mut)
+        {
+            creature.unit_mut().remove_from_world_like_cpp();
+        }
+    }
+
     pub fn generate_low_guid_like_cpp(
         &mut self,
         high: HighGuid,

--- a/crates/wow-map/src/terrain.rs
+++ b/crates/wow-map/src/terrain.rs
@@ -1,0 +1,323 @@
+//! `GridMapTerrain` — a real, file-backed terrain provider for a single map id.
+//!
+//! Faithful port of the height-query half of C++ `TerrainInfo` (`TerrainMgr.cpp`)
+//! for WoW 3.4.3: it owns the per-grid `.map` tiles for one map and answers
+//! `GetGridHeight` / `GetStaticHeight` / `Map::GetHeight`. It plugs into [`Map`]
+//! through the [`TerrainGridLoader`] + [`MapWorldObjectEnvironment`] seams so the
+//! `WorldObject -> WorldObjectEnvironment -> Map -> terrain` chain returns real
+//! ground heights instead of the [`NoopTerrainGridLoader`] sentinel.
+//!
+//! Scope (issue [03]/#15): **grid terrain height only**. VMap, liquid level, the
+//! dynamic GO-floor tree, and mmaps are out of scope here — exactly the branches
+//! that, in C++, would otherwise contribute to `GetStaticHeight`/`GetGameObjectFloor`.
+//! Those collapse to "no value" the same way C++ does when VMap/liquid are
+//! disabled, so the height returned is the raw `.map` surface (+ holes).
+//!
+//! [`Map`]: crate::map::Map
+//! [`NoopTerrainGridLoader`]: crate::map::NoopTerrainGridLoader
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use wow_core::Position;
+use wow_entities::{INVALID_HEIGHT, LineOfSightQuery, WorldObject, WorldObjectHeightQuery};
+
+use crate::grid_map::GridMap;
+use crate::map::{MapWorldObjectEnvironment, TerrainGridLoader};
+
+// C++ Grids/GridDefines.h
+const SIZE_OF_GRIDS: f32 = 533.333_3;
+const CENTER_GRID_ID: i32 = 32;
+const MAX_NUMBER_OF_GRIDS: i32 = 64;
+
+/// C++ `VMAP_INVALID_HEIGHT_VALUE` (`IVMapManager.h`): the value returned for an
+/// unknown height (distinct from the `INVALID_HEIGHT` *check* threshold).
+pub const VMAP_INVALID_HEIGHT_VALUE: f32 = -200_000.0;
+
+/// C++ `GROUND_HEIGHT_TOLERANCE` (`SharedDefines.h`): slack when deciding whether
+/// the probe `z` is at/above the raw ground surface.
+const GROUND_HEIGHT_TOLERANCE: f32 = 0.05;
+
+/// File-backed terrain for one map id: a lazily-populated `[64][64]` grid of
+/// `.map` height tiles read from `<data_dir>/maps/{mapId:04}_{gx:02}_{gy:02}.map`.
+///
+/// Mirrors `TerrainInfo`'s ownership: one instance per map id, shared across that
+/// map's instances. Tiles load on first touch (C++ `GetGrid(..., loadIfMissing)`)
+/// and also eagerly from [`TerrainGridLoader::load_map_and_vmap`] when the owning
+/// [`Map`](crate::map::Map) activates a grid.
+#[derive(Debug)]
+pub struct GridMapTerrain {
+    map_id: u32,
+    data_dir: PathBuf,
+    /// Key = raw tile index `(gx, gy)`; value `Some` = loaded, `None` = tried and
+    /// absent/invalid (cached negative so we do not re-stat every query). An
+    /// absent key means "not yet attempted".
+    grids: Mutex<HashMap<(i32, i32), Option<GridMap>>>,
+}
+
+impl GridMapTerrain {
+    /// Build terrain for `map_id` rooted at `data_dir` (the `DataDir` config; the
+    /// tiles live under `<data_dir>/maps/`). No I/O happens until the first query
+    /// or grid load.
+    #[must_use]
+    pub fn new(map_id: u32, data_dir: impl AsRef<Path>) -> Self {
+        Self {
+            map_id,
+            data_dir: data_dir.as_ref().to_path_buf(),
+            grids: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn map_id(&self) -> u32 {
+        self.map_id
+    }
+
+    /// Raw TrinityCore tile index for world `(x, y)` — `TerrainInfo::GetGrid`
+    /// (`TerrainMgr.cpp:284`): `gx = (int)(CENTER_GRID_ID - x / SIZE_OF_GRIDS)`.
+    fn tile_index(x: f32, y: f32) -> (i32, i32) {
+        let gx = (CENTER_GRID_ID as f32 - x / SIZE_OF_GRIDS) as i32;
+        let gy = (CENTER_GRID_ID as f32 - y / SIZE_OF_GRIDS) as i32;
+        (gx, gy)
+    }
+
+    fn tile_path(&self, gx: i32, gy: i32) -> PathBuf {
+        self.data_dir
+            .join("maps")
+            .join(format!("{:04}_{gx:02}_{gy:02}.map", self.map_id))
+    }
+
+    fn load_tile(&self, gx: i32, gy: i32) -> Option<GridMap> {
+        if !(0..MAX_NUMBER_OF_GRIDS).contains(&gx) || !(0..MAX_NUMBER_OF_GRIDS).contains(&gy) {
+            return None;
+        }
+        let bytes = std::fs::read(self.tile_path(gx, gy)).ok()?;
+        GridMap::parse(&bytes)
+    }
+
+    /// Ensure the tile covering `(gx, gy)` is in the cache (positive or negative),
+    /// then run `f` against it. Centralises the lazy-load + lock discipline.
+    fn with_tile<R>(&self, gx: i32, gy: i32, f: impl FnOnce(Option<&GridMap>) -> R) -> R {
+        let mut grids = self.grids.lock().expect("terrain grid cache poisoned");
+        let entry = grids
+            .entry((gx, gy))
+            .or_insert_with(|| self.load_tile(gx, gy));
+        f(entry.as_ref())
+    }
+
+    /// `TerrainInfo::GetGridHeight` (`TerrainMgr.cpp:687`): the raw `.map` surface
+    /// height at `(x, y)`, or [`VMAP_INVALID_HEIGHT_VALUE`] when there is no tile.
+    #[must_use]
+    pub fn grid_height(&self, x: f32, y: f32) -> f32 {
+        let (gx, gy) = Self::tile_index(x, y);
+        self.with_tile(gx, gy, |tile| {
+            tile.map_or(VMAP_INVALID_HEIGHT_VALUE, |gm| gm.get_height(x, y))
+        })
+    }
+
+    /// `TerrainInfo::GetStaticHeight` (`TerrainMgr.cpp:695`) with VMap disabled.
+    ///
+    /// The raw ground is only accepted when the probe `z` is at/above it (within
+    /// [`GROUND_HEIGHT_TOLERANCE`]); otherwise C++ leaves `mapHeight` at the
+    /// invalid sentinel. With no VMap there is no second candidate, so the result
+    /// is the map surface or [`VMAP_INVALID_HEIGHT_VALUE`].
+    #[must_use]
+    pub fn static_height(&self, x: f32, y: f32, z: f32) -> f32 {
+        let grid_height = self.grid_height(x, y);
+        if z >= grid_height - GROUND_HEIGHT_TOLERANCE {
+            grid_height
+        } else {
+            VMAP_INVALID_HEIGHT_VALUE
+        }
+    }
+}
+
+impl TerrainGridLoader for GridMapTerrain {
+    fn load_map_and_vmap(&mut self, grid_x: u32, grid_y: u32) {
+        // `Map::ensure_grid_created` passes the un-flipped raw tile indices
+        // (`terrain_grid_coords`), i.e. the same `(gx, gy)` the lazy path derives
+        // from world `(x, y)`. Populate the cache eagerly (C++ `LoadMapAndVMap`).
+        let (gx, gy) = (grid_x as i32, grid_y as i32);
+        let mut grids = self.grids.lock().expect("terrain grid cache poisoned");
+        grids
+            .entry((gx, gy))
+            .or_insert_with(|| self.load_tile(gx, gy));
+    }
+
+    fn unload_map(&mut self, grid_x: u32, grid_y: u32) {
+        let mut grids = self.grids.lock().expect("terrain grid cache poisoned");
+        grids.remove(&(grid_x as i32, grid_y as i32));
+    }
+}
+
+impl MapWorldObjectEnvironment for GridMapTerrain {
+    fn line_of_sight(&self, _query: LineOfSightQuery<'_>) -> bool {
+        // No VMap/dynamic tree in scope: C++ `Map::isInLineOfSight` with VMap
+        // disabled reports clear LOS. Real occlusion arrives with the VMap port.
+        true
+    }
+
+    fn map_height(
+        &self,
+        _object: &WorldObject,
+        x: f32,
+        y: f32,
+        z: f32,
+        _query: WorldObjectHeightQuery,
+    ) -> f32 {
+        // C++ `Map::GetHeight = max(GetStaticHeight, GetGameObjectFloor)`; without
+        // the dynamic tree the GO floor is `VMAP_INVALID_HEIGHT_VALUE`, so the max
+        // is the static (raw `.map`) height. `query.vmap` is moot with no VMap.
+        self.static_height(x, y, z)
+    }
+
+    fn floor_z(&self, _object: &WorldObject, _position: Position, _max_search_dist: f32) -> f32 {
+        // `Map::GetGameObjectFloor` needs the dynamic GO collision tree, which is
+        // not ported. Match the noop sentinel; `WorldObject::get_floor_z` already
+        // maxes this against the object's static floor.
+        INVALID_HEIGHT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use wow_constants::{TypeId, TypeMask};
+
+    const Z_PROBE: f32 = 100_000.0; // MAX_HEIGHT-ish: always "above ground".
+
+    /// Unique scratch dir per test; cleaned on drop.
+    struct TempMapsDir(PathBuf);
+
+    impl TempMapsDir {
+        fn new() -> Self {
+            static COUNTER: AtomicU32 = AtomicU32::new(0);
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let dir = std::env::temp_dir()
+                .join(format!("rustycore_terrain_test_{}_{n}", std::process::id()));
+            std::fs::create_dir_all(dir.join("maps")).expect("create temp maps dir");
+            Self(dir)
+        }
+
+        fn write_tile(&self, map_id: u32, gx: i32, gy: i32, bytes: &[u8]) {
+            let path = self
+                .0
+                .join("maps")
+                .join(format!("{map_id:04}_{gx:02}_{gy:02}.map"));
+            std::fs::write(path, bytes).expect("write tile");
+        }
+    }
+
+    impl Drop for TempMapsDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// A constant-height float `.map` tile (flat surface at `height`).
+    fn constant_float_tile(height: f32) -> Vec<u8> {
+        const V9: usize = 129 * 129;
+        const V8: usize = 128 * 128;
+        let height_off = 44u32;
+        let mut b = Vec::new();
+        b.extend_from_slice(b"MAPS");
+        b.extend_from_slice(&10u32.to_le_bytes()); // version
+        b.extend_from_slice(&0u32.to_le_bytes()); // build
+        b.extend_from_slice(&0u32.to_le_bytes()); // areaMapOffset
+        b.extend_from_slice(&0u32.to_le_bytes()); // areaMapSize
+        b.extend_from_slice(&height_off.to_le_bytes()); // heightMapOffset
+        for _ in 0..5 {
+            b.extend_from_slice(&0u32.to_le_bytes()); // height/liquid/holes offsets+sizes
+        }
+        b.extend_from_slice(b"MHGT");
+        b.extend_from_slice(&0u32.to_le_bytes()); // flags = float
+        b.extend_from_slice(&height.to_le_bytes()); // gridHeight
+        b.extend_from_slice(&height.to_le_bytes()); // gridMaxHeight
+        for _ in 0..V9 {
+            b.extend_from_slice(&height.to_le_bytes());
+        }
+        for _ in 0..V8 {
+            b.extend_from_slice(&height.to_le_bytes());
+        }
+        b
+    }
+
+    #[test]
+    fn missing_tile_returns_invalid_sentinel() {
+        let dir = TempMapsDir::new();
+        let terrain = GridMapTerrain::new(0, &dir.0);
+        // No file on disk → GetGridHeight returns the VMap-invalid sentinel.
+        assert_eq!(terrain.grid_height(0.0, 0.0), VMAP_INVALID_HEIGHT_VALUE);
+        // static_height likewise has no candidate.
+        assert_eq!(
+            terrain.static_height(0.0, 0.0, Z_PROBE),
+            VMAP_INVALID_HEIGHT_VALUE
+        );
+    }
+
+    #[test]
+    fn loads_correct_tile_for_world_position() {
+        // World (0,0) → raw tile index (32,32).
+        let dir = TempMapsDir::new();
+        dir.write_tile(0, 32, 32, &constant_float_tile(57.25));
+        let terrain = GridMapTerrain::new(0, &dir.0);
+        assert!((terrain.grid_height(0.0, 0.0) - 57.25).abs() < 1e-2);
+    }
+
+    #[test]
+    fn static_height_rejects_probe_below_ground() {
+        let dir = TempMapsDir::new();
+        dir.write_tile(0, 32, 32, &constant_float_tile(50.0));
+        let terrain = GridMapTerrain::new(0, &dir.0);
+        // Probe well above ground → ground accepted.
+        assert!((terrain.static_height(0.0, 0.0, 60.0) - 50.0).abs() < 1e-2);
+        // Probe well below ground → C++ leaves mapHeight invalid.
+        assert_eq!(
+            terrain.static_height(0.0, 0.0, 10.0),
+            VMAP_INVALID_HEIGHT_VALUE
+        );
+        // Within tolerance band → still accepted.
+        assert!((terrain.static_height(0.0, 0.0, 50.0 - 0.04) - 50.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn eager_load_then_unload_via_loader_seam() {
+        let dir = TempMapsDir::new();
+        dir.write_tile(0, 32, 32, &constant_float_tile(12.0));
+        let mut terrain = GridMapTerrain::new(0, &dir.0);
+        // Eager load (raw indices, as Map::ensure_grid_created supplies).
+        terrain.load_map_and_vmap(32, 32);
+        assert!((terrain.grid_height(0.0, 0.0) - 12.0).abs() < 1e-2);
+        // Unload drops the cache entry; a fresh query re-reads from disk.
+        terrain.unload_map(32, 32);
+        assert!((terrain.grid_height(0.0, 0.0) - 12.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn map_height_env_seam_returns_ground() {
+        let dir = TempMapsDir::new();
+        dir.write_tile(0, 32, 32, &constant_float_tile(33.0));
+        let terrain = GridMapTerrain::new(0, &dir.0);
+        let object = WorldObject::new(true, TypeId::Unit, TypeMask::UNIT);
+        let h = terrain.map_height(
+            &object,
+            0.0,
+            0.0,
+            Z_PROBE,
+            WorldObjectHeightQuery::default(),
+        );
+        assert!((h - 33.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn out_of_range_world_position_is_safe() {
+        let dir = TempMapsDir::new();
+        let terrain = GridMapTerrain::new(0, &dir.0);
+        // Absurd coordinate → tile index outside [0,64); must not panic.
+        assert_eq!(
+            terrain.grid_height(1.0e9, -1.0e9),
+            VMAP_INVALID_HEIGHT_VALUE
+        );
+    }
+}

--- a/crates/wow-map/src/terrain.rs
+++ b/crates/wow-map/src/terrain.rs
@@ -310,6 +310,29 @@ mod tests {
         assert!((h - 33.0).abs() < 1e-2);
     }
 
+    /// Real-data smoke check (not run in CI — needs the server's `DataDir`).
+    /// Run with: `cargo test -p wow-map --lib terrain::tests::real_map -- --ignored --nocapture`.
+    /// Validates the parser + height query against actual extracted `.map` tiles:
+    /// the human start in Elwynn Forest (map 0, ~(-8949.95, -132.49)) sits on
+    /// ground near Z≈83.5 in retail/TC data.
+    #[test]
+    #[ignore = "requires real DataDir at /home/server/woltk-server-core/Data"]
+    fn real_map_tile_returns_plausible_ground_height() {
+        let data_dir = "/home/server/woltk-server-core/Data";
+        let terrain = GridMapTerrain::new(0, data_dir);
+        let (x, y) = (-8949.95_f32, -132.49_f32);
+        let h = terrain.grid_height(x, y);
+        eprintln!("REAL map0 grid_height({x}, {y}) = {h}");
+        assert!(
+            h > 70.0 && h < 100.0,
+            "Elwynn human-start ground should be ~83.5, got {h}"
+        );
+        // GetStaticHeight from above ground accepts the surface.
+        let sh = terrain.static_height(x, y, h + 5.0);
+        eprintln!("REAL map0 static_height(probe={}) = {sh}", h + 5.0);
+        assert!((sh - h).abs() < 1e-2);
+    }
+
     #[test]
     fn out_of_range_world_position_is_safe() {
         let dir = TempMapsDir::new();

--- a/crates/wow-world/src/map_manager.rs
+++ b/crates/wow-world/src/map_manager.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock, mpsc};
+use std::sync::{Arc, Mutex, RwLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -15,10 +15,12 @@ use wow_constants::{
 };
 use wow_core::{ObjectGuid, Position};
 use wow_entities::{
-    Creature, CreatureAddonLifecycleRecordLikeCpp, CreatureAiState, DistractMovementAction,
-    EVENT_CHARGE_PREPATH, GenericMovementInform, MovementGeneratorKind, MovementGeneratorType,
-    MovementSlot, PhaseShift, PointMovementAction, PointMovementInform, RotateMovementUpdate,
+    AllowedPositionZCaps, Creature, CreatureAddonLifecycleRecordLikeCpp, CreatureAiState,
+    DistractMovementAction, EVENT_CHARGE_PREPATH, GenericMovementInform, MovementGeneratorKind,
+    MovementGeneratorType, MovementSlot, PhaseShift, PointMovementAction, PointMovementInform,
+    RotateMovementUpdate, Z_OFFSET_FIND_HEIGHT, allowed_position_z_from_ground_like_cpp,
 };
+use wow_map::GridMapTerrain;
 use wow_movement::generators::CreatureRandomMovementType as MovementCreatureRandomMovementType;
 use wow_movement::{
     MoveSpline, MoveSplineInit, MoveSplineLaunchInput, MoveSplineStopInput, MoveSplineStopResult,
@@ -3009,6 +3011,92 @@ impl RuntimeOutput {
     }
 }
 
+/// Live, file-backed terrain height for the legacy world runtime.
+///
+/// One [`GridMapTerrain`] per map id (created lazily, shared across that map's
+/// instances), mirroring C++ `TerrainInfo` ownership. Rooted at the server's
+/// `DataDir`; tiles load on first query. This is the seam that lets the live
+/// spawn/respawn path ground-snap creatures with real `.map` heights.
+#[derive(Debug)]
+pub struct LiveTerrainHeights {
+    data_dir: PathBuf,
+    per_map: Mutex<HashMap<u32, Arc<GridMapTerrain>>>,
+}
+
+impl LiveTerrainHeights {
+    #[must_use]
+    pub fn new(data_dir: impl AsRef<Path>) -> Self {
+        Self {
+            data_dir: data_dir.as_ref().to_path_buf(),
+            per_map: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn terrain_for_map(&self, map_id: u32) -> Arc<GridMapTerrain> {
+        let mut per_map = self.per_map.lock().expect("live terrain cache poisoned");
+        Arc::clone(
+            per_map
+                .entry(map_id)
+                .or_insert_with(|| Arc::new(GridMapTerrain::new(map_id, &self.data_dir))),
+        )
+    }
+
+    /// C++ `Map::GetHeight` (no VMap/GO-floor): the raw `.map` ground at `(x, y)`,
+    /// accepted only when the probe `z` is at/above it. The caller supplies the
+    /// already-offset probe `z` (matching `WorldObject::GetMapHeight`).
+    #[must_use]
+    pub fn static_height_like_cpp(&self, map_id: u32, x: f32, y: f32, z: f32) -> f32 {
+        self.terrain_for_map(map_id).static_height(x, y, z)
+    }
+}
+
+/// Ground-snap a freshly respawned creature, like C++ `Creature::Respawn`'s
+/// `UpdateAllowedPositionZ` + `SetHomePosition` (`Creature.cpp:461`).
+///
+/// No-op (Z untouched) when terrain has no tile/ground under the position, so the
+/// no-terrain runtime path is byte-identical to before this wiring. Flyers keep
+/// their altitude (raise-only); grounded creatures sit on `ground + hover`.
+pub fn snap_respawn_creature_to_ground_like_cpp(
+    world_creature: &mut WorldCreature,
+    map_id: u16,
+    terrain: &LiveTerrainHeights,
+) {
+    let creature = &world_creature.creature;
+    let pos = creature.unit().world().position();
+    // C++ `Unit::GetHoverOffset()`: hover height only while the HOVER flag is set.
+    let hover_offset = if creature
+        .movement_flags_like_cpp()
+        .contains(MovementFlag::HOVER)
+    {
+        creature.unit().data().hover_height
+    } else {
+        0.0
+    };
+    let caps = AllowedPositionZCaps {
+        // Transport passengers recompute position from the transport elsewhere;
+        // the legacy respawn path does not model on-transport spawns.
+        on_transport: false,
+        can_fly: creature.can_fly_like_cpp(),
+        can_swim: creature.can_swim_like_cpp(),
+        hover_offset,
+    };
+
+    // C++ `GetMapHeight` offsets the probe by `Z_OFFSET_FIND_HEIGHT` before the
+    // terrain lookup.
+    let probe_z = pos.z + Z_OFFSET_FIND_HEIGHT;
+    let ground = terrain.static_height_like_cpp(u32::from(map_id), pos.x, pos.y, probe_z);
+    let new_z = allowed_position_z_from_ground_like_cpp(true, ground, pos.z, caps);
+    if new_z != pos.z {
+        let snapped = Position::new(pos.x, pos.y, new_z, pos.orientation);
+        world_creature
+            .creature
+            .unit_mut()
+            .world_mut()
+            .relocate(snapped);
+        world_creature.creature.set_ai_home_position(snapped);
+    }
+}
+
 /// Global map manager containing all map instances.
 #[derive(Debug)]
 pub struct MapManager {
@@ -3016,6 +3104,10 @@ pub struct MapManager {
     free_instance_ids: Vec<bool>,
     next_instance_id: u32,
     tick_owner: RuntimeTickOwner,
+    /// Shared, file-backed terrain height (DataDir). `None` until wired at server
+    /// startup; while absent, height-dependent paths fall back to their prior
+    /// no-terrain behaviour.
+    terrain: Option<Arc<LiveTerrainHeights>>,
 }
 
 impl MapManager {
@@ -3025,9 +3117,22 @@ impl MapManager {
             free_instance_ids: Vec::new(),
             next_instance_id: 1,
             tick_owner: RuntimeTickOwner::Session,
+            terrain: None,
         };
         manager.init_instance_ids_from_max(0);
         manager
+    }
+
+    /// Attach the shared, file-backed terrain height store (server startup).
+    pub fn set_terrain(&mut self, terrain: Arc<LiveTerrainHeights>) {
+        self.terrain = Some(terrain);
+    }
+
+    /// Shared terrain height store, if wired. Cloned so callers can use it while
+    /// still holding `&mut self` for the spawn/respawn mutation.
+    #[must_use]
+    pub fn terrain(&self) -> Option<Arc<LiveTerrainHeights>> {
+        self.terrain.clone()
     }
 
     /// Returns the current tick owner for this map manager.
@@ -7168,6 +7273,104 @@ mod tests {
 
         let ready_0 = manager.drain_ready_respawns(0, 0, now);
         assert_eq!(ready_0.len(), 1);
+    }
+
+    /// Unique temp `maps/` dir holding one synthetic constant-height tile.
+    fn temp_dir_with_constant_tile(map_id: u32, gx: i32, gy: i32, height: f32) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("rustycore_live_terrain_{}_{n}", std::process::id()));
+        std::fs::create_dir_all(dir.join("maps")).expect("create temp maps dir");
+
+        // Minimal float `.map`: fileheader(44) + MHGT header(16) + V9 + V8, all = height.
+        const V9: usize = 129 * 129;
+        const V8: usize = 128 * 128;
+        let mut b = Vec::new();
+        b.extend_from_slice(b"MAPS");
+        b.extend_from_slice(&10u32.to_le_bytes()); // version
+        b.extend_from_slice(&0u32.to_le_bytes()); // build
+        b.extend_from_slice(&0u32.to_le_bytes()); // areaMapOffset
+        b.extend_from_slice(&0u32.to_le_bytes()); // areaMapSize
+        b.extend_from_slice(&44u32.to_le_bytes()); // heightMapOffset
+        for _ in 0..5 {
+            b.extend_from_slice(&0u32.to_le_bytes());
+        }
+        b.extend_from_slice(b"MHGT");
+        b.extend_from_slice(&0u32.to_le_bytes()); // flags = float
+        b.extend_from_slice(&height.to_le_bytes()); // gridHeight
+        b.extend_from_slice(&height.to_le_bytes()); // gridMaxHeight
+        for _ in 0..(V9 + V8) {
+            b.extend_from_slice(&height.to_le_bytes());
+        }
+        std::fs::write(
+            dir.join("maps")
+                .join(format!("{map_id:04}_{gx:02}_{gy:02}.map")),
+            &b,
+        )
+        .expect("write tile");
+        dir
+    }
+
+    #[test]
+    fn respawn_ground_snap_uses_real_terrain_like_cpp() {
+        // World (0,0) → raw tile (32,32). Ground at 77.0; spawn hovering above it.
+        let dir = temp_dir_with_constant_tile(0, 32, 32, 77.0);
+        let terrain = LiveTerrainHeights::new(&dir);
+
+        let mut pending = make_pending_respawn(Instant::now());
+        pending.home_pos.z = 80.0; // above ground; probe accepts the surface
+        let mut creature = world_creature_from_pending_respawn_like_cpp(&pending, 0);
+        assert!((creature.creature.unit().world().position().z - 80.0).abs() < 1e-3);
+
+        snap_respawn_creature_to_ground_like_cpp(&mut creature, 0, &terrain);
+
+        // Grounded, non-hovering: snapped exactly onto the surface (+0 hover).
+        assert!(
+            (creature.creature.unit().world().position().z - 77.0).abs() < 1e-2,
+            "respawn must sit on the .map ground like Creature::Respawn/UpdateAllowedPositionZ"
+        );
+        // C++ SetHomePosition takes the snapped Z too.
+        assert!((creature.home_position().z - 77.0).abs() < 1e-2);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn respawn_ground_snap_noop_without_terrain_tile_like_cpp() {
+        // Empty maps dir → no tile → GetGridHeight invalid → Z untouched.
+        let dir = temp_dir_with_constant_tile(0, 10, 10, 5.0); // tile for a different grid
+        let terrain = LiveTerrainHeights::new(&dir);
+
+        let mut pending = make_pending_respawn(Instant::now());
+        pending.home_pos.z = 80.0;
+        let mut creature = world_creature_from_pending_respawn_like_cpp(&pending, 0);
+        snap_respawn_creature_to_ground_like_cpp(&mut creature, 0, &terrain);
+
+        assert!(
+            (creature.creature.unit().world().position().z - 80.0).abs() < 1e-3,
+            "no terrain under the spawn → C++ leaves Z unchanged"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn respawn_ground_snap_skips_creature_far_below_surface_like_cpp() {
+        // Spawn well below ground: probe z < gridHeight - tolerance → GetStaticHeight
+        // returns invalid, so C++ does NOT rescue a buried creature.
+        let dir = temp_dir_with_constant_tile(0, 32, 32, 77.0);
+        let terrain = LiveTerrainHeights::new(&dir);
+
+        let mut pending = make_pending_respawn(Instant::now());
+        pending.home_pos.z = 10.0; // far under the 77.0 surface
+        let mut creature = world_creature_from_pending_respawn_like_cpp(&pending, 0);
+        snap_respawn_creature_to_ground_like_cpp(&mut creature, 0, &terrain);
+
+        assert!((creature.creature.unit().world().position().z - 10.0).abs() < 1e-3);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -46097,8 +46097,17 @@ pub fn run_legacy_creature_lifecycle_tick_once_like_cpp(
                 }
                 let position =
                     crate::map_manager::pending_respawn_create_position_like_cpp(&respawn);
-                let world_creature =
+                let mut world_creature =
                     world_creature_from_pending_respawn_like_cpp(&respawn, instance_id);
+                // C++ Creature::Respawn ground-snaps via UpdateAllowedPositionZ
+                // (Creature.cpp:461). No-op when terrain is not wired.
+                if let Some(terrain) = manager.terrain() {
+                    crate::map_manager::snap_respawn_creature_to_ground_like_cpp(
+                        &mut world_creature,
+                        map_id,
+                        &terrain,
+                    );
+                }
                 let canonical_creature = world_creature.creature.clone();
                 let (grid_x, grid_y) = world_to_grid_coords(position.x, position.y);
                 if manager.add_creature(map_id, instance_id, grid_x, grid_y, world_creature) {


### PR DESCRIPTION
Closes #15

## What

Ports **real `.map` terrain height** and uses it to ground-snap creatures, faithful to C++ `TerrainInfo`/`WorldObject::UpdateAllowedPositionZ`/`Creature::Respawn`.

Three slices:

- **A** (already on branch): `GridMap` `.map` parser + `getHeight` (triangle bilinear, int8/16/float/flat, holes). `GridMap.cpp`.
- **B** — `crates/wow-map/src/terrain.rs` `GridMapTerrain`: file-backed, per-map, lazy tile cache rooted at `DataDir`. Answers `GetGridHeight`/`GetStaticHeight`/`Map::GetHeight` and implements the `TerrainGridLoader` + `MapWorldObjectEnvironment` seams, so `WorldObject → environment → Map → terrain` returns real ground instead of the `Noop` sentinel. Raw TC tile index `(int)(CENTER_GRID_ID - x/SIZE_OF_GRIDS)`. `TerrainMgr.cpp`.
- **world_object** — port of `WorldObject::UpdateAllowedPositionZ` (`Object.cpp:1411`): `AllowedPositionZCaps` + a pure `allowed_position_z_from_ground_like_cpp` (single source of the branch logic).
- **C** — live wiring: `LiveTerrainHeights` (per-map `GridMapTerrain`) attached to the legacy `MapManager` (additive `Option`; absent ⇒ prior behaviour). The runtime respawn path ground-snaps via `snap_respawn_creature_to_ground_like_cpp`, mirroring `Creature::Respawn`'s `UpdateAllowedPositionZ` + `SetHomePosition` (`Creature.cpp:461`). `DataDir` wired in `world-server/main.rs`.

## Faithfulness boundaries (documented in code)

- VMap / liquid level / GO-floor dynamic tree **not** ported — they collapse to "no value" exactly like C++ with VMap disabled (raw `.map` surface + holes).
- Swim branch folds to ground (no liquid map parsed) — matches C++ `GetMapWaterOrGroundLevel` when liquid is unavailable.
- **Initial DB spawns keep their DB Z** (C++ does not snap on `Create`); snap applies on **respawn** + (future) movement-generator destinations once those generators are ported.

## Tests

- `GridMapTerrain`: 7 (synthetic tiles: missing, below-ground reject, eager load+unload, out-of-range, env seam).
- `UpdateAllowedPositionZ`: branch matrix (walk/fly/transport/non-unit/no-terrain).
- Live respawn snap: 3 (snaps onto surface + `SetHomePosition`; no-op without tile; skips buried creature per `GROUND_HEIGHT_TOLERANCE`).

`cargo fmt` clean; new code clippy-clean. Pre-existing wow-map `manager::tests` creature-update flakes (4) are unrelated to this PR (reproduce on the #14 base on this machine; timing/`GameTime`).

## Remaining human step (STATE.md §5 "done = capture-clean live")

Code is complete + tested. The live byte/opcode-clean validation (start server with real `DataDir`, observe respawned creatures sitting on the ground vs a C++ capture) is the one step that needs a running server + client — please validate live before final close.