### PR TITLE
Fix client death crash and live creature movement

### DIFF
--- a/crates/world-server/src/creature_loaded_grid.rs
+++ b/crates/world-server/src/creature_loaded_grid.rs
@@ -383,9 +383,15 @@ pub fn build_loaded_grid_creature_inputs_from_db_like_cpp(
         runtime_row.wander_distance,
     );
     let npc_flags = runtime_row.npc_flags.unwrap_or(template.npc_flags);
-    let unit_flags = runtime_row.unit_flags.unwrap_or(template.unit_flags);
-    let unit_flags2 = runtime_row.unit_flags2.unwrap_or(template.unit_flags2);
-    let unit_flags3 = runtime_row.unit_flags3.unwrap_or(template.unit_flags3);
+    // C++ `ObjectMgr::LoadCreatureTemplates` / `LoadCreatureData` strips
+    // disallowed SQL-backed creature unit flags before `ChooseCreatureFlags`
+    // feeds `Creature::UpdateEntry`.
+    let unit_flags = runtime_row.unit_flags.unwrap_or(template.unit_flags)
+        & wow_constants::unit::UNIT_FLAGS_ALLOWED_LIKE_CPP;
+    let unit_flags2 = runtime_row.unit_flags2.unwrap_or(template.unit_flags2)
+        & wow_constants::unit::UNIT_FLAGS2_ALLOWED_LIKE_CPP;
+    let unit_flags3 = runtime_row.unit_flags3.unwrap_or(template.unit_flags3)
+        & wow_constants::unit::UNIT_FLAGS3_ALLOWED_LIKE_CPP;
 
     let resolved_template = ResolvedCreatureTemplateLikeCpp {
         entry: template.entry,
@@ -1062,12 +1068,12 @@ mod tests {
             wow_constants::UnitFlags::IMMUNE_TO_PC.bits()
         );
         assert_eq!(
-            template.unit_flags2,
-            wow_constants::UnitFlags2::IGNORE_REPUTATION.bits()
+            template.unit_flags2, 0,
+            "C++ ObjectMgr strips disallowed creature `unit_flags2` SQL bits before UpdateEntry"
         );
         assert_eq!(
-            template.unit_flags3,
-            wow_constants::UnitFlags3::IGNORE_COMBAT.bits()
+            template.unit_flags3, 0,
+            "C++ ObjectMgr strips disallowed creature `unit_flags3` SQL bits before UpdateEntry"
         );
         assert_eq!(template.static_flags[0], static_flags[0]);
         assert_eq!(template.display_id, 999);
@@ -1115,8 +1121,90 @@ mod tests {
     }
 
     #[test]
-    fn loaded_grid_db_backed_builder_applies_creature_equipment_like_cpp() {
+    fn loaded_grid_db_backed_builder_sanitizes_sql_unit_flags_like_cpp() {
         let entry = 12_401;
+        let spawn = db_backed_spawn(entry);
+        let runtime_row = CreatureSpawnRuntimeRowLikeCpp {
+            spawn_id: spawn.spawn_id,
+            model_id: 0,
+            equipment_id: 0,
+            wander_distance: 0.0,
+            curhealth: 77,
+            curmana: 33,
+            movement_type: 0,
+            npc_flags: None,
+            unit_flags: Some(
+                wow_constants::UnitFlags::SKINNABLE.bits()
+                    | wow_constants::UnitFlags::PREVENT_EMOTES_FROM_CHAT_TEXT.bits()
+                    | wow_constants::UnitFlags::CAN_SWIM.bits(),
+            ),
+            unit_flags2: Some(
+                wow_constants::UnitFlags2::FEIGN_DEATH.bits()
+                    | wow_constants::UnitFlags2::REGENERATE_POWER.bits()
+                    | wow_constants::UnitFlags2::CANNOT_TURN.bits(),
+            ),
+            unit_flags3: Some(
+                wow_constants::UnitFlags3::IGNORE_COMBAT.bits()
+                    | wow_constants::UnitFlags3::FAKE_DEAD.bits()
+                    | wow_constants::UnitFlags3::AI_OBSTACLE.bits(),
+            ),
+            ground_movement_type: wow_constants::CreatureGroundMovementType::Run as u8,
+            swim_allowed: true,
+            flight_movement_type: 0,
+            rooted: false,
+            chase_movement_type: wow_constants::CreatureChaseMovementType::Run as u8,
+            random_movement_type: wow_constants::CreatureRandomMovementType::Walk as u8,
+            interaction_pause_timer_ms:
+                wow_entities::DEFAULT_CREATURE_INTERACTION_PAUSE_TIMER_MS_LIKE_CPP,
+            string_id: String::new(),
+            spawn_time_secs: 300,
+        };
+        let (display_store, model_store) = empty_display_stores();
+        let model_info_store = loaded_grid_model_info_store_like_cpp();
+        let mut random = TestLoadedGridCreatureRandomLikeCpp::default();
+
+        let (template, _, _) = build_loaded_grid_creature_inputs_from_db_like_cpp(
+            &spawn,
+            &runtime_row,
+            &db_backed_template_store(entry),
+            &db_backed_difficulty_store(entry),
+            &db_backed_base_stats_store(),
+            &CreatureClassificationHealthRatesLikeCpp::default(),
+            &display_store,
+            &model_store,
+            &model_info_store,
+            None,
+            &CreatureAddonStoreLikeCpp::default(),
+            2,
+            9,
+            123,
+            true,
+            None,
+            &mut random,
+        )
+        .expect("DB-backed builder should sanitize SQL creature unit flags");
+
+        assert_eq!(
+            template.unit_flags,
+            wow_constants::UnitFlags::CAN_SWIM.bits(),
+            "C++ ObjectMgr strips disallowed creature `unit_flags` SQL bits"
+        );
+        assert_eq!(
+            template.unit_flags2,
+            (wow_constants::UnitFlags2::REGENERATE_POWER | wow_constants::UnitFlags2::CANNOT_TURN)
+                .bits(),
+            "C++ ObjectMgr strips FEIGN_DEATH but keeps allowed `unit_flags2` SQL bits"
+        );
+        assert_eq!(
+            template.unit_flags3,
+            (wow_constants::UnitFlags3::FAKE_DEAD | wow_constants::UnitFlags3::AI_OBSTACLE).bits(),
+            "C++ ObjectMgr strips disallowed `unit_flags3` SQL bits and keeps allowed fake-dead/AI-obstacle bits"
+        );
+    }
+
+    #[test]
+    fn loaded_grid_db_backed_builder_applies_creature_equipment_like_cpp() {
+        let entry = 12_402;
         let spawn = db_backed_spawn(entry);
         let runtime_row = CreatureSpawnRuntimeRowLikeCpp {
             spawn_id: spawn.spawn_id,

--- a/crates/world-server/src/main.rs
+++ b/crates/world-server/src/main.rs
@@ -6988,55 +6988,55 @@ fn mirror_loaded_grid_primary_records_to_legacy_like_cpp(
         .count()
 }
 
-fn ensure_login_player_grid_loaded_like_cpp(
-    canonical_map_manager: &SharedCanonicalMapManager,
+fn player_visible_grid_coords_like_cpp(
+    position: Position,
+    visibility_range: f32,
+) -> Vec<wow_map::GridCoord> {
+    let center_cell = wow_map::cell_from_world(position.x, position.y);
+    let center_grid = wow_map::GridCoord::new(center_cell.grid_x(), center_cell.grid_y());
+    let visible_area =
+        wow_map::calculate_cell_area_like_cpp(position.x, position.y, visibility_range);
+    let mut seen = BTreeSet::new();
+    let mut grids = Vec::new();
+
+    let mut push_grid = |grid: wow_map::GridCoord| {
+        if seen.insert((grid.x_coord, grid.y_coord)) {
+            grids.push(grid);
+        }
+    };
+
+    // C++ visits the standing cell first (`CellImpl.h:105-107`). Keep the
+    // player's own NGrid first, then cover any adjacent NGrids touched by the
+    // visible cell area.
+    push_grid(center_grid);
+    for cell_x in visible_area.low_bound.x_coord..=visible_area.high_bound.x_coord {
+        for cell_y in visible_area.low_bound.y_coord..=visible_area.high_bound.y_coord {
+            let (grid, _, _) = wow_map::cell_to_grid_local(wow_map::CellCoord::new(cell_x, cell_y));
+            push_grid(grid);
+        }
+    }
+
+    grids
+}
+
+fn materialize_loaded_player_grid_records_like_cpp(
+    map: &mut wow_map::Map,
     legacy_manager: &SharedMapManager,
-    canonical_spawn_metadata: &SharedCanonicalSpawnMetadataLikeCpp,
+    canonical_spawn_metadata: &spawn_store_loader::CanonicalSpawnMetadataLikeCpp,
     loaded_grid_creature_respawn_caches: &LoadedGridCreatureRespawnCachesLikeCpp,
     area_trigger_template_store: &wow_data::AreaTriggerTemplateStore,
-    map_id: u16,
-    instance_id: u32,
-    position: Position,
-) -> wow_world::session::PlayerGridLoadOutcomeLikeCpp {
-    let mut outcome = wow_world::session::PlayerGridLoadOutcomeLikeCpp::default();
-    let map_id_u32 = u32::from(map_id);
-    let cell = wow_map::cell_from_world(position.x, position.y);
-    let grid = wow_map::GridCoord::new(cell.grid_x(), cell.grid_y());
-
-    let Ok(metadata) = canonical_spawn_metadata.lock() else {
-        warn!(
-            map_id = map_id_u32,
-            instance_id, "C++ login grid load skipped: canonical spawn metadata lock poisoned"
-        );
-        return outcome;
-    };
-    let Ok(mut manager) = canonical_map_manager.lock() else {
-        warn!(
-            map_id = map_id_u32,
-            instance_id, "C++ login grid load skipped: canonical map manager lock poisoned"
-        );
-        return outcome;
-    };
-
-    outcome.map_created = manager.find_map(map_id_u32, instance_id).is_none();
-    let managed_map = manager.create_world_map(map_id_u32, instance_id);
-    let map = managed_map.map_mut();
-
-    // C++ Map::AddPlayerToMap -> EnsureGridLoadedForActiveObject(cell, player)
-    // loads the player's grid before SendInitSelf. Rusty's NoopGridLifecycle does
-    // not own ObjectMgr DB state, so this bridge materializes loaded-grid records
-    // immediately after marking the grid loaded/active.
-    outcome.grid_loaded_now =
-        map.ensure_grid_loaded_for_active_object(&cell, wow_map::ActiveObjectKind::Player);
-
+    map_id: u32,
+    grid: wow_map::GridCoord,
+    outcome: &mut wow_world::session::PlayerGridLoadOutcomeLikeCpp,
+) {
     let spawn_mode = map.spawn_mode();
     let mut creature_spawn_ids = BTreeSet::new();
     let mut gameobject_spawn_ids = BTreeSet::new();
     let mut area_trigger_spawn_ids = BTreeSet::new();
     if let Some(ngrid) = map.get_ngrid(grid) {
         ngrid.visit_all_grids(|local_cell| {
-            let Some(cell_guids) = metadata.spawn_store().cell_object_guids(
-                map_id_u32,
+            let Some(cell_guids) = canonical_spawn_metadata.spawn_store().cell_object_guids(
+                map_id,
                 spawn_mode,
                 local_cell.cell_coord().get_id(),
             ) else {
@@ -7082,7 +7082,7 @@ fn ensure_login_player_grid_loaded_like_cpp(
             if let Some(creature) = already_loaded_creature
                 && mirror_loaded_grid_creature_to_legacy_like_cpp(
                     Some(legacy_manager),
-                    metadata.waypoint_paths_like_cpp(),
+                    canonical_spawn_metadata.waypoint_paths_like_cpp(),
                     creature,
                 )
             {
@@ -7092,18 +7092,21 @@ fn ensure_login_player_grid_loaded_like_cpp(
         }
 
         let should_spawn = map
-            .spawn_grid_load_state_like_cpp(metadata.spawn_store())
+            .spawn_grid_load_state_like_cpp(canonical_spawn_metadata.spawn_store())
             .should_be_spawned_on_grid_load(object_type, spawn_id);
         if !should_spawn {
             outcome.skipped_should_not_spawn += 1;
             continue;
         }
 
-        let Some(spawn_data) = metadata.spawn_store().spawn_data(object_type, spawn_id) else {
+        let Some(spawn_data) = canonical_spawn_metadata
+            .spawn_store()
+            .spawn_data(object_type, spawn_id)
+        else {
             outcome.stale_index_entries += 1;
             continue;
         };
-        if spawn_data.map_id != map_id_u32 {
+        if spawn_data.map_id != map_id {
             outcome.stale_index_entries += 1;
             continue;
         }
@@ -7119,7 +7122,7 @@ fn ensure_login_player_grid_loaded_like_cpp(
                     map,
                     object_type,
                     spawn_id,
-                    &metadata,
+                    canonical_spawn_metadata,
                     loaded_grid_creature_respawn_caches,
                 )
             }
@@ -7128,7 +7131,7 @@ fn ensure_login_player_grid_loaded_like_cpp(
                     map,
                     object_type,
                     spawn_id,
-                    &metadata,
+                    canonical_spawn_metadata,
                     loaded_grid_creature_respawn_caches,
                 )
             }
@@ -7137,7 +7140,7 @@ fn ensure_login_player_grid_loaded_like_cpp(
                     map,
                     object_type,
                     spawn_id,
-                    &metadata,
+                    canonical_spawn_metadata,
                     area_trigger_template_store,
                 )
             }
@@ -7177,7 +7180,7 @@ fn ensure_login_player_grid_loaded_like_cpp(
                     if let Some(creature) = legacy_creature
                         && mirror_loaded_grid_creature_to_legacy_like_cpp(
                             Some(legacy_manager),
-                            metadata.waypoint_paths_like_cpp(),
+                            canonical_spawn_metadata.waypoint_paths_like_cpp(),
                             creature,
                         )
                     {
@@ -7195,6 +7198,114 @@ fn ensure_login_player_grid_loaded_like_cpp(
                 outcome.add_to_map_errors += 1;
             }
         }
+    }
+}
+
+fn ensure_login_player_grid_loaded_like_cpp(
+    canonical_map_manager: &SharedCanonicalMapManager,
+    legacy_manager: &SharedMapManager,
+    canonical_spawn_metadata: &SharedCanonicalSpawnMetadataLikeCpp,
+    loaded_grid_creature_respawn_caches: &LoadedGridCreatureRespawnCachesLikeCpp,
+    area_trigger_template_store: &wow_data::AreaTriggerTemplateStore,
+    map_id: u16,
+    instance_id: u32,
+    position: Position,
+) -> wow_world::session::PlayerGridLoadOutcomeLikeCpp {
+    let mut outcome = wow_world::session::PlayerGridLoadOutcomeLikeCpp::default();
+    let map_id_u32 = u32::from(map_id);
+    let cell = wow_map::cell_from_world(position.x, position.y);
+    let grid = wow_map::GridCoord::new(cell.grid_x(), cell.grid_y());
+    let visible_grids =
+        player_visible_grid_coords_like_cpp(position, wow_world::map_manager::VISIBILITY_RADIUS);
+
+    let Ok(metadata) = canonical_spawn_metadata.lock() else {
+        warn!(
+            map_id = map_id_u32,
+            instance_id, "C++ login grid load skipped: canonical spawn metadata lock poisoned"
+        );
+        return outcome;
+    };
+    let Ok(mut manager) = canonical_map_manager.lock() else {
+        warn!(
+            map_id = map_id_u32,
+            instance_id, "C++ login grid load skipped: canonical map manager lock poisoned"
+        );
+        return outcome;
+    };
+
+    outcome.map_created = manager.find_map(map_id_u32, instance_id).is_none();
+    let managed_map = manager.create_world_map(map_id_u32, instance_id);
+    let map = managed_map.map_mut();
+
+    // C++ Map::AddPlayerToMap -> EnsureGridLoadedForActiveObject(cell, player)
+    // loads the player's grid before SendInitSelf. Rusty's NoopGridLifecycle does
+    // not own ObjectMgr DB state, so this bridge materializes loaded-grid records
+    // immediately after marking the grid loaded/active.
+    outcome.grid_loaded_now =
+        map.ensure_grid_loaded_for_active_object(&cell, wow_map::ActiveObjectKind::Player);
+
+    for visible_grid in visible_grids {
+        if visible_grid != grid {
+            outcome.grid_loaded_now |=
+                map.ensure_grid_loaded(&wow_map::cell_from_grid_center(visible_grid));
+        }
+        materialize_loaded_player_grid_records_like_cpp(
+            map,
+            legacy_manager,
+            &metadata,
+            loaded_grid_creature_respawn_caches,
+            area_trigger_template_store,
+            map_id_u32,
+            visible_grid,
+            &mut outcome,
+        );
+    }
+
+    if std::env::var_os("RUSTYCORE_CREATURE_VIS_TRACE").is_some()
+        && (outcome.map_created
+            || outcome.grid_loaded_now
+            || outcome.metadata_entries != 0
+            || outcome.skipped_already_loaded != 0
+            || outcome.skipped_should_not_spawn != 0
+            || outcome.skipped_difficulty_mismatch != 0
+            || outcome.stale_index_entries != 0
+            || outcome.creature_records_added != 0
+            || outcome.gameobject_records_added != 0
+            || outcome.area_trigger_records_added != 0
+            || outcome.pre_add_records_added != 0
+            || outcome.add_to_map_errors != 0
+            || outcome.load_record_missing != 0
+            || outcome.legacy_creature_mirrors != 0)
+    {
+        info!(
+            map_id = map_id_u32,
+            instance_id,
+            x = position.x,
+            y = position.y,
+            z = position.z,
+            cell_x = cell.cell_x(),
+            cell_y = cell.cell_y(),
+            grid_x = grid.x_coord,
+            grid_y = grid.y_coord,
+            map_created = outcome.map_created,
+            grid_loaded_now = outcome.grid_loaded_now,
+            metadata_entries = outcome.metadata_entries,
+            skipped_already_loaded = outcome.skipped_already_loaded,
+            skipped_should_not_spawn = outcome.skipped_should_not_spawn,
+            skipped_difficulty_mismatch = outcome.skipped_difficulty_mismatch,
+            stale_index_entries = outcome.stale_index_entries,
+            creature_records_added = outcome.creature_records_added,
+            gameobject_records_added = outcome.gameobject_records_added,
+            area_trigger_records_added = outcome.area_trigger_records_added,
+            pre_add_records_added = outcome.pre_add_records_added,
+            add_to_map_errors = outcome.add_to_map_errors,
+            load_record_missing = outcome.load_record_missing,
+            creature_load_record_missing = outcome.creature_load_record_missing,
+            gameobject_load_record_missing = outcome.gameobject_load_record_missing,
+            area_trigger_load_record_missing = outcome.area_trigger_load_record_missing,
+            legacy_creature_mirrors = outcome.legacy_creature_mirrors,
+            "RUST_CREATURE_VIS login_grid_load"
+        );
     }
 
     outcome
@@ -12060,6 +12171,7 @@ fn resolve_runtime_event_candidates_like_cpp(
                 summary.candidates_seen += 1;
                 let cmd = wow_network::SessionCommand::SendIfVisibleLikeCpp(
                     wow_network::player_registry::SendIfVisibleLikeCppCommand {
+                        queued_at: Instant::now(),
                         source_guid: event.source_guid,
                         map_id: target_map_id,
                         instance_id: target_instance_id,
@@ -12133,6 +12245,7 @@ fn resolve_runtime_event_candidates_like_cpp(
                     None => {
                         let cmd = wow_network::SessionCommand::SendIfVisibleLikeCpp(
                             wow_network::player_registry::SendIfVisibleLikeCppCommand {
+                                queued_at: Instant::now(),
                                 source_guid: event.source_guid,
                                 map_id: *map_id,
                                 instance_id: *instance_id,
@@ -12231,6 +12344,7 @@ fn resolve_runtime_event_candidates_like_cpp(
                     None => {
                         let cmd = wow_network::SessionCommand::SendIfVisibleLikeCpp(
                             wow_network::player_registry::SendIfVisibleLikeCppCommand {
+                                queued_at: Instant::now(),
                                 source_guid: event.source_guid,
                                 map_id: *map_id,
                                 instance_id: *instance_id,
@@ -20669,6 +20783,137 @@ mmap.enablePathFinding = 0
         assert!(
             legacy.read().unwrap().find_creature(571, 0, guid).is_some(),
             "already-loaded canonical creature must be present in legacy MapManager so the creature tick can move it"
+        );
+    }
+
+    #[test]
+    fn login_grid_load_materializes_visible_adjacent_ngrid_creature_like_cpp() {
+        let spawn_id = 304_317;
+        let entry = 3_114;
+        let player_position = Position::new(545.38, -4209.53, 15.9, 0.0);
+        let creature_position = Position::new(520.972, -4209.32, 15.9, 0.0);
+        let player_cell = wow_map::cell_from_world(player_position.x, player_position.y);
+        let creature_cell = wow_map::cell_from_world(creature_position.x, creature_position.y);
+        assert_ne!(
+            player_cell.grid_x(),
+            creature_cell.grid_x(),
+            "regression setup must place the player and nearby creature across a C++ NGrid boundary"
+        );
+        assert!(
+            player_position.distance_2d(&creature_position)
+                <= wow_world::map_manager::VISIBILITY_RADIUS,
+            "regression creature must be inside the client visibility radius"
+        );
+
+        let canonical: wow_world::SharedCanonicalMapManager =
+            Arc::new(Mutex::new(wow_map::MapManager::default()));
+        let legacy: wow_world::SharedMapManager =
+            Arc::new(RwLock::new(wow_world::MapManager::new()));
+        let mut store = SpawnStore::new();
+        store.add_object_spawn(
+            &SpawnData {
+                object_type: SpawnObjectType::Creature,
+                spawn_id,
+                map_id: 1,
+                db_data: true,
+                spawn_group: SpawnGroupTemplateData::default_group(),
+                id: entry,
+                spawn_point: SpawnPosition::new(
+                    creature_position.x,
+                    creature_position.y,
+                    creature_position.z,
+                    creature_position.orientation,
+                ),
+                phase_use_flags: 0,
+                phase_id: 0,
+                phase_group: 0,
+                terrain_swap_map: -1,
+                pool_id: 0,
+                spawn_time_secs: 120,
+                spawn_difficulties: vec![0],
+                script_id: 0,
+                string_id: String::new(),
+            },
+            |_| false,
+        );
+        let metadata = Arc::new(Mutex::new(
+            super::spawn_store_loader::CanonicalSpawnMetadataLikeCpp::new(store, BTreeMap::new())
+                .with_creature_runtime_rows_like_cpp(BTreeMap::from([(
+                    spawn_id,
+                    super::spawn_store_loader::CreatureSpawnRuntimeRowLikeCpp {
+                        spawn_id,
+                        model_id: 111,
+                        equipment_id: 0,
+                        wander_distance: 8.0,
+                        curhealth: 0,
+                        curmana: 0,
+                        movement_type: 1,
+                        npc_flags: None,
+                        unit_flags: None,
+                        unit_flags2: None,
+                        unit_flags3: None,
+                        ground_movement_type: wow_constants::CreatureGroundMovementType::Run as u8,
+                        swim_allowed: true,
+                        flight_movement_type: 0,
+                        rooted: false,
+                        chase_movement_type: wow_constants::CreatureChaseMovementType::Run as u8,
+                        random_movement_type: wow_constants::CreatureRandomMovementType::Walk as u8,
+                        interaction_pause_timer_ms:
+                            wow_entities::DEFAULT_CREATURE_INTERACTION_PAUSE_TIMER_MS_LIKE_CPP,
+                        string_id: "visible-adjacent-grid-creature".to_string(),
+                        spawn_time_secs: 120,
+                    },
+                )])),
+        ));
+        let caches =
+            variable_loaded_grid_creature_respawn_caches_with_vehicle_id_and_difficulty_like_cpp(
+                entry, 0, 0,
+            );
+        let area_trigger_templates = area_trigger_template_store_for_loaded_grid_like_cpp(1, 1);
+
+        let outcome = super::ensure_login_player_grid_loaded_like_cpp(
+            &canonical,
+            &legacy,
+            &metadata,
+            &caches,
+            &area_trigger_templates,
+            1,
+            0,
+            player_position,
+        );
+
+        assert_eq!(outcome.creature_records_added, 1);
+        assert_eq!(outcome.legacy_creature_mirrors, 1);
+        assert_eq!(outcome.load_record_missing, 0);
+        assert_eq!(outcome.add_to_map_errors, 0);
+        let guid = {
+            let guard = canonical.lock().unwrap();
+            guard
+                .find_map(1, 0)
+                .expect("login grid load should create the world map")
+                .map()
+                .get_creature_by_spawn_id_like_cpp(spawn_id)
+                .expect("visible adjacent NGrid creature should be materialized")
+                .guid()
+        };
+        assert!(
+            legacy.read().unwrap().find_creature(1, 0, guid).is_some(),
+            "materialized canonical creature must be mirrored into the legacy visible/tick world"
+        );
+        assert!(
+            legacy
+                .read()
+                .unwrap()
+                .get_visible_creatures(
+                    1,
+                    0,
+                    player_position.x,
+                    player_position.y,
+                    player_position.z
+                )
+                .iter()
+                .any(|creature| creature.guid() == guid),
+            "nearby creature from the adjacent C++ NGrid must be visible after login"
         );
     }
 

--- a/crates/wow-network/src/player_registry.rs
+++ b/crates/wow-network/src/player_registry.rs
@@ -11,6 +11,7 @@
 
 use dashmap::DashMap;
 use std::collections::{HashMap, HashSet};
+use std::time::Instant;
 use wow_core::{ObjectGuid, Position};
 use wow_packet::packets::loot::LootEntry;
 use wow_packet::packets::party::{
@@ -203,6 +204,9 @@ pub struct CreatureAttackStartLikeCppCommand {
 /// cross-instance delivery without touching the canonical map manager.
 #[derive(Clone, Debug)]
 pub struct SendIfVisibleLikeCppCommand {
+    /// Monotonic enqueue time. Rust uses this to drop movement fan-out produced
+    /// before a login's initial visibility burst has completed.
+    pub queued_at: Instant,
     /// GUID of the entity that emitted the packet — checked against
     /// `client_visible_guids_like_cpp` (C++ `HaveAtClient`).
     pub source_guid: ObjectGuid,
@@ -701,6 +705,7 @@ mod tests {
     fn send_if_visible_like_cpp_command_carries_map_and_instance_id() {
         let guid = ObjectGuid::create_player(1, 7);
         let cmd = SendIfVisibleLikeCppCommand {
+            queued_at: Instant::now(),
             source_guid: guid,
             map_id: 532,
             instance_id: 99,

--- a/crates/wow-packet/src/packets/misc.rs
+++ b/crates/wow-packet/src/packets/misc.rs
@@ -5917,7 +5917,7 @@ impl ServerPacket for TaxiNodeStatusPkt {
 
 // ── RequestCemeteryListResponse (SMSG 0x258F) ────────────────────────────────
 /// Response to CMSG_REQUEST_CEMETERY_LIST.
-/// C# ref: MiscPackets.RequestCemeteryListResponse (ConnectionType.Instance)
+/// C++ ref: `WorldPackets::Misc::RequestCemeteryListResponse::Write`.
 pub struct RequestCemeteryListResponse {
     pub is_gossip_triggered: bool,
     pub cemetery_ids: Vec<u32>,

--- a/crates/wow-packet/src/packets/movement.rs
+++ b/crates/wow-packet/src/packets/movement.rs
@@ -1072,6 +1072,15 @@ impl Default for MovementSpline {
 
 impl MovementSpline {
     pub fn write(&self, pkt: &mut WorldPacket) {
+        // C++ `operator<<(MovementSpline)` opens with `data << uint32(Flags)`,
+        // and every `ByteBuffer::operator<<` routes through
+        // `ByteBuffer::append()`, whose first line is `FlushBits()`
+        // (ByteBuffer.cpp:100). That flushes the 4 bits written just before by
+        // `MovementMonsterSpline::write` (CrzTeleport + StopDistanceTolerance)
+        // into their own byte BEFORE the flags u32. Omitting this flush shifts
+        // the entire spline tail one byte earlier on the wire; the 3.4.3 client
+        // then discards the spline and the creature appears frozen.
+        pkt.flush_bits();
         pkt.write_uint32_unflushed(self.flags);
         pkt.write_int32_unflushed(self.elapsed);
         pkt.write_uint32_unflushed(self.move_time);
@@ -1741,24 +1750,27 @@ mod tests {
         assert_eq!(pkt.read_float().unwrap(), 10.0);
         assert_eq!(pkt.read_float().unwrap(), 20.0);
         assert_eq!(pkt.read_float().unwrap(), 30.0);
-        assert_eq!(pkt.read_uint32().unwrap(), 0x0040_0000);
-        assert_eq!(pkt.read_int32().unwrap(), 0);
-        assert_eq!(pkt.read_uint32().unwrap(), 1_500);
-        assert_eq!(pkt.read_uint32().unwrap(), 0);
-        assert_eq!(pkt.read_uint8().unwrap(), 0);
-        assert_eq!(pkt.read_packed_guid().unwrap(), ObjectGuid::EMPTY);
-        assert_eq!(pkt.read_int8().unwrap(), -1);
-        assert!(!pkt.has_bit().unwrap());
-        assert_eq!(pkt.read_bits(3).unwrap(), 0);
-        assert_eq!(pkt.read_bits(2).unwrap(), 0);
-        assert_eq!(pkt.read_bits(16).unwrap(), 1);
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert_eq!(pkt.read_bits(16).unwrap(), 0);
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
+        // C++ MovementMonsterSpline writes CrzTeleport(1) + StopDistanceTolerance(3)
+        // before the spline; the spline's first integer write flushes those
+        // bits into their own byte before Flags.
+        assert!(!pkt.has_bit().unwrap()); // CrzTeleport
+        assert_eq!(pkt.read_bits(3).unwrap(), 0); // StopDistanceTolerance
+        assert_eq!(pkt.read_uint32().unwrap(), 0x0040_0000); // Flags
+        assert_eq!(pkt.read_int32().unwrap(), 0); // Elapsed
+        assert_eq!(pkt.read_uint32().unwrap(), 1_500); // MoveTime
+        assert_eq!(pkt.read_uint32().unwrap(), 0); // FadeObjectTime
+        assert_eq!(pkt.read_uint8().unwrap(), 0); // Mode
+        assert_eq!(pkt.read_packed_guid().unwrap(), ObjectGuid::EMPTY); // TransportGUID
+        assert_eq!(pkt.read_int8().unwrap(), -1); // VehicleSeat
+        assert_eq!(pkt.read_bits(2).unwrap(), 0); // Face
+        assert_eq!(pkt.read_bits(16).unwrap(), 1); // Points.len()
+        assert!(!pkt.has_bit().unwrap()); // VehicleExitVoluntary
+        assert!(!pkt.has_bit().unwrap()); // Interpolate
+        assert_eq!(pkt.read_bits(16).unwrap(), 0); // PackedDeltas.len()
+        assert!(!pkt.has_bit().unwrap()); // SplineFilter
+        assert!(!pkt.has_bit().unwrap()); // SpellEffectExtraData
+        assert!(!pkt.has_bit().unwrap()); // JumpExtraData
+        assert!(!pkt.has_bit().unwrap()); // AnimTierTransition
         assert_eq!(pkt.read_float().unwrap(), 10.0);
         assert_eq!(pkt.read_float().unwrap(), 20.0);
         assert_eq!(pkt.read_float().unwrap(), 30.0);
@@ -1784,24 +1796,24 @@ mod tests {
         assert_eq!(pkt.read_float().unwrap(), 0.0);
         assert_eq!(pkt.read_float().unwrap(), 0.0);
         assert_eq!(pkt.read_float().unwrap(), 0.0);
-        assert_eq!(pkt.read_uint32().unwrap(), 0);
-        assert_eq!(pkt.read_int32().unwrap(), 0);
-        assert_eq!(pkt.read_uint32().unwrap(), 0);
-        assert_eq!(pkt.read_uint32().unwrap(), 0);
-        assert_eq!(pkt.read_uint8().unwrap(), 0);
-        assert_eq!(pkt.read_packed_guid().unwrap(), ObjectGuid::EMPTY);
-        assert_eq!(pkt.read_int8().unwrap(), -1);
-        assert!(!pkt.has_bit().unwrap());
-        assert_eq!(pkt.read_bits(3).unwrap(), 2);
-        assert_eq!(pkt.read_bits(2).unwrap(), 0);
-        assert_eq!(pkt.read_bits(16).unwrap(), 0);
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert_eq!(pkt.read_bits(16).unwrap(), 0);
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
+        assert!(!pkt.has_bit().unwrap()); // CrzTeleport
+        assert_eq!(pkt.read_bits(3).unwrap(), 2); // StopDistanceTolerance
+        assert_eq!(pkt.read_uint32().unwrap(), 0); // Flags
+        assert_eq!(pkt.read_int32().unwrap(), 0); // Elapsed
+        assert_eq!(pkt.read_uint32().unwrap(), 0); // MoveTime
+        assert_eq!(pkt.read_uint32().unwrap(), 0); // FadeObjectTime
+        assert_eq!(pkt.read_uint8().unwrap(), 0); // Mode
+        assert_eq!(pkt.read_packed_guid().unwrap(), ObjectGuid::EMPTY); // TransportGUID
+        assert_eq!(pkt.read_int8().unwrap(), -1); // VehicleSeat
+        assert_eq!(pkt.read_bits(2).unwrap(), 0); // Face
+        assert_eq!(pkt.read_bits(16).unwrap(), 0); // Points.len()
+        assert!(!pkt.has_bit().unwrap()); // VehicleExitVoluntary
+        assert!(!pkt.has_bit().unwrap()); // Interpolate
+        assert_eq!(pkt.read_bits(16).unwrap(), 0); // PackedDeltas.len()
+        assert!(!pkt.has_bit().unwrap()); // SplineFilter
+        assert!(!pkt.has_bit().unwrap()); // SpellEffectExtraData
+        assert!(!pkt.has_bit().unwrap()); // JumpExtraData
+        assert!(!pkt.has_bit().unwrap()); // AnimTierTransition
         assert!(pkt.is_empty());
     }
 
@@ -1834,24 +1846,24 @@ mod tests {
         assert_eq!(pkt.read_float().unwrap(), 12.0);
         assert_eq!(pkt.read_float().unwrap(), 0.0);
         assert_eq!(pkt.read_float().unwrap(), 0.0);
-        assert_eq!(pkt.read_uint32().unwrap(), 0);
-        assert_eq!(pkt.read_int32().unwrap(), 0);
-        assert_eq!(pkt.read_uint32().unwrap(), 0);
-        assert_eq!(pkt.read_uint32().unwrap(), 0);
-        assert_eq!(pkt.read_uint8().unwrap(), 0);
-        assert_eq!(pkt.read_packed_guid().unwrap(), ObjectGuid::EMPTY);
-        assert_eq!(pkt.read_int8().unwrap(), -1);
-        assert!(!pkt.has_bit().unwrap());
-        assert_eq!(pkt.read_bits(3).unwrap(), 0);
-        assert_eq!(pkt.read_bits(2).unwrap(), 3);
-        assert_eq!(pkt.read_bits(16).unwrap(), 1);
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert_eq!(pkt.read_bits(16).unwrap(), 1);
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
+        assert!(!pkt.has_bit().unwrap()); // CrzTeleport
+        assert_eq!(pkt.read_bits(3).unwrap(), 0); // StopDistanceTolerance
+        assert_eq!(pkt.read_uint32().unwrap(), 0); // Flags
+        assert_eq!(pkt.read_int32().unwrap(), 0); // Elapsed
+        assert_eq!(pkt.read_uint32().unwrap(), 0); // MoveTime
+        assert_eq!(pkt.read_uint32().unwrap(), 0); // FadeObjectTime
+        assert_eq!(pkt.read_uint8().unwrap(), 0); // Mode
+        assert_eq!(pkt.read_packed_guid().unwrap(), ObjectGuid::EMPTY); // TransportGUID
+        assert_eq!(pkt.read_int8().unwrap(), -1); // VehicleSeat
+        assert_eq!(pkt.read_bits(2).unwrap(), 3); // Face = FacingAngle
+        assert_eq!(pkt.read_bits(16).unwrap(), 1); // Points.len()
+        assert!(!pkt.has_bit().unwrap()); // VehicleExitVoluntary
+        assert!(!pkt.has_bit().unwrap()); // Interpolate
+        assert_eq!(pkt.read_bits(16).unwrap(), 1); // PackedDeltas.len()
+        assert!(!pkt.has_bit().unwrap()); // SplineFilter
+        assert!(!pkt.has_bit().unwrap()); // SpellEffectExtraData
+        assert!(!pkt.has_bit().unwrap()); // JumpExtraData
+        assert!(!pkt.has_bit().unwrap()); // AnimTierTransition
         assert_eq!(pkt.read_float().unwrap(), 1.25);
         assert_eq!(pkt.read_float().unwrap(), 12.0);
         assert_eq!(pkt.read_float().unwrap(), 0.0);

--- a/crates/wow-packet/src/packets/update.rs
+++ b/crates/wow-packet/src/packets/update.rs
@@ -11597,8 +11597,16 @@ mod tests {
             "C++ UnitData::WriteCreate writes MountDisplayID after native display scale"
         );
         assert!(
-            bytes.windows(4).any(|window| window == [2, 0, 0x12, 3]),
-            "C++ UnitData::WriteCreate writes StandState/PetTalentPoints/VisFlags/AnimTier"
+            bytes
+                .windows(8)
+                .any(|window| window == [2, 0, 0x12, 3, 0, 0, 0, 0]),
+            "C++ UnitData::WriteCreate writes StandState/PetTalentPoints/VisFlags/AnimTier followed by PetNumber"
+        );
+        assert!(
+            !bytes
+                .windows(5)
+                .any(|window| window == [2, 0, 0x12, 0x12, 3]),
+            "C++ UnitData::WriteCreate writes VisFlags once, not twice"
         );
         assert!(
             bytes

--- a/crates/wow-world/src/handlers/character.rs
+++ b/crates/wow-world/src/handlers/character.rs
@@ -6649,6 +6649,48 @@ impl WorldSession {
             || canonical_dynamic_objects.is_some()
             || canonical_area_triggers.is_some()
         {
+            let creature_vis_trace = std::env::var_os("RUSTYCORE_CREATURE_VIS_TRACE").is_some();
+            if creature_vis_trace {
+                info!(
+                    account = self.account_id,
+                    map_id,
+                    x = pos.x,
+                    y = pos.y,
+                    z = pos.z,
+                    visibility_range = range,
+                    candidate_creatures = map_creatures.len(),
+                    already_visible_guids = self.client_visible_guids_like_cpp.len(),
+                    "RUST_CREATURE_VIS visibility_candidates"
+                );
+                for (idx, creature) in map_creatures.iter().take(80).enumerate() {
+                    let creature_pos = creature.position();
+                    let guid = creature.guid();
+                    info!(
+                        account = self.account_id,
+                        map_id,
+                        idx,
+                        ?guid,
+                        entry = creature.entry(),
+                        level = creature.level(),
+                        hp = creature.current_hp(),
+                        max_hp = creature.max_hp(),
+                        x = creature_pos.x,
+                        y = creature_pos.y,
+                        z = creature_pos.z,
+                        distance_2d = creature_pos.distance_2d(&pos),
+                        already_client_visible = self.client_visible_guids_like_cpp.contains(&guid),
+                        "RUST_CREATURE_VIS candidate"
+                    );
+                }
+                if map_creatures.len() > 80 {
+                    info!(
+                        account = self.account_id,
+                        map_id,
+                        omitted = map_creatures.len() - 80,
+                        "RUST_CREATURE_VIS candidates_omitted"
+                    );
+                }
+            }
             let mut new_visible_creatures: HashSet<ObjectGuid> = HashSet::new();
             let mut new_visible_gos: HashSet<ObjectGuid> = HashSet::new();
             let mut new_visible_dynamic_objects: HashSet<ObjectGuid> = HashSet::new();
@@ -6674,6 +6716,26 @@ impl WorldSession {
                             guid,
                             create_data.npc_flags,
                         );
+                    if creature_vis_trace {
+                        let creature_pos = creature.position();
+                        info!(
+                            account = self.account_id,
+                            map_id,
+                            ?guid,
+                            entry = creature.entry(),
+                            level = create_data.level,
+                            hp = create_data.health,
+                            max_hp = create_data.max_health,
+                            npc_flags = create_data.npc_flags,
+                            unit_flags = create_data.unit_flags,
+                            unit_flags2 = create_data.unit_flags2,
+                            unit_flags3 = create_data.unit_flags3,
+                            x = creature_pos.x,
+                            y = creature_pos.y,
+                            z = creature_pos.z,
+                            "RUST_CREATURE_VIS create_creature"
+                        );
+                    }
                     update_blocks.push(UpdateObject::create_creature_block_with_spline(
                         create_data,
                         &creature.position(),
@@ -13365,12 +13427,12 @@ impl WorldSession {
 
         // C++ `HandlePlayerLogin` calls `ObjectAccessor::AddObject`, then
         // `Player::SendInitialPacketsAfterAddToMap`; that method starts with
-        // `UpdateVisibilityForPlayer()`. In the captured C++ 3.4.3 login stream
-        // this point does not emit a nearby creature/gameobject CREATE batch.
-        // Rust's broad scanner does, so only mirror the player/seer visibility
-        // flags here and let normal movement/map visibility deliver object
-        // creates from the same later phase as C++.
+        // `UpdateVisibilityForPlayer()`. Rust must force the same rebuild here
+        // because Map::AddPlayerToMap just cleared the client-visible GUID cache;
+        // after logout/relogin at the same position the normal movement-distance
+        // throttle can otherwise leave the client with no visible creatures.
         self.sync_current_player_session_visibility_detection_like_cpp();
+        self.force_update_visibility_like_cpp().await;
         if updateobject_trace_enabled {
             info!(
                 guid = ?guid,
@@ -13605,8 +13667,7 @@ impl WorldSession {
             combat.max_health.max(1).min(u32::MAX as i64) as u32,
         );
         self.login_time = Some(std::time::Instant::now());
-        self.suppress_creature_movement_until_like_cpp =
-            Some(std::time::Instant::now() + std::time::Duration::from_secs(10));
+        self.suppress_creature_movement_queued_at_or_before_like_cpp = None;
         // Clear per-session loot/combat state as part of the Rust AddToWorld
         // equivalent, before C++ would build `Map::SendInitSelf`.
         self.loot_table.clear();
@@ -13733,6 +13794,10 @@ impl WorldSession {
             );
         }
         self.client_visible_guids_like_cpp.clear();
+        // C++ clears m_clientGUIDs here, then Player::SendInitialPacketsAfterAddToMap
+        // starts with UpdateVisibilityForPlayer. Do not let Rust's movement-distance
+        // throttle reuse the previous login/logout position after the clear.
+        self.last_visibility_pos = None;
         if updateobject_trace_enabled {
             info!(
                 guid = ?guid,
@@ -13761,6 +13826,13 @@ impl WorldSession {
             updateobject_trace_enabled,
         )
         .await;
+
+        // C++ does not deliver SMSG_ON_MONSTER_MOVE inside the initial
+        // enter-world packet burst. Rust fan-out commands are queued from a
+        // sessionless world tick, so remember the burst boundary and drop only
+        // movement commands that were queued at or before it.
+        self.suppress_creature_movement_queued_at_or_before_like_cpp =
+            Some(std::time::Instant::now());
 
         // Rust keeps the session status flip after the initial after-add packet
         // subset so the network loop cannot process normal movement/gameplay

--- a/crates/wow-world/src/handlers/loot.rs
+++ b/crates/wow-world/src/handlers/loot.rs
@@ -783,6 +783,7 @@ impl WorldSession {
                 .command_tx
                 .try_send(SessionCommand::SendIfVisibleLikeCpp(
                     SendIfVisibleLikeCppCommand {
+                        queued_at: Instant::now(),
                         source_guid: gameobject_guid,
                         map_id: current_map_id,
                         instance_id: current_instance_id,
@@ -3379,22 +3380,21 @@ impl WorldSession {
             return;
         }
         // Gate 1b: C++ does not deliver SMSG_ON_MONSTER_MOVE during the
-        // initial enter-world packet burst. Rust can repopulate HaveAtClient
-        // before that burst is complete, so keep this movement-only guard
-        // separate from the generic visibility gate below.
+        // initial enter-world packet burst. Rust queues fan-out commands from
+        // a sessionless world tick, so drop only movement commands that were
+        // queued before the login burst completed.
         if is_monster_move {
-            if let Some(until) = self.suppress_creature_movement_until_like_cpp {
-                let now = Instant::now();
-                if now < until {
+            if let Some(cutoff) = self.suppress_creature_movement_queued_at_or_before_like_cpp {
+                if command.queued_at <= cutoff {
                     tracing::info!(
                         account = self.account_id,
                         source_guid = ?command.source_guid,
-                        remaining_ms = until.saturating_duration_since(now).as_millis(),
-                        "RUST_MONSTER_MOVE_DELIVERY rejected: initial enter-world movement gate"
+                        queued_before_cutoff_ms =
+                            cutoff.saturating_duration_since(command.queued_at).as_millis(),
+                        "RUST_MONSTER_MOVE_DELIVERY rejected: queued before enter-world movement cutoff"
                     );
                     return;
                 }
-                self.suppress_creature_movement_until_like_cpp = None;
             }
         }
         // Gate 2: map must match.

--- a/crates/wow-world/src/handlers/misc.rs
+++ b/crates/wow-world/src/handlers/misc.rs
@@ -10,7 +10,8 @@
 use tracing::{debug, info, warn};
 use wow_constants::unit::{NPCFlags1, Team};
 use wow_constants::{
-    ClientOpcodes, InventoryResult, ItemExtendedCostFlags, SpellCastResult, UnitStandStateType,
+    ClientOpcodes, ConditionType, InventoryResult, ItemExtendedCostFlags, SpellCastResult,
+    UnitStandStateType,
 };
 use wow_core::{GameTime, ObjectGuid};
 use wow_database::{
@@ -2395,17 +2396,40 @@ impl crate::session::WorldSession {
     /// CMSG_REQUEST_CEMETERY_LIST — client asks for graveyards in zone.
     /// C++ ref: `WorldSession::HandleRequestCemeteryList`.
     pub async fn handle_request_cemetery_list(&mut self, _pkt: wow_packet::WorldPacket) {
-        let (zone_id, _) = self.player_zone_area_like_cpp();
-        let Some(graveyard_store) = self.graveyard_store().cloned() else {
-            debug!(
+        if std::env::var_os("RUSTYCORE_PACKET_SEQUENCE_TRACE").is_some() {
+            info!(
+                account = self.account_id,
+                state = ?self.state(),
+                "RUST_CEMETERY_TRACE handler entry"
+            );
+        }
+        let (zone_id, area_id) = self.player_zone_area_like_cpp();
+        if std::env::var_os("RUSTYCORE_PACKET_SEQUENCE_TRACE").is_some() {
+            info!(
+                account = self.account_id,
+                state = ?self.state(),
                 zone = zone_id,
+                area = area_id,
+                map_id = self.player_map_id_like_cpp(),
+                player = ?self.player_guid(),
+                "RUST_CEMETERY_TRACE handler resolved zone_area"
+            );
+        }
+        let Some(graveyard_store) = self.graveyard_store().cloned() else {
+            info!(
+                zone = zone_id,
+                area = area_id,
+                map_id = self.player_map_id_like_cpp(),
+                player = ?self.player_guid(),
                 "No graveyard store available for CMSG_REQUEST_CEMETERY_LIST"
             );
             return;
         };
         let Some(graveyards) = graveyard_store.graveyards_for_zone(zone_id) else {
-            debug!(
+            info!(
                 zone = zone_id,
+                area = area_id,
+                map_id = self.player_map_id_like_cpp(),
                 player = ?self.player_guid(),
                 "No graveyards found in CMSG_REQUEST_CEMETERY_LIST"
             );
@@ -2423,14 +2447,27 @@ impl crate::session::WorldSession {
         }
 
         if cemetery_ids.is_empty() {
-            debug!(
+            info!(
                 zone = zone_id,
+                area = area_id,
+                map_id = self.player_map_id_like_cpp(),
+                candidate_count = graveyards.len(),
                 player = ?self.player_guid(),
                 "No graveyards passed conditions in CMSG_REQUEST_CEMETERY_LIST"
             );
             return;
         }
 
+        info!(
+            zone = zone_id,
+            area = area_id,
+            map_id = self.player_map_id_like_cpp(),
+            candidate_count = graveyards.len(),
+            accepted_count = cemetery_ids.len(),
+            cemetery_ids = ?cemetery_ids,
+            player = ?self.player_guid(),
+            "Sending C++ RequestCemeteryListResponse"
+        );
         self.send_packet(&RequestCemeteryListResponse {
             is_gossip_triggered: false,
             cemetery_ids,
@@ -2459,16 +2496,26 @@ impl crate::session::WorldSession {
 
         let player_unit_snapshot = self.condition_player_unit_snapshot_like_cpp();
         let player_snapshot = self.condition_player_snapshot_like_cpp();
-        let player_condition_store = self.player_condition_store().cloned();
-        let player_condition_context = self.represented_player_condition_context_like_cpp();
+        let needs_player_condition_context = conditions.iter().any(|condition| {
+            condition.reference_id != 0
+                || condition.condition_type == ConditionType::PlayerCondition
+        });
+        let player_condition_store = needs_player_condition_context
+            .then(|| self.player_condition_store().cloned())
+            .flatten();
+        let player_condition_context = needs_player_condition_context
+            .then(|| self.represented_player_condition_context_like_cpp());
 
         let mut source_info =
             crate::conditions::ConditionSourceInfo::from_targets(Some(&player_object), None, None);
         source_info.set_unit_target_snapshot(0, player_unit_snapshot);
         source_info.set_player_target_snapshot(0, player_snapshot);
-        if let Some(store) = player_condition_store.as_ref() {
+        if let (Some(store), Some(context)) = (
+            player_condition_store.as_ref(),
+            player_condition_context.as_ref(),
+        ) {
             source_info.set_player_condition_store(store.as_ref());
-            source_info.set_player_condition_context(0, player_condition_context.as_context(self));
+            source_info.set_player_condition_context(0, context.as_context(self));
         }
 
         crate::conditions::is_object_meet_to_conditions_like_cpp(
@@ -2902,6 +2949,7 @@ impl crate::session::WorldSession {
         for command_tx in candidates {
             let _ = command_tx.try_send(wow_network::SessionCommand::SendIfVisibleLikeCpp(
                 wow_network::player_registry::SendIfVisibleLikeCppCommand {
+                    queued_at: std::time::Instant::now(),
                     source_guid,
                     map_id,
                     instance_id,

--- a/crates/wow-world/src/handlers/movement.rs
+++ b/crates/wow-world/src/handlers/movement.rs
@@ -29,6 +29,7 @@ use wow_packet::packets::movement::{
     MovementAckMessage, MovementInfo, MovementSpeedAck, SetActiveMover,
 };
 
+use crate::map_manager::zone_and_area_for_position_like_cpp;
 use crate::session::{
     SPELL_AURA_INTERRUPT_FLAG_LANDING_OR_FLIGHT_LIKE_CPP, SPELL_AURA_INTERRUPT_FLAG2_JUMP_LIKE_CPP,
     WorldSession,
@@ -197,6 +198,19 @@ impl WorldSession {
         } else {
             None
         };
+        let new_player_cell_like_cpp =
+            mover_is_player.then(|| wow_map::cell_from_world(pos.x, pos.y));
+        let old_player_cell_like_cpp = current_mover_position
+            .filter(|_| mover_is_player)
+            .map(|current| wow_map::cell_from_world(current.x, current.y));
+        let load_player_active_grid_like_cpp = match (
+            old_player_cell_like_cpp.as_ref(),
+            new_player_cell_like_cpp.as_ref(),
+        ) {
+            (Some(old_cell), Some(new_cell)) => old_cell.diff_grid(new_cell),
+            (None, Some(_)) => true,
+            _ => false,
+        };
         if let Some(transport) = &info.transport {
             if current_mover_position.is_some_and(|current| {
                 pos.distance_2d(&current) > wow_core::Position::GRID_SIZE_LIKE_CPP
@@ -256,7 +270,108 @@ impl WorldSession {
             let _ = self.mutate_canonical_player_like_cpp(|player| {
                 player.unit_mut().world_mut().relocate(info.position);
             });
-            let (_, area_id) = self.player_zone_area_like_cpp();
+            if load_player_active_grid_like_cpp
+                && let Some(outcome) =
+                    self.ensure_player_grid_loaded_like_cpp(self.player_map_id_like_cpp(), 0, pos)
+            {
+                trace!(
+                    account = self.account_id,
+                    map_id = self.player_map_id_like_cpp(),
+                    old_grid_x = old_player_cell_like_cpp.as_ref().map(|cell| cell.grid_x()),
+                    old_grid_y = old_player_cell_like_cpp.as_ref().map(|cell| cell.grid_y()),
+                    new_grid_x = new_player_cell_like_cpp.as_ref().map(|cell| cell.grid_x()),
+                    new_grid_y = new_player_cell_like_cpp.as_ref().map(|cell| cell.grid_y()),
+                    grid_loaded_now = outcome.grid_loaded_now,
+                    creature_records_added = outcome.creature_records_added,
+                    gameobject_records_added = outcome.gameobject_records_added,
+                    area_trigger_records_added = outcome.area_trigger_records_added,
+                    legacy_creature_mirrors = outcome.legacy_creature_mirrors,
+                    "C++ Map::PlayerRelocation active grid loaded before player visibility"
+                );
+                if (std::env::var_os("RUSTYCORE_PACKET_SEQUENCE_TRACE").is_some()
+                    || std::env::var_os("RUSTYCORE_CREATURE_VIS_TRACE").is_some())
+                    && (outcome.map_created
+                        || outcome.grid_loaded_now
+                        || outcome.metadata_entries != 0
+                        || outcome.skipped_already_loaded != 0
+                        || outcome.skipped_should_not_spawn != 0
+                        || outcome.skipped_difficulty_mismatch != 0
+                        || outcome.stale_index_entries != 0
+                        || outcome.creature_records_added != 0
+                        || outcome.gameobject_records_added != 0
+                        || outcome.area_trigger_records_added != 0
+                        || outcome.pre_add_records_added != 0
+                        || outcome.add_to_map_errors != 0
+                        || outcome.load_record_missing != 0
+                        || outcome.legacy_creature_mirrors != 0)
+                {
+                    info!(
+                        account = self.account_id,
+                        map_id = self.player_map_id_like_cpp(),
+                        instance_id = 0u32,
+                        x = pos.x,
+                        y = pos.y,
+                        z = pos.z,
+                        old_grid_x = old_player_cell_like_cpp.as_ref().map(|cell| cell.grid_x()),
+                        old_grid_y = old_player_cell_like_cpp.as_ref().map(|cell| cell.grid_y()),
+                        new_grid_x = new_player_cell_like_cpp.as_ref().map(|cell| cell.grid_x()),
+                        new_grid_y = new_player_cell_like_cpp.as_ref().map(|cell| cell.grid_y()),
+                        map_created = outcome.map_created,
+                        grid_loaded_now = outcome.grid_loaded_now,
+                        metadata_entries = outcome.metadata_entries,
+                        skipped_already_loaded = outcome.skipped_already_loaded,
+                        skipped_should_not_spawn = outcome.skipped_should_not_spawn,
+                        skipped_difficulty_mismatch = outcome.skipped_difficulty_mismatch,
+                        stale_index_entries = outcome.stale_index_entries,
+                        creature_records_added = outcome.creature_records_added,
+                        gameobject_records_added = outcome.gameobject_records_added,
+                        area_trigger_records_added = outcome.area_trigger_records_added,
+                        pre_add_records_added = outcome.pre_add_records_added,
+                        add_to_map_errors = outcome.add_to_map_errors,
+                        load_record_missing = outcome.load_record_missing,
+                        creature_load_record_missing = outcome.creature_load_record_missing,
+                        gameobject_load_record_missing = outcome.gameobject_load_record_missing,
+                        area_trigger_load_record_missing = outcome.area_trigger_load_record_missing,
+                        legacy_creature_mirrors = outcome.legacy_creature_mirrors,
+                        "RUST_CREATURE_VIS movement_grid_load"
+                    );
+                }
+            }
+            let area_id = match zone_and_area_for_position_like_cpp(
+                &self.mmap_runtime_config_like_cpp().data_dir,
+                u32::from(self.player_map_id_like_cpp()),
+                info.position.x,
+                info.position.y,
+                self.area_table_store().map(|store| store.as_ref()),
+                |map_id| {
+                    self.map_store()
+                        .as_deref()
+                        .map(|store| u32::from(store.area_table_id_like_cpp(map_id)))
+                        .unwrap_or(0)
+                },
+            ) {
+                Ok((zone_id, area_id)) => {
+                    if area_id != 0 {
+                        self.update_zone_represented_like_cpp(zone_id, area_id);
+                        area_id
+                    } else {
+                        let (_, current_area_id) = self.player_zone_area_like_cpp();
+                        current_area_id
+                    }
+                }
+                Err(error) => {
+                    let (_, area_id) = self.player_zone_area_like_cpp();
+                    warn!(
+                        account = self.account_id,
+                        map_id = self.player_map_id_like_cpp(),
+                        x = info.position.x,
+                        y = info.position.y,
+                        %error,
+                        "failed to resolve C++ terrain zone/area after movement; keeping existing zone/area"
+                    );
+                    area_id
+                }
+            };
             self.check_area_explore_and_outdoor_represented_like_cpp(area_id)
                 .await;
             // Keep the broadcast registry in sync so chat range checks are accurate.
@@ -347,6 +462,7 @@ impl WorldSession {
             for command_tx in candidates {
                 let _ = command_tx.try_send(wow_network::SessionCommand::SendIfVisibleLikeCpp(
                     wow_network::player_registry::SendIfVisibleLikeCppCommand {
+                        queued_at: std::time::Instant::now(),
                         source_guid: mover_guid,
                         map_id,
                         instance_id,
@@ -653,10 +769,14 @@ impl WorldSession {
 mod tests {
     use super::*;
     use crate::session::{
-        AuraApplication, MoveSplineDoneTaxiActionLikeCpp, MoveTeleportAckActionLikeCpp,
-        MovementSpeedAckActionLikeCpp, RepresentedAuraEffectLikeCpp,
-        RepresentedTaxiFlightNodeLikeCpp, SessionPlayerController, UnitMoveTypeLikeCpp,
+        AuraApplication, MMapRuntimeConfigLikeCpp, MoveSplineDoneTaxiActionLikeCpp,
+        MoveTeleportAckActionLikeCpp, MovementSpeedAckActionLikeCpp, PlayerGridLoadOutcomeLikeCpp,
+        RepresentedAuraEffectLikeCpp, RepresentedTaxiFlightNodeLikeCpp, SessionPlayerController,
+        UnitMoveTypeLikeCpp,
     };
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex, RwLock};
     use wow_constants::ServerOpcodes;
     use wow_constants::movement::MovementFlag;
@@ -691,6 +811,63 @@ mod tests {
         movement.write(&mut inbound);
         inbound.read_uint16().expect("movement opcode");
         inbound
+    }
+
+    fn unique_temp_data_dir(test_name: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
+            "rustycore-movement-{test_name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(dir.join("maps")).expect("create maps dir");
+        dir
+    }
+
+    fn write_single_area_map_tile_like_cpp(
+        data_dir: &std::path::Path,
+        map_id: u32,
+        x: f32,
+        y: f32,
+        area_id: u16,
+    ) {
+        const MAP_FILE_HEADER_SIZE_LIKE_CPP: usize = 44;
+        const MAP_AREA_HEADER_SIZE_LIKE_CPP: usize = 8;
+        const MAP_AREA_CELLS_PER_GRID_LIKE_CPP: usize = 16;
+
+        let area_offset = MAP_FILE_HEADER_SIZE_LIKE_CPP as u32;
+        let area_size = (MAP_AREA_HEADER_SIZE_LIKE_CPP
+            + MAP_AREA_CELLS_PER_GRID_LIKE_CPP
+                * MAP_AREA_CELLS_PER_GRID_LIKE_CPP
+                * std::mem::size_of::<u16>()) as u32;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"MAPS");
+        bytes.extend_from_slice(&10_u32.to_le_bytes());
+        bytes.extend_from_slice(&0_u32.to_le_bytes());
+        bytes.extend_from_slice(&area_offset.to_le_bytes());
+        bytes.extend_from_slice(&area_size.to_le_bytes());
+        for _ in 0..6 {
+            bytes.extend_from_slice(&0_u32.to_le_bytes());
+        }
+        assert_eq!(bytes.len(), MAP_FILE_HEADER_SIZE_LIKE_CPP);
+        bytes.extend_from_slice(b"AREA");
+        bytes.extend_from_slice(&0_u16.to_le_bytes());
+        bytes.extend_from_slice(&area_id.to_le_bytes());
+        for _ in 0..(MAP_AREA_CELLS_PER_GRID_LIKE_CPP * MAP_AREA_CELLS_PER_GRID_LIKE_CPP) {
+            bytes.extend_from_slice(&area_id.to_le_bytes());
+        }
+
+        let (gx, gy) = crate::map_manager::terrain_grid_coords_for_wow_position_like_cpp(x, y);
+        fs::write(
+            data_dir
+                .join("maps")
+                .join(format!("{map_id:04}_{gx:02}_{gy:02}.map")),
+            bytes,
+        )
+        .expect("write movement area map");
     }
 
     fn drain_server_opcodes(send_rx: &flume::Receiver<Vec<u8>>) -> Vec<ServerOpcodes> {
@@ -817,6 +994,77 @@ mod tests {
         assert_eq!(jump.xy_speed, 7.5);
     }
 
+    #[tokio::test]
+    async fn player_movement_loads_active_grid_before_visibility_like_cpp() {
+        let mut session = make_session();
+        let guid = ObjectGuid::create_player(1, 45);
+        let login_position = Position::new(1.0, 2.0, 3.0, 0.25);
+        let same_grid_position = Position::new(10.0, 20.0, 30.0, 1.0);
+        let new_grid_position = Position::new(600.0, 20.0, 30.0, 1.0);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+
+        session.attach_player_controller_like_cpp(SessionPlayerController::new(
+            guid,
+            "MovementGridLoader".to_string(),
+            login_position,
+            1,
+            1,
+            3,
+            10,
+            0,
+        ));
+        session.set_player_moved_unit_guid_like_cpp(guid);
+        let calls_for_resolver = Arc::clone(&calls);
+        let seen_for_resolver = Arc::clone(&seen);
+        session.set_player_grid_load_resolver_like_cpp(Arc::new(
+            move |map_id, instance_id, pos| {
+                calls_for_resolver.fetch_add(1, Ordering::SeqCst);
+                seen_for_resolver
+                    .lock()
+                    .unwrap()
+                    .push((map_id, instance_id, pos));
+                PlayerGridLoadOutcomeLikeCpp {
+                    grid_loaded_now: true,
+                    creature_records_added: 7,
+                    legacy_creature_mirrors: 7,
+                    ..PlayerGridLoadOutcomeLikeCpp::default()
+                }
+            },
+        ));
+
+        let same_grid = MovementInfo {
+            guid,
+            flags: MovementFlag::FORWARD,
+            position: same_grid_position,
+            ..MovementInfo::default()
+        };
+        session
+            .handle_movement_info_like_cpp(Some(ClientOpcodes::MoveHeartbeat), same_grid)
+            .await;
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "C++ Map::PlayerRelocation does not EnsureGridLoadedForActiveObject when the player stays in the same grid"
+        );
+
+        let new_grid = MovementInfo {
+            guid,
+            flags: MovementFlag::FORWARD,
+            position: new_grid_position,
+            ..MovementInfo::default()
+        };
+        session
+            .handle_movement_info_like_cpp(Some(ClientOpcodes::MoveHeartbeat), new_grid)
+            .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            seen.lock().unwrap().as_slice(),
+            &[(1, 0, new_grid_position)]
+        );
+    }
+
     #[test]
     fn movement_fall_land_applies_cpp_base_fall_damage_and_updates_fall_info() {
         let (mut session, send_rx) = make_session_with_send_rx();
@@ -840,12 +1088,45 @@ mod tests {
         let sent = send_rx.try_recv().expect("fall environmental damage log");
         let opcode = u16::from_le_bytes([sent[0], sent[1]]);
         assert_eq!(opcode, ServerOpcodes::EnvironmentalDamageLog as u16);
+        assert!(
+            send_rx.try_recv().is_err(),
+            "non-lethal fall damage must not send a death values update"
+        );
 
         let mut harmless = MovementInfo::default();
         harmless.position.z = 99.0;
         harmless.jump.fall_time = 1_600;
         session.apply_movement_side_effects_like_cpp(Some(ClientOpcodes::MoveFallLand), &harmless);
         assert_eq!(session.fall_damage_events_like_cpp().len(), 1);
+    }
+
+    #[test]
+    fn movement_fall_land_lethal_damage_sends_player_values_update_like_cpp() {
+        let (mut session, send_rx) = make_session_with_send_rx();
+        session.set_player_guid(Some(ObjectGuid::create_player(1, 43)));
+        session.set_player_health_like_cpp(1_000, 1_000);
+        session.set_fall_information_like_cpp(1_200, 300.0);
+        let mut info = MovementInfo::default();
+        info.position.z = 100.0;
+        info.jump.fall_time = 1_500;
+
+        session.apply_movement_side_effects_like_cpp(Some(ClientOpcodes::MoveFallLand), &info);
+
+        let events = session.fall_damage_events_like_cpp();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].damage, 1_000);
+        assert_eq!(events[0].final_damage, 1_000);
+        assert_eq!(session.player_health_like_cpp(), 0);
+        assert!(!session.player_is_alive_like_cpp());
+        assert_eq!(
+            drain_server_opcodes(&send_rx),
+            vec![
+                ServerOpcodes::HealthUpdate,
+                ServerOpcodes::EnvironmentalDamageLog,
+                ServerOpcodes::UpdateObject,
+            ],
+            "C++ lethal EnvironmentalDamage goes through Unit::Kill/Player::setDeathState before release/cemetery flows; Rust must publish the zero-health values update, not only the combat log"
+        );
     }
 
     #[test]
@@ -942,6 +1223,9 @@ mod tests {
         let sent = send_rx.try_recv().expect("void environmental damage log");
         let opcode = u16::from_le_bytes([sent[0], sent[1]]);
         assert_eq!(opcode, ServerOpcodes::EnvironmentalDamageLog as u16);
+        let sent = send_rx.try_recv().expect("void death values update");
+        let opcode = u16::from_le_bytes([sent[0], sent[1]]);
+        assert_eq!(opcode, ServerOpcodes::UpdateObject as u16);
 
         info.position.z = -499.0;
         session.apply_movement_side_effects_like_cpp(Some(ClientOpcodes::MoveHeartbeat), &info);
@@ -1939,6 +2223,91 @@ mod tests {
             "C++ discovery criteria only fires when the explored-zone bit changes"
         );
         assert!(!drain_server_opcodes(&send_rx).contains(&ServerOpcodes::UpdateObject));
+    }
+
+    #[tokio::test]
+    async fn handle_movement_resolves_zone_area_for_cemetery_flow_like_cpp() {
+        let (mut session, _send_rx) = make_session_with_send_rx();
+        let canonical = Arc::new(Mutex::new(wow_map::MapManager::default()));
+        let guid = ObjectGuid::create_player(1, 1095);
+        let map_id = 1_u32;
+        let login_position = Position::new(1.0, 2.0, 3.0, 0.25);
+        let moved_position = Position::new(1922.0, -4345.0, 25.0, 1.0);
+        let data_dir = unique_temp_data_dir("zone-area-cemetery");
+        write_single_area_map_tile_like_cpp(
+            &data_dir,
+            map_id,
+            moved_position.x,
+            moved_position.y,
+            5170,
+        );
+
+        canonical.lock().unwrap().create_world_map(map_id, 0);
+        session.set_mmap_runtime_config_like_cpp(MMapRuntimeConfigLikeCpp {
+            data_dir: data_dir.to_string_lossy().into_owned(),
+            ..MMapRuntimeConfigLikeCpp::default()
+        });
+        session.set_canonical_map_manager(Arc::clone(&canonical));
+        session.set_map_store(Arc::new(wow_data::MapStore::from_entries([
+            wow_data::MapEntry {
+                id: map_id,
+                instance_type: wow_data::map::MAP_COMMON,
+                expansion_id: 0,
+                parent_map_id: -1,
+                cosmetic_parent_map_id: -1,
+                flags1: 0,
+                flags2: 0,
+            },
+        ])));
+        session.set_area_table_store(Arc::new(wow_data::AreaTableStore::from_entries([
+            wow_data::AreaTableEntry {
+                id: 1637,
+                continent_id: map_id as u16,
+                parent_area_id: 0,
+                area_bit: -1,
+                exploration_level: 0,
+                mount_flags: 0,
+                flags: 0,
+            },
+            wow_data::AreaTableEntry {
+                id: 5170,
+                continent_id: map_id as u16,
+                parent_area_id: 1637,
+                area_bit: -1,
+                exploration_level: 0,
+                mount_flags: 0,
+                flags: 0x4000_0000,
+            },
+        ])));
+        session.attach_player_controller_like_cpp(SessionPlayerController::new(
+            guid,
+            "MovementZone".to_string(),
+            login_position,
+            map_id as u16,
+            10,
+            5,
+            80,
+            0,
+        ));
+        session.set_player_moved_unit_guid_like_cpp(guid);
+        session.set_player_zone_area_like_cpp(1, 1);
+        let _ = session.ensure_canonical_world_map_for_current_player_like_cpp();
+
+        let movement = MovementInfo {
+            guid,
+            flags: MovementFlag::FORWARD,
+            position: moved_position,
+            ..MovementInfo::default()
+        };
+        session
+            .handle_movement(movement_packet(ClientOpcodes::MoveHeartbeat, &movement))
+            .await;
+
+        assert_eq!(
+            session.player_zone_area_like_cpp(),
+            (1637, 5170),
+            "C++ Player::Update uses terrain GetZoneAndAreaId, so cemetery requests after movement must use the Orgrimmar zone, not stale DB zone"
+        );
     }
 
     #[tokio::test]

--- a/crates/wow-world/src/handlers/quest.rs
+++ b/crates/wow-world/src/handlers/quest.rs
@@ -10444,13 +10444,37 @@ mod tests {
             u16::from_le_bytes([bytes[0], bytes[1]]),
             wow_constants::ServerOpcodes::QuestPushResult as u16
         );
+        let result = read_push_quest_result_response_bytes(&bytes);
+        assert!(send_rx.try_recv().is_err());
+        result
+    }
+
+    fn recv_push_quest_result_response_after_death_sync(
+        send_rx: &flume::Receiver<Vec<u8>>,
+    ) -> (ObjectGuid, u8, String) {
+        loop {
+            let bytes = send_rx
+                .try_recv()
+                .expect("quest push result response packet after death sync");
+            let opcode = u16::from_le_bytes([bytes[0], bytes[1]]);
+            if opcode == wow_constants::ServerOpcodes::QuestPushResult as u16 {
+                return read_push_quest_result_response_bytes(&bytes);
+            }
+            assert_eq!(
+                opcode,
+                wow_constants::ServerOpcodes::UpdateObject as u16,
+                "only UpdateObject death-state sync may precede QuestPushResult"
+            );
+        }
+    }
+
+    fn read_push_quest_result_response_bytes(bytes: &[u8]) -> (ObjectGuid, u8, String) {
         let mut pkt = WorldPacket::from_bytes(&bytes[2..]);
         let sender_guid = pkt.read_packed_guid().unwrap();
         let result = pkt.read_uint8().unwrap();
         let title_len = pkt.read_bits(9).unwrap() as usize;
         let quest_title = pkt.read_string(title_len).unwrap();
         assert_eq!(pkt.remaining(), 0);
-        assert!(send_rx.try_recv().is_err());
         (sender_guid, result, quest_title)
     }
 
@@ -15097,7 +15121,7 @@ mod tests {
             )
         );
         assert_eq!(
-            recv_push_quest_result_response(&receiver_rx),
+            recv_push_quest_result_response_after_death_sync(&receiver_rx),
             (
                 sender_guid,
                 QUEST_PUSH_REASON_DEAD_TO_RECIPIENT_LIKE_CPP,

--- a/crates/wow-world/src/map_manager.rs
+++ b/crates/wow-world/src/map_manager.rs
@@ -758,17 +758,37 @@ pub fn path_generator_from_detour_like_cpp(
     detour_path: &DetourPolyPath,
     force_destination: bool,
 ) -> PathGenerator {
+    path_generator_from_detour_with_normalizer_like_cpp(
+        start,
+        destination,
+        detour_path,
+        force_destination,
+        |point| point,
+    )
+}
+
+pub fn path_generator_from_detour_with_normalizer_like_cpp(
+    start: Position,
+    destination: Position,
+    detour_path: &DetourPolyPath,
+    force_destination: bool,
+    mut normalize_position: impl FnMut(Position) -> Position,
+) -> PathGenerator {
     let mut path = PathGenerator::new();
+    let actual_end = normalize_position(position_from_detour_point_like_cpp(
+        detour_path.point_path.actual_end,
+    ));
     path.apply_detour_path_like_cpp(
         start,
         destination,
-        position_from_detour_point_like_cpp(detour_path.point_path.actual_end),
+        actual_end,
         detour_path
             .point_path
             .points
             .iter()
             .copied()
-            .map(position_from_detour_point_like_cpp),
+            .map(position_from_detour_point_like_cpp)
+            .map(normalize_position),
         &detour_path.poly_refs,
         path_type_from_detour_like_cpp(detour_path.point_path.path_type),
         force_destination,
@@ -1684,10 +1704,78 @@ impl WorldCreature {
         true
     }
 
+    fn allowed_position_z_caps_like_cpp(&self) -> AllowedPositionZCaps {
+        let hover_offset = if self
+            .creature
+            .movement_flags_like_cpp()
+            .contains(MovementFlag::HOVER)
+        {
+            self.creature.unit().data().hover_height
+        } else {
+            0.0
+        };
+        AllowedPositionZCaps {
+            on_transport: false,
+            can_fly: self.creature.can_fly_like_cpp(),
+            can_swim: self.creature.can_swim_like_cpp(),
+            hover_offset,
+        }
+    }
+
+    fn normalize_path_position_z_like_cpp(
+        &self,
+        point: Position,
+        terrain: Option<&LiveTerrainHeights>,
+    ) -> Position {
+        let Some(terrain) = terrain else {
+            return point;
+        };
+        let probe_z = point.z + Z_OFFSET_FIND_HEIGHT;
+        let ground = terrain.static_height_like_cpp(self.map_id(), point.x, point.y, probe_z);
+        let z = allowed_position_z_from_ground_like_cpp(
+            true,
+            ground,
+            point.z,
+            self.allowed_position_z_caps_like_cpp(),
+        );
+        Position::new(point.x, point.y, z, point.orientation)
+    }
+
+    fn path_generator_from_detour_for_creature_like_cpp(
+        &self,
+        destination: Position,
+        detour_path: &DetourPolyPath,
+        force_destination: bool,
+        terrain: Option<&LiveTerrainHeights>,
+    ) -> PathGenerator {
+        path_generator_from_detour_with_normalizer_like_cpp(
+            self.position(),
+            destination,
+            detour_path,
+            force_destination,
+            |point| self.normalize_path_position_z_like_cpp(point, terrain),
+        )
+    }
+
     pub fn update_default_random_movement_with_path_resolver_like_cpp(
         &mut self,
         diff_ms: u32,
         should_try_pathfinding: bool,
+        resolve_path: impl FnMut(Position, Position, usize) -> Option<DetourPolyPath>,
+    ) -> Option<(Position, MoveSpline)> {
+        self.update_default_random_movement_with_path_resolver_and_terrain_like_cpp(
+            diff_ms,
+            should_try_pathfinding,
+            None,
+            resolve_path,
+        )
+    }
+
+    pub fn update_default_random_movement_with_path_resolver_and_terrain_like_cpp(
+        &mut self,
+        diff_ms: u32,
+        should_try_pathfinding: bool,
+        terrain: Option<&LiveTerrainHeights>,
         mut resolve_path: impl FnMut(Position, Position, usize) -> Option<DetourPolyPath>,
     ) -> Option<(Position, MoveSpline)> {
         if self.active_random_generator.is_none() {
@@ -1742,6 +1830,8 @@ impl WorldCreature {
                 if let Some(path) = detour_path.as_ref() {
                     let path_type = path_type_from_detour_like_cpp(path.point_path.path_type);
                     path_result = random_path_result_from_path_type_like_cpp(path_type);
+                } else {
+                    path_result = RandomPathResult::Failed;
                 }
             }
         }
@@ -1759,7 +1849,12 @@ impl WorldCreature {
             Some(generator) => generator.update_like_cpp(true, diff_ms, snapshot),
             None => return None,
         };
-        self.apply_random_movement_action_like_cpp(action, detour_path.as_ref(), 0)
+        self.apply_random_movement_action_with_terrain_like_cpp(
+            action,
+            detour_path.as_ref(),
+            0,
+            terrain,
+        )
     }
 
     pub fn update_default_waypoint_movement_like_cpp(
@@ -1768,6 +1863,36 @@ impl WorldCreature {
     ) -> WaypointMovementAction {
         self.update_default_waypoint_movement_with_launch_like_cpp(diff_ms)
             .0
+    }
+
+    pub fn update_default_waypoint_movement_with_path_resolver_like_cpp(
+        &mut self,
+        diff_ms: u32,
+        should_try_pathfinding: bool,
+        resolve_path: impl FnMut(Position, Position, usize) -> Option<DetourPolyPath>,
+    ) -> (WaypointMovementAction, Option<(Position, MoveSpline)>) {
+        self.update_default_waypoint_movement_with_path_resolver_and_terrain_like_cpp(
+            diff_ms,
+            should_try_pathfinding,
+            None,
+            resolve_path,
+        )
+    }
+
+    pub fn update_default_waypoint_movement_with_path_resolver_and_terrain_like_cpp(
+        &mut self,
+        diff_ms: u32,
+        should_try_pathfinding: bool,
+        terrain: Option<&LiveTerrainHeights>,
+        resolve_path: impl FnMut(Position, Position, usize) -> Option<DetourPolyPath>,
+    ) -> (WaypointMovementAction, Option<(Position, MoveSpline)>) {
+        self.update_default_waypoint_movement_with_wait_roll_path_resolver_and_launch_like_cpp(
+            diff_ms,
+            None,
+            should_try_pathfinding,
+            terrain,
+            resolve_path,
+        )
     }
 
     fn random_unit_snapshot_like_cpp(
@@ -1818,11 +1943,12 @@ impl WorldCreature {
         }
     }
 
-    fn apply_random_movement_action_like_cpp(
+    fn apply_random_movement_action_with_terrain_like_cpp(
         &mut self,
         action: RandomMovementAction,
         detour_path: Option<&DetourPolyPath>,
         planned_travel_time_ms: i32,
+        terrain: Option<&LiveTerrainHeights>,
     ) -> Option<(Position, MoveSpline)> {
         match action {
             RandomMovementAction::StopMoving => {
@@ -1839,10 +1965,11 @@ impl WorldCreature {
                     .unit_mut()
                     .add_unit_state(UnitState::ROAMING_MOVE.bits());
                 let movement = self
-                    .begin_random_move_spline_with_detour_path_like_cpp(
+                    .begin_random_move_spline_with_detour_path_and_terrain_like_cpp(
                         launch.destination,
                         detour_path,
                         false,
+                        terrain,
                     )
                     .map(|(from, spline, _path)| (from, spline))?;
                 self.creature
@@ -1872,7 +1999,13 @@ impl WorldCreature {
         &mut self,
         diff_ms: u32,
     ) -> (WaypointMovementAction, Option<(Position, MoveSpline)>) {
-        self.update_default_waypoint_movement_with_wait_roll_and_launch_like_cpp(diff_ms, None)
+        self.update_default_waypoint_movement_with_wait_roll_path_resolver_and_launch_like_cpp(
+            diff_ms,
+            None,
+            false,
+            None,
+            |_, _, _| None,
+        )
     }
 
     pub fn update_default_waypoint_movement_with_wait_roll_like_cpp(
@@ -1880,17 +2013,23 @@ impl WorldCreature {
         diff_ms: u32,
         wait_time_roll_ms: Option<i32>,
     ) -> WaypointMovementAction {
-        self.update_default_waypoint_movement_with_wait_roll_and_launch_like_cpp(
+        self.update_default_waypoint_movement_with_wait_roll_path_resolver_and_launch_like_cpp(
             diff_ms,
             wait_time_roll_ms,
+            false,
+            None,
+            |_, _, _| None,
         )
         .0
     }
 
-    fn update_default_waypoint_movement_with_wait_roll_and_launch_like_cpp(
+    fn update_default_waypoint_movement_with_wait_roll_path_resolver_and_launch_like_cpp(
         &mut self,
         diff_ms: u32,
         wait_time_roll_ms: Option<i32>,
+        should_try_pathfinding: bool,
+        terrain: Option<&LiveTerrainHeights>,
+        mut resolve_path: impl FnMut(Position, Position, usize) -> Option<DetourPolyPath>,
     ) -> (WaypointMovementAction, Option<(Position, MoveSpline)>) {
         if let Some(mut random) = self.active_waypoint_random_at_path_end {
             let _ = self.update_move_spline_like_cpp();
@@ -1903,12 +2042,22 @@ impl WorldCreature {
             return (WaypointMovementAction::Continue, None);
         }
 
+        // C++ `Unit::Update` advances `UpdateSplineMovement` before
+        // `MotionMaster::Update`, so waypoint generators observe an arrived
+        // `movespline` in the same tick and can launch the next segment.
+        let _ = self.update_move_spline_like_cpp();
+
         let snapshot = self.waypoint_unit_snapshot_like_cpp();
         let Some(generator) = self.active_waypoint_generator.as_mut() else {
             return (WaypointMovementAction::Continue, None);
         };
         let action = generator.update_like_cpp(true, diff_ms, snapshot, wait_time_roll_ms);
-        let launch_result = self.apply_waypoint_movement_action_like_cpp(action);
+        let launch_result = self.apply_waypoint_movement_action_with_path_resolver_like_cpp(
+            action,
+            should_try_pathfinding,
+            terrain,
+            &mut resolve_path,
+        );
         if matches!(
             action,
             WaypointMovementAction::Arrived(arrived)
@@ -1918,7 +2067,13 @@ impl WorldCreature {
             if let Some(generator) = self.active_waypoint_generator.as_mut() {
                 let chained = generator.update_like_cpp(true, 0, snapshot, None);
                 if chained != WaypointMovementAction::Continue {
-                    let chained_launch = self.apply_waypoint_movement_action_like_cpp(chained);
+                    let chained_launch = self
+                        .apply_waypoint_movement_action_with_path_resolver_like_cpp(
+                            chained,
+                            should_try_pathfinding,
+                            terrain,
+                            &mut resolve_path,
+                        );
                     return (chained, chained_launch);
                 }
             }
@@ -1926,9 +2081,12 @@ impl WorldCreature {
         (action, launch_result)
     }
 
-    fn apply_waypoint_movement_action_like_cpp(
+    fn apply_waypoint_movement_action_with_path_resolver_like_cpp(
         &mut self,
         action: WaypointMovementAction,
+        should_try_pathfinding: bool,
+        terrain: Option<&LiveTerrainHeights>,
+        resolve_path: &mut impl FnMut(Position, Position, usize) -> Option<DetourPolyPath>,
     ) -> Option<(Position, MoveSpline)> {
         match action {
             WaypointMovementAction::StopMoving => {
@@ -1972,7 +2130,22 @@ impl WorldCreature {
                 let _ = ended;
                 None
             }
-            WaypointMovementAction::Launch(launch) => self.begin_waypoint_launch_like_cpp(launch),
+            WaypointMovementAction::Launch(launch) => {
+                let detour_path = (launch.generate_path && should_try_pathfinding)
+                    .then(|| {
+                        resolve_path(
+                            self.position(),
+                            launch.destination,
+                            MAX_POINT_PATH_LENGTH_LIKE_CPP,
+                        )
+                    })
+                    .flatten();
+                self.begin_waypoint_launch_with_detour_path_like_cpp(
+                    launch,
+                    detour_path.as_ref(),
+                    terrain,
+                )
+            }
             _ => None,
         }
     }
@@ -1993,16 +2166,32 @@ impl WorldCreature {
         }
     }
 
-    fn begin_waypoint_launch_like_cpp(
+    fn begin_waypoint_launch_with_detour_path_like_cpp(
         &mut self,
         launch: WaypointLaunchPlan,
+        detour_path: Option<&DetourPolyPath>,
+        terrain: Option<&LiveTerrainHeights>,
     ) -> Option<(Position, MoveSpline)> {
         let spline_id = self.spline_id().saturating_add(1);
         let mut init = MoveSplineInit::new(spline_id);
         if launch.disable_transport_transform {
             init.disable_transport_path_transformations();
         }
-        init.move_to(launch.destination);
+        let path = detour_path
+            .map(|detour_path| {
+                self.path_generator_from_detour_for_creature_like_cpp(
+                    launch.destination,
+                    detour_path,
+                    false,
+                    terrain,
+                )
+            })
+            .filter(|path| !path.path_type().contains(PathType::NOPATH));
+        if let Some(path) = path {
+            init.move_by_path(path.path_points().to_vec(), 0);
+        } else {
+            init.move_to(launch.destination);
+        }
         if let Some(facing) = launch.facing {
             init.set_facing_angle(facing);
         }
@@ -2039,17 +2228,32 @@ impl WorldCreature {
         detour_path: Option<&DetourPolyPath>,
         force_destination: bool,
     ) -> Option<(Position, MoveSpline, Option<PathGenerator>)> {
+        self.begin_move_spline_with_detour_path_and_terrain_like_cpp(
+            dst,
+            detour_path,
+            force_destination,
+            None,
+        )
+    }
+
+    pub fn begin_move_spline_with_detour_path_and_terrain_like_cpp(
+        &mut self,
+        dst: Position,
+        detour_path: Option<&DetourPolyPath>,
+        force_destination: bool,
+        terrain: Option<&LiveTerrainHeights>,
+    ) -> Option<(Position, MoveSpline, Option<PathGenerator>)> {
         let Some(detour_path) = detour_path else {
             return self
                 .begin_move_spline_like_cpp(dst)
                 .map(|(from, spline)| (from, spline, None));
         };
 
-        let path = path_generator_from_detour_like_cpp(
-            self.position(),
+        let path = self.path_generator_from_detour_for_creature_like_cpp(
             dst,
             detour_path,
             force_destination,
+            terrain,
         );
         if path.path_type().contains(PathType::NOPATH) {
             return self
@@ -2068,17 +2272,32 @@ impl WorldCreature {
         detour_path: Option<&DetourPolyPath>,
         force_destination: bool,
     ) -> Option<(Position, MoveSpline, Option<PathGenerator>)> {
+        self.begin_random_move_spline_with_detour_path_and_terrain_like_cpp(
+            dst,
+            detour_path,
+            force_destination,
+            None,
+        )
+    }
+
+    pub fn begin_random_move_spline_with_detour_path_and_terrain_like_cpp(
+        &mut self,
+        dst: Position,
+        detour_path: Option<&DetourPolyPath>,
+        force_destination: bool,
+        terrain: Option<&LiveTerrainHeights>,
+    ) -> Option<(Position, MoveSpline, Option<PathGenerator>)> {
         let Some(detour_path) = detour_path else {
             return self
                 .begin_random_move_spline_like_cpp(dst)
                 .map(|(from, spline)| (from, spline, None));
         };
 
-        let path = path_generator_from_detour_like_cpp(
-            self.position(),
+        let path = self.path_generator_from_detour_for_creature_like_cpp(
             dst,
             detour_path,
             force_destination,
+            terrain,
         );
         if path
             .path_type()
@@ -3638,9 +3857,11 @@ impl MapManager {
                             continue;
                         }
 
-                        // Optional: Check actual distance for precise visibility
-                        let dist =
-                            Position::distance(&Position::new(x, y, z, 0.0), &creature.position());
+                        // C++ `CanSeeOrDetect(..., distanceCheck=true)` uses
+                        // `IsWithinDist(..., is3D=false)` for visibility
+                        // (`Object.cpp:1609`). Keep the legacy map path aligned
+                        // with the canonical map visibility path.
+                        let dist = Position::new(x, y, z, 0.0).distance_2d(&creature.position());
                         if dist <= visibility_range {
                             creatures.push(creature.clone());
                         }
@@ -5010,6 +5231,12 @@ mod tests {
             0,
             0,
         );
+        creature
+            .creature
+            .unit_mut()
+            .world_mut()
+            .set_map(0, 0)
+            .expect("bind test creature to map");
         creature.clock_started_at = Instant::now() - Duration::from_secs(10);
         let dst = Position::new(15.0, 10.0, 0.0, 0.0);
 
@@ -5308,6 +5535,128 @@ mod tests {
     }
 
     #[test]
+    fn world_creature_waypoint_generate_path_uses_detour_point_path_like_cpp() {
+        let guid = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 0, 0, 1, 54348);
+        let mut creature = WorldCreature::new(
+            guid,
+            1,
+            Position::new(10.0, 10.0, 0.0, 0.0),
+            50,
+            2,
+            5,
+            10,
+            20.0,
+            100,
+            14,
+            0,
+            0,
+        );
+        let destination = Position::new(30.0, 10.0, 0.0, 0.0);
+        let path = WaypointPath::new(
+            77,
+            vec![wow_movement::WaypointNode::new(10, 30.0, 10.0, 0.0)],
+        );
+        assert_eq!(
+            creature.initialize_default_waypoint_movement_like_cpp(Some(path)),
+            WaypointMovementAction::StopMoving
+        );
+        let mut resolver_calls = 0;
+
+        let (action, launched) = creature
+            .update_default_waypoint_movement_with_path_resolver_like_cpp(
+                wow_movement::WAYPOINT_INITIAL_DELAY_MS_LIKE_CPP as u32,
+                true,
+                |start, destination_arg, point_path_limit| {
+                    resolver_calls += 1;
+                    assert_eq!(start, Position::new(10.0, 10.0, 0.0, 0.0));
+                    assert_eq!(destination_arg, destination);
+                    assert_eq!(point_path_limit, MAX_POINT_PATH_LENGTH_LIKE_CPP);
+                    Some(DetourPolyPath {
+                        poly_refs: vec![11, 22, 33],
+                        point_path: wow_recastdetour::DetourPointPath {
+                            points: vec![[10.0, 10.0, 0.0], [20.0, 15.0, 2.0], [30.0, 10.0, 0.0]],
+                            actual_end: [30.0, 10.0, 0.0],
+                            path_type: DetourPathType::NORMAL,
+                        },
+                        start_far_from_poly: false,
+                        end_far_from_poly: false,
+                    })
+                },
+            );
+
+        assert!(matches!(action, WaypointMovementAction::Launch(_)));
+        assert_eq!(resolver_calls, 1);
+        let (_from, spline) = launched.expect("waypoint detour path launches");
+        assert_eq!(spline.final_destination(), Some(destination));
+        assert!(
+            spline
+                .create_object_path_points_like_cpp()
+                .contains(&Position::new(20.0, 15.0, 2.0, 0.0)),
+            "C++ MoveSplineInit::MoveTo(generatePath=true) switches to MovebyPath(PathGenerator::GetPath())"
+        );
+        assert!(
+            !spline.monster_move_path_data().packed_deltas.is_empty(),
+            "a generated multi-point waypoint path must not serialize as a single direct segment"
+        );
+    }
+
+    #[test]
+    fn world_creature_waypoint_generate_path_nopath_falls_back_direct_like_cpp() {
+        let guid = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 0, 0, 1, 54349);
+        let mut creature = WorldCreature::new(
+            guid,
+            1,
+            Position::new(10.0, 10.0, 0.0, 0.0),
+            50,
+            2,
+            5,
+            10,
+            20.0,
+            100,
+            14,
+            0,
+            0,
+        );
+        let destination = Position::new(30.0, 10.0, 0.0, 0.0);
+        let path = WaypointPath::new(
+            77,
+            vec![wow_movement::WaypointNode::new(10, 30.0, 10.0, 0.0)],
+        );
+        assert_eq!(
+            creature.initialize_default_waypoint_movement_like_cpp(Some(path)),
+            WaypointMovementAction::StopMoving
+        );
+        let mut resolver_calls = 0;
+
+        let (_action, launched) = creature
+            .update_default_waypoint_movement_with_path_resolver_like_cpp(
+                wow_movement::WAYPOINT_INITIAL_DELAY_MS_LIKE_CPP as u32,
+                true,
+                |_start, _destination_arg, _point_path_limit| {
+                    resolver_calls += 1;
+                    Some(DetourPolyPath {
+                        poly_refs: Vec::new(),
+                        point_path: wow_recastdetour::DetourPointPath {
+                            points: vec![[10.0, 10.0, 0.0], [20.0, 15.0, 2.0], [30.0, 10.0, 0.0]],
+                            actual_end: [30.0, 10.0, 0.0],
+                            path_type: DetourPathType::NOPATH,
+                        },
+                        start_far_from_poly: false,
+                        end_far_from_poly: false,
+                    })
+                },
+            );
+
+        assert_eq!(resolver_calls, 1);
+        let (_from, spline) = launched.expect("waypoint direct fallback launches");
+        assert_eq!(spline.final_destination(), Some(destination));
+        assert!(
+            spline.monster_move_path_data().packed_deltas.is_empty(),
+            "C++ MoveSplineInit::MoveTo(generatePath=true) falls back to a direct path when PathGenerator reports NOPATH"
+        );
+    }
+
+    #[test]
     fn world_creature_waypoint_launch_applies_land_takeoff_anim_tier_like_cpp() {
         for (move_type, expected_anim_tier) in [
             (wow_movement::WaypointMoveType::Land, 0),
@@ -5506,6 +5855,75 @@ mod tests {
         assert_eq!(
             creature.move_target(),
             Some(Position::new(12.0, 10.0, 0.0, 0.0))
+        );
+    }
+
+    #[test]
+    fn world_creature_waypoint_tick_advances_spline_before_motionmaster_like_cpp() {
+        let guid = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 0, 0, 1, 54338);
+        let mut creature = WorldCreature::new(
+            guid,
+            1,
+            Position::new(10.0, 10.0, 0.0, 0.0),
+            50,
+            2,
+            5,
+            10,
+            20.0,
+            100,
+            14,
+            0,
+            0,
+        );
+        let path = WaypointPath::new(
+            92,
+            vec![
+                wow_movement::WaypointNode::new(10, 11.0, 10.0, 0.0),
+                wow_movement::WaypointNode::new(20, 12.0, 10.0, 0.0),
+            ],
+        );
+        assert_eq!(
+            creature.initialize_default_waypoint_movement_like_cpp(Some(path)),
+            WaypointMovementAction::StopMoving
+        );
+        assert!(matches!(
+            creature.update_default_waypoint_movement_like_cpp(
+                wow_movement::WAYPOINT_INITIAL_DELAY_MS_LIKE_CPP as u32
+            ),
+            WaypointMovementAction::Launch(_)
+        ));
+        creature
+            .active_move_spline
+            .as_mut()
+            .expect("initial waypoint spline")
+            .finalize();
+        assert!(
+            !creature
+                .creature
+                .unit()
+                .subsystems()
+                .motion
+                .spline
+                .finalized,
+            "the represented MotionSubsystem is stale until Unit::UpdateSplineMovement runs"
+        );
+
+        let action = creature.update_default_waypoint_movement_like_cpp(0);
+
+        match action {
+            WaypointMovementAction::Launch(launch) => {
+                assert_eq!(launch.node_id, 20);
+                assert_eq!(launch.path_id, 92);
+                assert_eq!(launch.destination, Position::new(12.0, 10.0, 0.0, 0.0));
+            }
+            other => panic!("expected next waypoint launch after spline advance, got {other:?}"),
+        }
+        assert_eq!(
+            creature.creature.ai_ownership().last_movement_inform,
+            Some(wow_entities::CreatureMovementInform {
+                movement_type: MovementGeneratorKind::Waypoint.trinity_id(),
+                movement_id: 10,
+            })
         );
     }
 
@@ -5741,6 +6159,75 @@ mod tests {
     }
 
     #[test]
+    fn world_creature_detour_path_bridge_normalizes_points_to_terrain_like_cpp() {
+        let guid = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 0, 0, 1, 54350);
+        let mut creature = WorldCreature::new(
+            guid,
+            1,
+            Position::new(10.0, 10.0, 1.75, 0.0),
+            50,
+            2,
+            5,
+            10,
+            20.0,
+            100,
+            14,
+            0,
+            0,
+        );
+        creature
+            .creature
+            .unit_mut()
+            .world_mut()
+            .set_map(1, 0)
+            .expect("bind test creature to terrain map");
+        creature.clock_started_at = Instant::now() - Duration::from_secs(10);
+        let data_dir = temp_dir_with_constant_tile(1, 31, 31, 2.0);
+        let terrain = LiveTerrainHeights::new(&data_dir);
+        assert!(
+            (terrain.static_height_like_cpp(1, 10.0, 10.0, 51.75) - 2.0).abs() < 1e-3,
+            "synthetic terrain tile must cover the test path"
+        );
+        let dst = Position::new(15.0, 12.0, 1.75, 0.0);
+        let normal_path = DetourPolyPath {
+            poly_refs: vec![11, 22],
+            point_path: wow_recastdetour::DetourPointPath {
+                points: vec![[10.0, 10.0, 1.75], [12.0, 11.0, 1.75], [15.0, 12.0, 1.75]],
+                actual_end: [15.0, 12.0, 1.75],
+                path_type: DetourPathType::NORMAL,
+            },
+            start_far_from_poly: false,
+            end_far_from_poly: false,
+        };
+
+        let (_from, spline, path) = creature
+            .begin_random_move_spline_with_detour_path_and_terrain_like_cpp(
+                dst,
+                Some(&normal_path),
+                false,
+                Some(&terrain),
+            )
+            .expect("terrain-normalized detour path launches");
+
+        let path = path.expect("path generator");
+        assert_eq!(
+            path.path_points(),
+            &[
+                Position::new(10.0, 10.0, 2.0, 0.0),
+                Position::new(12.0, 11.0, 2.0, 0.0),
+                Position::new(15.0, 12.0, 2.0, 0.0),
+            ],
+            "C++ PathGenerator::NormalizePath calls UpdateAllowedPositionZ for every path point"
+        );
+        assert_eq!(
+            spline.final_destination(),
+            Some(Position::new(15.0, 12.0, 2.0, 0.0))
+        );
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[test]
     fn world_creature_random_detour_rejects_nopath_and_shortcut_like_cpp() {
         let guid = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 0, 0, 1, 54327);
         let mut creature = WorldCreature::new(
@@ -5785,6 +6272,57 @@ mod tests {
             );
             assert!(creature.active_move_spline_like_cpp().is_none());
         }
+    }
+
+    #[test]
+    fn world_creature_random_missing_path_retries_instead_of_direct_fallback_like_cpp() {
+        let guid = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 0, 0, 1, 54340);
+        let mut creature = WorldCreature::new(
+            guid,
+            1,
+            Position::new(10.0, 10.0, 0.0, 0.0),
+            50,
+            2,
+            5,
+            10,
+            20.0,
+            100,
+            14,
+            0,
+            0,
+        );
+        creature
+            .creature
+            .set_default_movement_type_runtime_like_cpp(
+                wow_entities::MovementGeneratorType::Random,
+            );
+        creature.creature.ai_ownership_mut().wander_radius = 8.0;
+        creature.clock_started_at = Instant::now() - Duration::from_secs(10);
+
+        let mut resolver_called = false;
+        let movement = creature.update_default_random_movement_with_path_resolver_like_cpp(
+            10,
+            true,
+            |_start, _destination, _point_path_limit| {
+                resolver_called = true;
+                None
+            },
+        );
+
+        assert!(resolver_called);
+        assert!(
+            movement.is_none(),
+            "C++ RandomMovementGenerator retries when PathGenerator cannot build a usable path"
+        );
+        assert!(creature.active_move_spline_like_cpp().is_none());
+        assert_eq!(
+            creature
+                .active_random_generator
+                .as_ref()
+                .expect("random generator")
+                .timer_ms(),
+            wow_movement::RANDOM_PATH_RETRY_MS_LIKE_CPP
+        );
     }
 
     #[test]
@@ -6425,6 +6963,36 @@ mod tests {
             unfiltered.iter().map(WorldCreature::guid).collect();
         assert!(unfiltered_guids.contains(&visible_guid));
         assert!(unfiltered_guids.contains(&hidden_guid));
+    }
+
+    #[test]
+    fn get_visible_creatures_uses_cpp_2d_sight_range() {
+        let mut manager = MapManager::new();
+        manager.get_or_create_map(1, 0);
+        let guid = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 0, 0, 1, 72);
+        let creature = WorldCreature::new(
+            guid,
+            1,
+            Position::new(80.0, 0.0, 80.0, 0.0),
+            50,
+            1,
+            5,
+            10,
+            20.0,
+            0,
+            35,
+            0,
+            0,
+        );
+        manager.add_creature(1, 0, 0, 0, creature);
+
+        let visible = manager.get_visible_creatures_in_phase(1, 0, 0.0, 0.0, 0.0, 100.0, None);
+
+        assert_eq!(
+            visible.iter().map(WorldCreature::guid).collect::<Vec<_>>(),
+            vec![guid],
+            "C++ visibility uses horizontal distance; a vertically separated creature inside sight range must still be sent"
+        );
     }
 
     #[test]

--- a/crates/wow-world/src/map_manager.rs
+++ b/crates/wow-world/src/map_manager.rs
@@ -16,9 +16,10 @@ use wow_constants::{
 use wow_core::{ObjectGuid, Position};
 use wow_entities::{
     AllowedPositionZCaps, Creature, CreatureAddonLifecycleRecordLikeCpp, CreatureAiState,
-    DistractMovementAction, EVENT_CHARGE_PREPATH, GenericMovementInform, MovementGeneratorKind,
-    MovementGeneratorType, MovementSlot, PhaseShift, PointMovementAction, PointMovementInform,
-    RotateMovementUpdate, Z_OFFSET_FIND_HEIGHT, allowed_position_z_from_ground_like_cpp,
+    DEFAULT_HEIGHT_SEARCH, DistractMovementAction, EVENT_CHARGE_PREPATH, GenericMovementInform,
+    INVALID_HEIGHT, MovementGeneratorKind, MovementGeneratorType, MovementSlot, PhaseShift,
+    PointMovementAction, PointMovementInform, RotateMovementUpdate, Z_OFFSET_FIND_HEIGHT,
+    allowed_position_z_from_ground_like_cpp,
 };
 use wow_map::GridMapTerrain;
 use wow_movement::generators::CreatureRandomMovementType as MovementCreatureRandomMovementType;
@@ -1731,7 +1732,16 @@ impl WorldCreature {
             return point;
         };
         let probe_z = point.z + Z_OFFSET_FIND_HEIGHT;
-        let ground = terrain.static_height_like_cpp(self.map_id(), point.x, point.y, probe_z);
+        let mut ground = terrain.static_height_like_cpp(self.map_id(), point.x, point.y, probe_z);
+        if ground <= INVALID_HEIGHT {
+            let grid_ground = terrain.grid_height_like_cpp(self.map_id(), point.x, point.y);
+            if grid_ground > INVALID_HEIGHT
+                && point.z < grid_ground
+                && grid_ground - point.z <= DEFAULT_HEIGHT_SEARCH
+            {
+                ground = grid_ground;
+            }
+        }
         let z = allowed_position_z_from_ground_like_cpp(
             true,
             ground,
@@ -3266,6 +3276,15 @@ impl LiveTerrainHeights {
     #[must_use]
     pub fn static_height_like_cpp(&self, map_id: u32, x: f32, y: f32, z: f32) -> f32 {
         self.terrain_for_map(map_id).static_height(x, y, z)
+    }
+
+    /// Raw `.map` surface height at `(x, y)`, without the C++ probe-Z acceptance
+    /// gate. This is intentionally not a general `Map::GetHeight` replacement;
+    /// creature path normalization uses it only as a guard for Rust MMap points
+    /// that arrived below the client-visible terrain surface.
+    #[must_use]
+    pub fn grid_height_like_cpp(&self, map_id: u32, x: f32, y: f32) -> f32 {
+        self.terrain_for_map(map_id).grid_height(x, y)
     }
 }
 
@@ -6222,6 +6241,145 @@ mod tests {
         assert_eq!(
             spline.final_destination(),
             Some(Position::new(15.0, 12.0, 2.0, 0.0))
+        );
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[test]
+    fn world_creature_detour_path_bridge_raises_low_mmap_points_to_grid_ground_like_cpp() {
+        let guid = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 0, 0, 1, 54351);
+        let mut creature = WorldCreature::new(
+            guid,
+            1,
+            Position::new(10.0, 10.0, 43.0, 0.0),
+            50,
+            2,
+            5,
+            10,
+            20.0,
+            100,
+            14,
+            0,
+            0,
+        );
+        creature
+            .creature
+            .unit_mut()
+            .world_mut()
+            .set_map(1, 0)
+            .expect("bind test creature to terrain map");
+        creature.clock_started_at = Instant::now() - Duration::from_secs(10);
+        let data_dir = temp_dir_with_constant_tile(1, 31, 31, 50.0);
+        let terrain = LiveTerrainHeights::new(&data_dir);
+        assert!(
+            terrain.static_height_like_cpp(1, 10.0, 10.0, 43.0 + Z_OFFSET_FIND_HEIGHT)
+                <= INVALID_HEIGHT,
+            "the C++ probe gate rejects this low Rust MMap point"
+        );
+        assert!(
+            (terrain.grid_height_like_cpp(1, 10.0, 10.0) - 50.0).abs() < 1e-3,
+            "synthetic terrain still has a usable raw ground height"
+        );
+        let dst = Position::new(15.0, 12.0, 43.0, 0.0);
+        let low_mmap_path = DetourPolyPath {
+            poly_refs: vec![11, 22],
+            point_path: wow_recastdetour::DetourPointPath {
+                points: vec![[10.0, 10.0, 43.0], [12.0, 11.0, 43.0], [15.0, 12.0, 43.0]],
+                actual_end: [15.0, 12.0, 43.0],
+                path_type: DetourPathType::NORMAL,
+            },
+            start_far_from_poly: false,
+            end_far_from_poly: false,
+        };
+
+        let (_from, spline, path) = creature
+            .begin_random_move_spline_with_detour_path_and_terrain_like_cpp(
+                dst,
+                Some(&low_mmap_path),
+                false,
+                Some(&terrain),
+            )
+            .expect("terrain-normalized low detour path launches");
+
+        let path = path.expect("path generator");
+        assert_eq!(
+            path.path_points(),
+            &[
+                Position::new(10.0, 10.0, 50.0, 0.0),
+                Position::new(12.0, 11.0, 50.0, 0.0),
+                Position::new(15.0, 12.0, 50.0, 0.0),
+            ],
+            "NormalizePath must not serialize underground Rust MMap points to the client"
+        );
+        assert_eq!(
+            spline.final_destination(),
+            Some(Position::new(15.0, 12.0, 50.0, 0.0))
+        );
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[test]
+    fn world_creature_detour_path_bridge_keeps_far_below_points_without_ground_like_cpp() {
+        let guid = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 0, 0, 1, 54352);
+        let mut creature = WorldCreature::new(
+            guid,
+            1,
+            Position::new(10.0, 10.0, -5.0, 0.0),
+            50,
+            2,
+            5,
+            10,
+            20.0,
+            100,
+            14,
+            0,
+            0,
+        );
+        creature
+            .creature
+            .unit_mut()
+            .world_mut()
+            .set_map(1, 0)
+            .expect("bind test creature to terrain map");
+        creature.clock_started_at = Instant::now() - Duration::from_secs(10);
+        let data_dir = temp_dir_with_constant_tile(1, 31, 31, 50.0);
+        let terrain = LiveTerrainHeights::new(&data_dir);
+        let dst = Position::new(15.0, 12.0, -5.0, 0.0);
+        let far_below_path = DetourPolyPath {
+            poly_refs: vec![11, 22],
+            point_path: wow_recastdetour::DetourPointPath {
+                points: vec![[10.0, 10.0, -5.0], [12.0, 11.0, -5.0], [15.0, 12.0, -5.0]],
+                actual_end: [15.0, 12.0, -5.0],
+                path_type: DetourPathType::NORMAL,
+            },
+            start_far_from_poly: false,
+            end_far_from_poly: false,
+        };
+
+        let (_from, spline, path) = creature
+            .begin_random_move_spline_with_detour_path_and_terrain_like_cpp(
+                dst,
+                Some(&far_below_path),
+                false,
+                Some(&terrain),
+            )
+            .expect("far-below detour path launches without terrain lift");
+
+        let path = path.expect("path generator");
+        assert_eq!(
+            path.path_points(),
+            &[
+                Position::new(10.0, 10.0, -5.0, 0.0),
+                Position::new(12.0, 11.0, -5.0, 0.0),
+                Position::new(15.0, 12.0, -5.0, 0.0),
+            ],
+            "points farther than DEFAULT_HEIGHT_SEARCH below raw ground keep C++ no-ground behavior"
+        );
+        assert_eq!(
+            spline.final_destination(),
+            Some(Position::new(15.0, 12.0, -5.0, 0.0))
         );
 
         let _ = std::fs::remove_dir_all(&data_dir);

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -4845,8 +4845,10 @@ pub struct WorldSession {
     ///
     /// The C++ 3.4.3 login baseline does not deliver `SMSG_ON_MONSTER_MOVE`
     /// during the initial enter-world packet burst, even after
-    /// `UpdateVisibilityForPlayer()` has repopulated `m_clientGUIDs`.
-    pub(crate) suppress_creature_movement_until_like_cpp: Option<Instant>,
+    /// `UpdateVisibilityForPlayer()` has repopulated `m_clientGUIDs`. Rust uses
+    /// the cutoff to drop movement commands queued before the burst completes
+    /// without blocking movement generated after the player is in world.
+    pub(crate) suppress_creature_movement_queued_at_or_before_like_cpp: Option<Instant>,
     /// Represented C++ `Player::m_seer`. This slice keeps only the GUID seam:
     /// self/player GUID by default, current viewpoint GUID after valid FAR_SIGHT enable.
     pub(crate) represented_seer_guid_like_cpp: Option<wow_core::ObjectGuid>,
@@ -6312,7 +6314,7 @@ impl WorldSession {
             represented_personal_loot_money: std::collections::HashMap::new(),
             represented_personal_loot_owners: std::collections::HashSet::new(),
             client_visible_guids_like_cpp: std::collections::HashSet::new(),
-            suppress_creature_movement_until_like_cpp: None,
+            suppress_creature_movement_queued_at_or_before_like_cpp: None,
             represented_seer_guid_like_cpp: None,
             represented_dynamic_object_values_updates_delivered_like_cpp:
                 std::collections::HashSet::new(),
@@ -12197,35 +12199,40 @@ impl WorldSession {
             return Vec::new();
         }
 
-        let mut creatures = self
-            .visible_creatures_from_canonical_map_like_cpp(map_id, position)
-            .unwrap_or_default();
-        let mut seen = creatures
-            .iter()
-            .map(crate::map_manager::WorldCreature::guid)
-            .collect::<std::collections::HashSet<_>>();
+        let mut creatures = Vec::new();
+        let mut seen = std::collections::HashSet::new();
 
-        let Some(manager) = &self.map_manager else {
-            return creatures;
-        };
-        let visibility_range = self.player_map_visibility_range_like_cpp(map_id);
+        if let Some(manager) = &self.map_manager {
+            let visibility_range = self.player_map_visibility_range_like_cpp(map_id);
+            creatures.extend(
+                manager
+                    .read()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .get_visible_creatures_in_phase(
+                        map_id,
+                        0,
+                        position.x,
+                        position.y,
+                        position.z,
+                        visibility_range,
+                        Some(&self.represented_player_phase_shift),
+                    )
+                    .into_iter()
+                    .filter(|creature| {
+                        self.represented_can_see_or_detect_world_creature_like_cpp(creature)
+                    })
+                    .filter(|creature| seen.insert(creature.guid())),
+            );
+        }
+
+        // C++ has one map-owned Creature object. During Rust's temporary
+        // canonical/legacy split, the legacy creature owns live movement
+        // splines, so prefer it for duplicate GUIDs and use canonical only as
+        // a fallback for objects absent from the legacy runtime.
         creatures.extend(
-            manager
-                .read()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .get_visible_creatures_in_phase(
-                    map_id,
-                    0,
-                    position.x,
-                    position.y,
-                    position.z,
-                    visibility_range,
-                    Some(&self.represented_player_phase_shift),
-                )
+            self.visible_creatures_from_canonical_map_like_cpp(map_id, position)
+                .unwrap_or_default()
                 .into_iter()
-                .filter(|creature| {
-                    self.represented_can_see_or_detect_world_creature_like_cpp(creature)
-                })
                 .filter(|creature| seen.insert(creature.guid())),
         );
         creatures
@@ -25423,6 +25430,7 @@ impl WorldSession {
         for command_tx in candidates {
             let _ = command_tx.try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid: guid,
                     map_id,
                     instance_id,
@@ -26460,6 +26468,16 @@ impl WorldSession {
             if !self.evaluate_packet_spoof_like_cpp(&pkt) {
                 break;
             }
+            if std::env::var_os("RUSTYCORE_PACKET_SEQUENCE_TRACE").is_some()
+                && pkt.client_opcode() == Some(ClientOpcodes::RequestCemeteryList)
+            {
+                info!(
+                    account = self.account_id,
+                    state = ?self.state,
+                    pending_before = self.pending_packets.len(),
+                    "RUST_CEMETERY_TRACE queued primary packet"
+                );
+            }
             self.pending_packets.push(pkt);
             processed += 1;
         }
@@ -26474,6 +26492,16 @@ impl WorldSession {
                         self.reset_timeout_time_for_packet_like_cpp(pkt.opcode_raw());
                         if !self.evaluate_packet_spoof_like_cpp(&pkt) {
                             break;
+                        }
+                        if std::env::var_os("RUSTYCORE_PACKET_SEQUENCE_TRACE").is_some()
+                            && pkt.client_opcode() == Some(ClientOpcodes::RequestCemeteryList)
+                        {
+                            info!(
+                                account = self.account_id,
+                                state = ?self.state,
+                                pending_before = self.pending_packets.len(),
+                                "RUST_CEMETERY_TRACE queued realm packet"
+                            );
                         }
                         self.pending_packets.push(pkt);
                         processed += 1;
@@ -28187,6 +28215,15 @@ impl WorldSession {
 
         let packets: Vec<WorldPacket> = self.pending_packets.drain(..).collect();
         for pkt in packets {
+            if std::env::var_os("RUSTYCORE_PACKET_SEQUENCE_TRACE").is_some()
+                && pkt.client_opcode() == Some(ClientOpcodes::RequestCemeteryList)
+            {
+                info!(
+                    account = self.account_id,
+                    state = ?self.state,
+                    "RUST_CEMETERY_TRACE dispatching queued packet"
+                );
+            }
             self.dispatch_packet(pkt).await;
         }
     }
@@ -28324,6 +28361,17 @@ impl WorldSession {
         };
 
         // Check session status
+        if std::env::var_os("RUSTYCORE_PACKET_SEQUENCE_TRACE").is_some()
+            && opcode == ClientOpcodes::RequestCemeteryList
+        {
+            info!(
+                account = self.account_id,
+                state = ?self.state,
+                required = ?entry.status,
+                handler = entry.handler_name,
+                "RUST_CEMETERY_TRACE dispatch reached status gate"
+            );
+        }
         if !self.is_status_allowed(entry.status) {
             warn!(
                 "Handler {} rejected: session state {:?} doesn't match required {:?}",
@@ -28339,6 +28387,18 @@ impl WorldSession {
 
         // Skip opcode before reading payload
         pkt.skip_opcode();
+        if std::env::var_os("RUSTYCORE_PACKET_SEQUENCE_TRACE").is_some()
+            && opcode == ClientOpcodes::RequestCemeteryList
+        {
+            info!(
+                account = self.account_id,
+                state = ?self.state,
+                packet_size = pkt.size(),
+                remaining = pkt.remaining(),
+                read_position = pkt.read_position(),
+                "RUST_CEMETERY_TRACE skipped opcode"
+            );
+        }
 
         match opcode {
             ClientOpcodes::EnumCharacters => {
@@ -28443,7 +28503,21 @@ impl WorldSession {
                 self.handle_area_trigger(pkt).await;
             }
             ClientOpcodes::RequestCemeteryList => {
+                if std::env::var_os("RUSTYCORE_PACKET_SEQUENCE_TRACE").is_some() {
+                    info!(
+                        account = self.account_id,
+                        state = ?self.state,
+                        "RUST_CEMETERY_TRACE before handler call"
+                    );
+                }
                 self.handle_request_cemetery_list(pkt).await;
+                if std::env::var_os("RUSTYCORE_PACKET_SEQUENCE_TRACE").is_some() {
+                    info!(
+                        account = self.account_id,
+                        state = ?self.state,
+                        "RUST_CEMETERY_TRACE after handler call"
+                    );
+                }
             }
             ClientOpcodes::ResurrectResponse => {
                 self.handle_resurrect_response(pkt).await;
@@ -30539,6 +30613,7 @@ impl WorldSession {
         for command_tx in candidates {
             let _ = command_tx.try_send(wow_network::SessionCommand::SendIfVisibleLikeCpp(
                 wow_network::player_registry::SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid,
                     map_id,
                     instance_id,
@@ -31533,6 +31608,7 @@ impl WorldSession {
         &mut self,
         mut controller: SessionPlayerController,
     ) {
+        let controller_position = controller.position();
         controller.set_gold(self.player_gold);
         controller.set_character_points(self.player_character_points_like_cpp);
         controller.set_xp(self.player_xp);
@@ -31543,7 +31619,7 @@ impl WorldSession {
         controller.set_inventory(self.session_player_inventory_runtime_like_cpp());
         self.player_guid = Some(controller.guid());
         self.player_name = Some(controller.name().to_string());
-        self.player_position = Some(controller.position());
+        self.player_position = Some(controller_position);
         self.current_map_id = controller.map_id();
         self.player_race = controller.race();
         self.player_class = controller.class();
@@ -31553,6 +31629,7 @@ impl WorldSession {
         self.represented_seer_guid_like_cpp = Some(controller.guid());
         self.player_controller = Some(controller);
         self.initialize_reputation_mgr_like_cpp();
+        self.set_fall_information_like_cpp(0, controller_position.z);
     }
 
     pub(crate) fn ensure_login_player_controller_like_cpp(
@@ -31576,6 +31653,7 @@ impl WorldSession {
             self.set_loaded_player_name_like_cpp(name);
             self.set_loaded_player_identity_like_cpp(map_id, race, class, level, gender);
             self.set_player_map_position_like_cpp(map_id, position);
+            self.set_fall_information_like_cpp(0, position.z);
             false
         }
     }
@@ -35959,6 +36037,21 @@ impl WorldSession {
         self.sync_player_registry_state_like_cpp();
     }
 
+    fn apply_represented_player_environmental_death_like_cpp(&mut self) {
+        // C++ `Player::EnvironmentalDamage` routes lethal damage through
+        // `Unit::Kill` -> `Player::setDeathState(JUST_DIED)` before the client
+        // proceeds into release/cemetery flows.
+        self.player_health_like_cpp = 0;
+        self.player_alive_like_cpp = false;
+        let _ = self.mutate_canonical_player_like_cpp(|player| {
+            player
+                .unit_mut()
+                .set_death_state(wow_constants::DeathState::JustDied);
+            player.unit_mut().set_health(0);
+        });
+        self.sync_player_registry_state_like_cpp();
+    }
+
     pub(crate) fn player_health_like_cpp(&self) -> u32 {
         self.player_health_like_cpp
     }
@@ -36119,10 +36212,12 @@ impl WorldSession {
             damage.min(original_health)
         };
         self.player_health_like_cpp = self.player_health_like_cpp.saturating_sub(final_damage);
-        if self.player_health_like_cpp == 0 {
-            self.player_alive_like_cpp = false;
+        let killed_player = final_damage > 0 && self.player_health_like_cpp == 0;
+        if killed_player {
+            self.apply_represented_player_environmental_death_like_cpp();
+        } else {
+            self.sync_player_registry_state_like_cpp();
         }
-        self.sync_player_registry_state_like_cpp();
         if final_damage > 0
             && let Some(player_guid) = self.player_guid()
         {
@@ -36137,6 +36232,9 @@ impl WorldSession {
                 0,
                 0,
             );
+            if killed_player {
+                self.send_player_health_values_update_like_cpp(player_guid, 0);
+            }
         }
 
         let event = MovementFallDamageEvent {
@@ -36237,8 +36335,9 @@ impl WorldSession {
         let original_health = self.player_health_like_cpp;
         let damage = self.player_max_health_like_cpp;
         self.player_health_like_cpp = self.player_health_like_cpp.saturating_sub(damage);
-        if self.player_health_like_cpp == 0 {
-            self.player_alive_like_cpp = false;
+        let killed_player = self.player_health_like_cpp == 0;
+        if killed_player {
+            self.apply_represented_player_environmental_death_like_cpp();
         }
         if self.player_health_like_cpp != original_health
             && let Some(player_guid) = self.player_guid()
@@ -36254,6 +36353,9 @@ impl WorldSession {
                 0,
                 0,
             );
+            if killed_player {
+                self.send_player_health_values_update_like_cpp(player_guid, 0);
+            }
         }
 
         // C++ calls KillPlayer if EnvironmentalDamage did not kill due to GM/immunity.
@@ -43886,6 +43988,7 @@ impl WorldSession {
         for command_tx in candidates {
             let _ = command_tx.try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid: pet_guid,
                     map_id,
                     instance_id,
@@ -45740,6 +45843,7 @@ pub(crate) fn step_creature_movement_like_cpp(
     guid: wow_core::ObjectGuid,
     mmap_config: &MMapRuntimeConfigLikeCpp,
     mmap_pathfinder: Option<&crate::map_manager::WorldMMapPathfinderWorkerLikeCpp>,
+    terrain: Option<&crate::map_manager::LiveTerrainHeights>,
     diff_ms: u32,
 ) -> Option<Vec<u8>> {
     use wow_packet::ServerPacket;
@@ -45763,39 +45867,41 @@ pub(crate) fn step_creature_movement_like_cpp(
             let phase_shift = creature.phase_shift().clone();
             let should_try_pathfinding = mmap_config
                 .should_try_pathfinding_like_cpp(source_map_id, owner_ignores_pathfinding);
-            let movement = creature.update_default_random_movement_with_path_resolver_like_cpp(
-                diff_ms,
-                should_try_pathfinding,
-                |start, destination, point_path_limit| {
-                    mmap_pathfinder.and_then(|worker| {
-                        match worker.calculate_path_like_cpp(
-                            crate::map_manager::WorldMMapPathRequestLikeCpp {
-                                start,
-                                destination,
-                                mesh_map_id: source_map_id,
-                                instance_map_id: source_map_id,
-                                instance_id: source_instance_id,
-                                filter_context: PathQueryFilterContext::creature(
-                                    true, false, false, false,
-                                ),
-                                force_destination: false,
-                                point_path_limit,
-                                phase_shift: phase_shift.clone(),
-                            },
-                        ) {
-                            Ok(path) => path,
-                            Err(error) => {
-                                tracing::warn!(
-                                    "mmap pathfinding failed for creature {:?}: {:?}",
-                                    guid,
-                                    error
-                                );
-                                None
+            let movement = creature
+                .update_default_random_movement_with_path_resolver_and_terrain_like_cpp(
+                    diff_ms,
+                    should_try_pathfinding,
+                    terrain,
+                    |start, destination, point_path_limit| {
+                        mmap_pathfinder.and_then(|worker| {
+                            match worker.calculate_path_like_cpp(
+                                crate::map_manager::WorldMMapPathRequestLikeCpp {
+                                    start,
+                                    destination,
+                                    mesh_map_id: source_map_id,
+                                    instance_map_id: source_map_id,
+                                    instance_id: source_instance_id,
+                                    filter_context: PathQueryFilterContext::creature(
+                                        true, false, false, false,
+                                    ),
+                                    force_destination: false,
+                                    point_path_limit,
+                                    phase_shift: phase_shift.clone(),
+                                },
+                            ) {
+                                Ok(path) => path,
+                                Err(error) => {
+                                    tracing::warn!(
+                                        "mmap pathfinding failed for creature {:?}: {:?}",
+                                        guid,
+                                        error
+                                    );
+                                    None
+                                }
                             }
-                        }
-                    })
-                },
-            );
+                        })
+                    },
+                );
             if let Some((from, move_spline)) = movement {
                 let packet_spline = MovementMonsterSpline::from_move_spline(&move_spline);
                 let pkt = MonsterMove {
@@ -45826,11 +45932,52 @@ pub(crate) fn step_creature_movement_like_cpp(
         wow_entities::CreatureAiState::WalkingWaypoint => {
             // C++ `WaypointMovementGenerator<Creature>::DoUpdate` advances the
             // generator from the map-owned creature update and `StartMove`
-            // launches a MoveSpline, which serializes as MonsterMove to
-            // visible clients. Keep this session-free so the global legacy
-            // runtime and the old session tick use the same body.
-            let (_action, launched_spline) =
-                creature.update_default_waypoint_movement_with_launch_like_cpp(diff_ms);
+            // launches `MoveSplineInit::MoveTo(..., _generatePath)`, which
+            // resolves `PathGenerator` before falling back to a direct segment.
+            let owner_ignores_pathfinding = creature
+                .creature
+                .unit()
+                .has_unit_state(UnitState::IGNORE_PATHFINDING.bits());
+            let source_map_id = creature.map_id();
+            let source_instance_id = creature.instance_id();
+            let phase_shift = creature.phase_shift().clone();
+            let should_try_pathfinding = mmap_config
+                .should_try_pathfinding_like_cpp(source_map_id, owner_ignores_pathfinding);
+            let (_action, launched_spline) = creature
+                .update_default_waypoint_movement_with_path_resolver_and_terrain_like_cpp(
+                    diff_ms,
+                    should_try_pathfinding,
+                    terrain,
+                    |start, destination, point_path_limit| {
+                        mmap_pathfinder.and_then(|worker| {
+                            match worker.calculate_path_like_cpp(
+                                crate::map_manager::WorldMMapPathRequestLikeCpp {
+                                    start,
+                                    destination,
+                                    mesh_map_id: source_map_id,
+                                    instance_map_id: source_map_id,
+                                    instance_id: source_instance_id,
+                                    filter_context: PathQueryFilterContext::creature(
+                                        true, false, false, false,
+                                    ),
+                                    force_destination: false,
+                                    point_path_limit,
+                                    phase_shift: phase_shift.clone(),
+                                },
+                            ) {
+                                Ok(path) => path,
+                                Err(error) => {
+                                    tracing::warn!(
+                                        "mmap waypoint pathfinding failed for creature {:?}: {:?}",
+                                        guid,
+                                        error
+                                    );
+                                    None
+                                }
+                            }
+                        })
+                    },
+                );
             if let Some((from, move_spline)) = launched_spline {
                 let packet_spline = MovementMonsterSpline::from_move_spline(&move_spline);
                 let pkt = MonsterMove {
@@ -45874,6 +46021,13 @@ fn trace_monster_move_packet_like_cpp(
         .collect::<Vec<_>>()
         .join(" ");
     let suffix = if bytes.len() > hex_len { " ..." } else { "" };
+    let path_points = move_spline.create_object_path_points_like_cpp();
+    let (path_z_min, path_z_max) = path_points.iter().fold(
+        (f32::INFINITY, f32::NEG_INFINITY),
+        |(min_z, max_z), point| (min_z.min(point.z), max_z.max(point.z)),
+    );
+    let path_z_min = path_z_min.is_finite().then_some(path_z_min);
+    let path_z_max = path_z_max.is_finite().then_some(path_z_max);
 
     info!(
         source,
@@ -45895,6 +46049,10 @@ fn trace_monster_move_packet_like_cpp(
         spline_id = packet_spline.id,
         spline_duration = move_spline.duration_ms(),
         spline_flags = move_spline.flags().bits(),
+        spline_final = ?move_spline.final_destination(),
+        spline_path_points = path_points.len(),
+        spline_path_z_min = ?path_z_min,
+        spline_path_z_max = ?path_z_max,
         packet_len = bytes.len(),
         packet_hex = format!("{hex}{suffix}"),
         "RUST_MONSTER_MOVE"
@@ -45949,6 +46107,7 @@ pub fn run_legacy_creature_movement_tick_once_like_cpp(
         }
 
         let map_keys = manager.active_map_keys();
+        let live_terrain = manager.terrain();
         outcome.maps_seen = map_keys.len();
         for (map_id, instance_id) in map_keys {
             let guids = manager.creature_guids(map_id, instance_id);
@@ -45962,6 +46121,7 @@ pub fn run_legacy_creature_movement_tick_once_like_cpp(
                     guid,
                     mmap_config,
                     mmap_pathfinder,
+                    live_terrain.as_deref(),
                     diff_ms,
                 );
                 let source_position = creature.position();
@@ -47609,6 +47769,12 @@ impl WorldSession {
 
         let mmap_runtime_config = self.mmap_runtime_config_like_cpp.clone();
         let mmap_pathfinder = self.mmap_pathfinder_like_cpp.clone();
+        let live_terrain = self.map_manager.as_ref().and_then(|manager| {
+            manager
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .terrain()
+        });
         let visible_guids = self.client_visible_guids_like_cpp.clone();
         let player_position = self.player_position_like_cpp();
         let player_map_id = u32::from(self.player_map_id_like_cpp());
@@ -47676,6 +47842,7 @@ impl WorldSession {
                     guid,
                     &mmap_runtime_config,
                     mmap_pathfinder.as_deref(),
+                    live_terrain.as_deref(),
                     200,
                 ) {
                     if monster_move_trace {
@@ -48301,6 +48468,7 @@ impl WorldSession {
                 .command_tx
                 .try_send(SessionCommand::SendIfVisibleLikeCpp(
                     SendIfVisibleLikeCppCommand {
+                        queued_at: Instant::now(),
                         source_guid: guid,
                         map_id,
                         instance_id,
@@ -61018,6 +61186,7 @@ mod tests {
             .session_command_tx()
             .try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid,
                     map_id: 571,
                     instance_id: 0,
@@ -61069,6 +61238,7 @@ mod tests {
             .session_command_tx()
             .try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid,
                     map_id: 571,
                     instance_id: 0,
@@ -61087,7 +61257,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_if_visible_monster_move_rejected_during_initial_enter_world_gate_like_cpp() {
+    async fn send_if_visible_monster_move_rejects_commands_queued_before_enter_world_cutoff_like_cpp()
+     {
         let (mut session, _, send_rx) = make_session();
         let source_guid =
             ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 777, 1012);
@@ -61117,13 +61288,14 @@ mod tests {
         session.set_map_manager(Arc::clone(&manager));
         session.set_player_map_position_like_cpp(571, Position::ZERO);
         session.client_visible_guids_like_cpp.insert(source_guid);
-        session.suppress_creature_movement_until_like_cpp =
-            Some(Instant::now() + Duration::from_secs(60));
+        let enter_world_cutoff = Instant::now();
+        session.suppress_creature_movement_queued_at_or_before_like_cpp = Some(enter_world_cutoff);
 
         session
             .session_command_tx()
             .try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: enter_world_cutoff - Duration::from_millis(1),
                     source_guid,
                     map_id: 571,
                     instance_id: 0,
@@ -61139,12 +61311,11 @@ mod tests {
             "C++ baseline has no SMSG_ON_MONSTER_MOVE in the initial enter-world packet burst"
         );
 
-        session.suppress_creature_movement_until_like_cpp =
-            Some(Instant::now() - Duration::from_millis(1));
         session
             .session_command_tx()
             .try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: enter_world_cutoff + Duration::from_millis(1),
                     source_guid,
                     map_id: 571,
                     instance_id: 0,
@@ -61158,10 +61329,13 @@ mod tests {
         assert_eq!(
             send_rx
                 .try_recv()
-                .expect("movement delivers after initial gate expires"),
+                .expect("movement queued after enter-world cutoff delivers"),
             packet_bytes
         );
-        assert!(session.suppress_creature_movement_until_like_cpp.is_none());
+        assert_eq!(
+            session.suppress_creature_movement_queued_at_or_before_like_cpp,
+            Some(enter_world_cutoff)
+        );
         assert!(send_rx.try_recv().is_err(), "no extra packets");
     }
 
@@ -61180,6 +61354,7 @@ mod tests {
             .session_command_tx()
             .try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid,
                     map_id: 530, // wrong map
                     instance_id: 0,
@@ -61212,6 +61387,7 @@ mod tests {
             .session_command_tx()
             .try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid,
                     map_id: 571,
                     instance_id: 99, // different instance
@@ -61243,6 +61419,7 @@ mod tests {
             .session_command_tx()
             .try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid,
                     map_id: 571,
                     instance_id: 0,
@@ -61307,6 +61484,7 @@ mod tests {
             .session_command_tx()
             .try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid,
                     map_id: 571, // matches session map — as set by the fixed ExplicitPlayer routing
                     instance_id: 0,
@@ -61363,6 +61541,7 @@ mod tests {
             .session_command_tx()
             .try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid,
                     map_id: 571,
                     instance_id: 0,
@@ -61390,6 +61569,7 @@ mod tests {
             .session_command_tx()
             .try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid,
                     map_id: 571,
                     instance_id: 0,
@@ -61413,6 +61593,7 @@ mod tests {
             .session_command_tx()
             .try_send(SessionCommand::SendIfVisibleLikeCpp(
                 SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
                     source_guid,
                     map_id: 571,
                     instance_id: 0,
@@ -76227,6 +76408,93 @@ mod tests {
     }
 
     #[test]
+    fn visible_world_creatures_prefer_legacy_runtime_duplicate_with_active_spline_like_cpp() {
+        use wow_constants::movement::MovementFlag;
+
+        let (mut session, _pkt_tx, _send_rx) = make_session();
+        let manager = shared_map_manager();
+        let canonical = shared_canonical_map_manager();
+        let player_guid = ObjectGuid::create_player(1, 76_010);
+        let creature_guid = test_creature_guid(76_011);
+        let player_position = Position::new(10.0, 10.0, 0.0, 0.0);
+        let creature_position = Position::new(20.0, 20.0, 0.0, 0.0);
+
+        session.set_map_manager(Arc::clone(&manager));
+        session.set_canonical_map_manager(Arc::clone(&canonical));
+        session.attach_player_controller_like_cpp(SessionPlayerController::new(
+            player_guid,
+            "VisibleCreatureViewer".to_string(),
+            player_position,
+            571,
+            1,
+            1,
+            80,
+            0,
+        ));
+        add_canonical_test_player_on_map(&canonical, player_guid, player_position, 571, 0);
+        add_canonical_test_creature_on_map_with_world_state(
+            &canonical,
+            creature_guid,
+            76_011,
+            creature_position,
+            0,
+            571,
+            0,
+            true,
+        );
+
+        let mut legacy_creature = crate::map_manager::WorldCreature::new(
+            creature_guid,
+            76_011,
+            creature_position,
+            100,
+            12,
+            1,
+            2,
+            0.0,
+            1,
+            35,
+            0,
+            0,
+        );
+        legacy_creature
+            .creature
+            .unit_mut()
+            .world_mut()
+            .set_map(571, 0)
+            .unwrap();
+        legacy_creature
+            .creature
+            .unit_mut()
+            .world_mut()
+            .object_mut()
+            .add_to_world();
+        legacy_creature
+            .begin_move_spline_like_cpp(Position::new(24.0, 20.0, 0.0, 0.0))
+            .expect("legacy runtime spline must launch");
+        let (grid_x, grid_y) =
+            crate::map_manager::world_to_grid_coords(creature_position.x, creature_position.y);
+        manager
+            .write()
+            .unwrap()
+            .add_creature(571, 0, grid_x, grid_y, legacy_creature);
+
+        let visible = session.visible_world_creatures_from_map_like_cpp(571, &player_position);
+
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].guid(), creature_guid);
+        assert!(
+            visible[0].active_move_spline_like_cpp().is_some(),
+            "C++ has one map Creature; Rust visibility must keep the legacy active MoveSpline for duplicate canonical/legacy GUIDs"
+        );
+        assert!(
+            MovementFlag::from_bits_retain(visible[0].create_data.movement_flags)
+                .contains(MovementFlag::FORWARD),
+            "active legacy spline should carry C++ MoveSplineInit::Launch movement flags into CREATE"
+        );
+    }
+
+    #[test]
     fn active_creature_update_guids_use_cpp_cell_activation_area() {
         let (mut session, _pkt_tx, _send_rx) = make_session();
         let manager = shared_map_manager();
@@ -76871,6 +77139,80 @@ mod tests {
                         == ServerOpcodes::UpdateObject as u16
             }),
             "initial forced visibility should send CREATE update data for newly visible objects"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_initial_packets_after_add_to_map_rebuilds_visibility_after_login_clear_like_cpp()
+    {
+        let (mut session, _pkt_tx, send_rx) = make_session();
+        let manager = shared_map_manager();
+        let canonical = shared_canonical_map_manager();
+        let player_guid = ObjectGuid::create_player(1, 74_332);
+        let player_position = Position::new(10.0, 10.0, 0.0, 0.0);
+        let creature_guid = test_creature_guid(74_333);
+
+        session.set_map_manager(Arc::clone(&manager));
+        session.set_canonical_map_manager(Arc::clone(&canonical));
+        session.attach_player_controller_like_cpp(SessionPlayerController::new(
+            player_guid,
+            "LoginAfterAddVisibility".to_string(),
+            player_position,
+            571,
+            1,
+            1,
+            80,
+            0,
+        ));
+        session.apply_move_init_active_mover_complete_like_cpp(0);
+        let _ = drain_server_packet_bytes(&send_rx);
+
+        let creature_position = Position::new(20.0, 20.0, 0.0, 0.0);
+        let (grid_x, grid_y) =
+            crate::map_manager::world_to_grid_coords(creature_position.x, creature_position.y);
+        manager.write().unwrap().add_creature(
+            571,
+            0,
+            grid_x,
+            grid_y,
+            crate::map_manager::WorldCreature::new(
+                creature_guid,
+                901,
+                creature_position,
+                100,
+                80,
+                1,
+                2,
+                0.0,
+                1,
+                35,
+                0,
+                0,
+            ),
+        );
+
+        session.last_visibility_pos = Some(player_position);
+        session.client_visible_guids_like_cpp.clear();
+
+        session
+            .send_initial_packets_after_add_to_map(player_guid, &player_position, 571, false)
+            .await;
+
+        assert!(
+            session
+                .client_visible_guids_like_cpp
+                .contains(&creature_guid),
+            "C++ SendInitialPacketsAfterAddToMap::UpdateVisibilityForPlayer rebuilds visibility after Map::AddPlayerToMap clears m_clientGUIDs"
+        );
+        assert_eq!(session.last_visibility_pos, Some(player_position));
+        let packets = drain_server_packet_bytes(&send_rx);
+        assert!(
+            packets.iter().any(|packet| {
+                packet.len() >= 2
+                    && u16::from_le_bytes([packet[0], packet[1]])
+                        == ServerOpcodes::UpdateObject as u16
+            }),
+            "post-add visibility rebuild should send creature CREATE update data during login"
         );
     }
 
@@ -81567,10 +81909,12 @@ mod tests {
         assert_eq!(session.player_name_like_cpp(), Some("LoginTester"));
         assert_eq!(session.player_position_like_cpp(), Some(start));
         assert_eq!(session.player_map_id_like_cpp(), 571);
+        assert_eq!(session.fall_information_like_cpp(), (0, start.z));
 
         session.set_player_gold_like_cpp(1234);
         session.set_player_xp_like_cpp(55);
         session.set_known_spells_like_cpp(vec![118, 133]);
+        session.set_fall_information_like_cpp(1_200, 80.0);
 
         let moved = Position::new(5.0, 6.0, 7.0, 8.0);
         assert!(!session.ensure_login_player_controller_like_cpp(
@@ -81588,6 +81932,7 @@ mod tests {
         assert_eq!(session.player_name_like_cpp(), Some("LoginTesterRenamed"));
         assert_eq!(session.player_position_like_cpp(), Some(moved));
         assert_eq!(session.player_map_id_like_cpp(), 1);
+        assert_eq!(session.fall_information_like_cpp(), (0, moved.z));
         assert_eq!(session.player_race_like_cpp(), 2);
         assert_eq!(session.player_class_like_cpp(), 3);
         assert_eq!(session.player_level_like_cpp(), 71);
@@ -95569,28 +95914,30 @@ mod tests {
         assert_eq!(pkt.read_float().unwrap(), 10.0);
         assert_eq!(pkt.read_float().unwrap(), 10.0);
         assert_eq!(pkt.read_float().unwrap(), 0.0);
-        assert_eq!(pkt.read_uint32().unwrap(), 3);
+        assert_eq!(pkt.read_uint32().unwrap(), 3); // spline id
         assert_eq!(pkt.read_float().unwrap(), 0.0);
         assert_eq!(pkt.read_float().unwrap(), 0.0);
         assert_eq!(pkt.read_float().unwrap(), 0.0);
-        assert_eq!(pkt.read_uint32().unwrap(), 0);
-        assert_eq!(pkt.read_int32().unwrap(), 0);
-        assert_eq!(pkt.read_uint32().unwrap(), 0);
-        assert_eq!(pkt.read_uint32().unwrap(), 0);
-        assert_eq!(pkt.read_uint8().unwrap(), 0);
-        assert_eq!(pkt.read_packed_guid().unwrap(), ObjectGuid::EMPTY);
-        assert_eq!(pkt.read_int8().unwrap(), -1);
-        assert!(!pkt.has_bit().unwrap());
-        assert_eq!(pkt.read_bits(3).unwrap(), 2);
-        assert_eq!(pkt.read_bits(2).unwrap(), 0);
-        assert_eq!(pkt.read_bits(16).unwrap(), 0);
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert_eq!(pkt.read_bits(16).unwrap(), 0);
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
-        assert!(!pkt.has_bit().unwrap());
+        // CrzTeleport + StopDistanceTolerance precede Flags on the wire: the
+        // spline's first integer write flushes those 4 bits into their own byte.
+        assert!(!pkt.has_bit().unwrap()); // CrzTeleport
+        assert_eq!(pkt.read_bits(3).unwrap(), 2); // StopDistanceTolerance
+        assert_eq!(pkt.read_uint32().unwrap(), 0); // Flags
+        assert_eq!(pkt.read_int32().unwrap(), 0); // Elapsed
+        assert_eq!(pkt.read_uint32().unwrap(), 0); // MoveTime
+        assert_eq!(pkt.read_uint32().unwrap(), 0); // FadeObjectTime
+        assert_eq!(pkt.read_uint8().unwrap(), 0); // Mode
+        assert_eq!(pkt.read_packed_guid().unwrap(), ObjectGuid::EMPTY); // TransportGUID
+        assert_eq!(pkt.read_int8().unwrap(), -1); // VehicleSeat
+        assert_eq!(pkt.read_bits(2).unwrap(), 0); // Face
+        assert_eq!(pkt.read_bits(16).unwrap(), 0); // Points.len()
+        assert!(!pkt.has_bit().unwrap()); // VehicleExitVoluntary
+        assert!(!pkt.has_bit().unwrap()); // Interpolate
+        assert_eq!(pkt.read_bits(16).unwrap(), 0); // PackedDeltas.len()
+        assert!(!pkt.has_bit().unwrap()); // SplineFilter
+        assert!(!pkt.has_bit().unwrap()); // SpellEffectExtraData
+        assert!(!pkt.has_bit().unwrap()); // JumpExtraData
+        assert!(!pkt.has_bit().unwrap()); // AnimTierTransition
     }
 
     #[test]
@@ -126616,7 +126963,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = step_creature_movement_like_cpp(&mut creature, guid, &config, None, 200);
+        let result = step_creature_movement_like_cpp(&mut creature, guid, &config, None, None, 200);
 
         // Must return Some with a serialised MonsterMove packet.
         assert!(
@@ -126654,7 +127001,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = step_creature_movement_like_cpp(&mut creature, guid, &config, None, 200);
+        let result = step_creature_movement_like_cpp(&mut creature, guid, &config, None, None, 200);
 
         assert!(
             result.is_none(),
@@ -126679,7 +127026,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = step_creature_movement_like_cpp(&mut creature, guid, &config, None, 200);
+        let result = step_creature_movement_like_cpp(&mut creature, guid, &config, None, None, 200);
 
         assert!(
             result.is_none(),
@@ -126703,7 +127050,7 @@ mod tests {
 
         let config = MMapRuntimeConfigLikeCpp::default();
 
-        let result = step_creature_movement_like_cpp(&mut creature, guid, &config, None, 200);
+        let result = step_creature_movement_like_cpp(&mut creature, guid, &config, None, None, 200);
 
         assert!(
             result.is_none(),
@@ -126740,6 +127087,7 @@ mod tests {
             &mut creature,
             guid,
             &config,
+            None,
             None,
             wow_movement::WAYPOINT_INITIAL_DELAY_MS_LIKE_CPP as u32,
         );
@@ -126779,7 +127127,7 @@ mod tests {
 
         let config = MMapRuntimeConfigLikeCpp::default();
 
-        let result = step_creature_movement_like_cpp(&mut creature, guid, &config, None, 200);
+        let result = step_creature_movement_like_cpp(&mut creature, guid, &config, None, None, 200);
 
         assert!(result.is_none(), "dead + respawn must return None");
         // After respawn the creature is alive and in Idle state.

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -83610,6 +83610,10 @@ mod tests {
     #[test]
     fn tick_creatures_sync_launches_real_move_spline_for_represented_wander() {
         let (mut session, _, send_rx) = make_session();
+        session.set_mmap_runtime_config_like_cpp(MMapRuntimeConfigLikeCpp {
+            enabled: false,
+            ..Default::default()
+        });
         let manager = shared_map_manager();
         let guid = test_creature_guid(77);
         register_test_creature(&mut session, manager, guid, 25);
@@ -83630,9 +83634,12 @@ mod tests {
             .unwrap();
         session.client_visible_guids_like_cpp.insert(guid);
 
-        session.tick_creatures_sync();
-
-        let sent = send_rx.try_recv().unwrap();
+        let sent = (0..32)
+            .find_map(|_| {
+                session.tick_creatures_sync();
+                send_rx.try_recv().ok()
+            })
+            .expect("random movement should eventually launch a MonsterMove packet");
         let opcode = u16::from_le_bytes([sent[0], sent[1]]);
         assert_eq!(opcode, ServerOpcodes::OnMonsterMove as u16);
         let mut pkt = WorldPacket::from_bytes(&sent[2..]);
@@ -122290,6 +122297,10 @@ mod tests {
 
         // Session A: call run_creatures_tick and collect output.
         let (mut session_a, _, recv_a) = make_session();
+        session_a.set_mmap_runtime_config_like_cpp(MMapRuntimeConfigLikeCpp {
+            enabled: false,
+            ..Default::default()
+        });
         let guid = test_creature_guid(90_001);
         register_test_creature(&mut session_a, manager.clone(), guid, 25);
         session_a.client_visible_guids_like_cpp.insert(guid);
@@ -122308,12 +122319,17 @@ mod tests {
             })
             .unwrap();
 
-        let output = session_a.run_creatures_tick();
-        // Channel must be empty — no direct send happened.
-        assert!(
-            recv_a.try_recv().is_err(),
-            "run_creatures_tick must not send directly to the channel"
-        );
+        let output = (0..32)
+            .find_map(|_| {
+                let output = session_a.run_creatures_tick();
+                // Channel must be empty — no direct send happened.
+                assert!(
+                    recv_a.try_recv().is_err(),
+                    "run_creatures_tick must not send directly to the channel"
+                );
+                (!output.packets.is_empty()).then_some(output)
+            })
+            .expect("session-owned random movement should eventually emit MonsterMove");
         // Flush and verify at least one packet arrived (MonsterMove).
         session_a.flush_runtime_output(output);
         let pkt = recv_a
@@ -126643,6 +126659,10 @@ mod tests {
 
         // ── creatures tick ─────────────────────────────────────────────────
         let (mut session_c, _, recv_c) = make_session();
+        session_c.set_mmap_runtime_config_like_cpp(MMapRuntimeConfigLikeCpp {
+            enabled: false,
+            ..Default::default()
+        });
         let guid_c = test_creature_guid(90_005);
         register_test_creature(&mut session_c, manager.clone(), guid_c, 25);
         session_c.client_visible_guids_like_cpp.insert(guid_c);
@@ -126661,16 +126681,16 @@ mod tests {
             })
             .unwrap();
 
-        let output_c = session_c.run_creatures_tick();
-        assert!(
-            recv_c.try_recv().is_err(),
-            "run_creatures_tick must not send before flush"
-        );
-        // Verify output is non-empty (wander should have produced a MonsterMove).
-        assert!(
-            !output_c.packets.is_empty(),
-            "run_creatures_tick must return at least one packet"
-        );
+        let output_c = (0..32)
+            .find_map(|_| {
+                let output = session_c.run_creatures_tick();
+                assert!(
+                    recv_c.try_recv().is_err(),
+                    "run_creatures_tick must not send before flush"
+                );
+                (!output.packets.is_empty()).then_some(output)
+            })
+            .expect("run_creatures_tick must eventually return at least one packet");
         // Flush and confirm the channel is now populated.
         session_c.flush_runtime_output(output_c);
         assert!(


### PR DESCRIPTION
Closes #76

## Summary

- Fixes the pre-existing 3.4.3 client ERROR #132 death/release crash path by making the represented death state and cemetery-list packet handling C++-anchored.
- Restores live creature visibility across login/relog and nearby grid loading.
- Fixes live creature movement splines that could serialize Rust MMap points below the client-visible terrain surface.

## C++ anchors

- WorldSession::HandleRequestCemeteryList / RequestCemeteryListResponse::Write
- Player death/repop/corpse flow references from the issue
- PathGenerator::NormalizePath and WorldObject::UpdateAllowedPositionZ for movement path Z normalization

## Validation

- PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-world world_creature_detour_path_bridge --lib
- cargo fmt --all -- --check
- PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p world-server
- git diff --check
- PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo build -p world-server --release
- Installed/restarted the running Rust world-server under PM2.
- Manual client validation: death/release crash no longer reproduces; Durotar creatures/NPCs load after login and relog; Razormane movement completes without going below terrain.

## Notes

The same runtime DB still contains invalid graveyard/condition data rows, and the C++ reference install logs comparable graveyard_zone skips with these DBs. Rust still logs no cemetery list response when the current C++ zone has no direct graveyard links, matching the C++ handler's empty-range return behavior.

Formal capture-diff vs C++ remains the strict final gate before converting this draft to ready-for-review.