### PR TITLE
[02.2][M0.1] Load CombatRatings GameTable for rating scaling

### DIFF
--- a/crates/world-server/src/main.rs
+++ b/crates/world-server/src/main.rs
@@ -2426,13 +2426,18 @@ async fn main() -> Result<ExitCode> {
         wow_data::BattlePetXpGameTableLikeCpp::load(&data_dir)
             .context("Failed to load gt/BattlePetXP.txt — check DataDir config")?,
     );
+    let combat_ratings_game_table = Arc::new(
+        wow_data::CombatRatingsGameTableLikeCpp::load(&data_dir)
+            .context("Failed to load gt/CombatRatings.txt - check DataDir config")?,
+    );
     info!(
-        "Loaded battle-pet stat DB2 stores: {} quality rows, {} breed-state rows, {} species rows, {} species-state rows; BattlePetXP rows={}",
+        "Loaded battle-pet stat DB2 stores: {} quality rows, {} breed-state rows, {} species rows, {} species-state rows; BattlePetXP rows={}; CombatRatings rows={}",
         battle_pet_breed_quality_store.len(),
         battle_pet_breed_state_store.len(),
         battle_pet_species_entry_store.len(),
         battle_pet_species_state_store.len(),
-        battle_pet_xp_game_table.len()
+        battle_pet_xp_game_table.len(),
+        combat_ratings_game_table.len()
     );
 
     let shield_block_regular_game_table = Arc::new(
@@ -4453,6 +4458,7 @@ async fn main() -> Result<ExitCode> {
         battle_pet_species_store: Some(Arc::clone(&battle_pet_species_entry_store)),
         battle_pet_species_state_store: Some(Arc::clone(&battle_pet_species_state_store)),
         battle_pet_xp_game_table: Some(Arc::clone(&battle_pet_xp_game_table)),
+        combat_ratings_game_table: Some(Arc::clone(&combat_ratings_game_table)),
         shield_block_regular_game_table: Some(Arc::clone(&shield_block_regular_game_table)),
         transmog_set_item_store: Some(Arc::clone(&transmog_set_item_store)),
         item_price_base_store: Some(Arc::clone(&item_price_base_store)),
@@ -11383,6 +11389,9 @@ async fn create_session(
     }
     if let Some(ref table) = resources.battle_pet_xp_game_table {
         session.set_battle_pet_xp_game_table(Arc::clone(table));
+    }
+    if let Some(ref table) = resources.combat_ratings_game_table {
+        session.set_combat_ratings_game_table(Arc::clone(table));
     }
     if let Some(ref table) = resources.shield_block_regular_game_table {
         session.set_shield_block_regular_game_table(Arc::clone(table));

--- a/crates/wow-data/src/game_tables.rs
+++ b/crates/wow-data/src/game_tables.rs
@@ -25,6 +25,21 @@ pub struct BattlePetXpGameTableLikeCpp {
     rows: Vec<BattlePetXpEntryLikeCpp>,
 }
 
+/// C++ `GtCombatRatingsEntry`.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct CombatRatingsEntryLikeCpp {
+    columns: [f32; CombatRatingsGameTableLikeCpp::VALUE_COLUMN_COUNT],
+}
+
+/// C++ `sCombatRatingsGameTable`.
+///
+/// GameTables are indexed by row position, not by the explicit first column.
+/// Row 0 is a default unused entry, matching `LoadGameTable`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CombatRatingsGameTableLikeCpp {
+    rows: Vec<CombatRatingsEntryLikeCpp>,
+}
+
 /// C++ `GtShieldBlockRegularEntry`.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct ShieldBlockRegularEntryLikeCpp {
@@ -137,6 +152,158 @@ impl BattlePetXpGameTableLikeCpp {
 
 pub fn battle_pet_xp_per_level_like_cpp(row: &BattlePetXpEntryLikeCpp) -> f32 {
     row.wins * row.xp
+}
+
+impl CombatRatingsEntryLikeCpp {
+    pub const WEAPON_SKILL: usize = 0;
+    pub const DEFENSE_SKILL: usize = 1;
+    pub const DODGE: usize = 2;
+    pub const PARRY: usize = 3;
+    pub const BLOCK: usize = 4;
+    pub const HIT_MELEE: usize = 5;
+    pub const HIT_RANGED: usize = 6;
+    pub const HIT_SPELL: usize = 7;
+    pub const CRIT_MELEE: usize = 8;
+    pub const CRIT_RANGED: usize = 9;
+    pub const CRIT_SPELL: usize = 10;
+    pub const HIT_TAKEN_MELEE: usize = 11;
+    pub const HIT_TAKEN_RANGED: usize = 12;
+    pub const HIT_TAKEN_SPELL: usize = 13;
+    pub const HASTE_MELEE: usize = 17;
+    pub const HASTE_RANGED: usize = 18;
+    pub const HASTE_SPELL: usize = 19;
+
+    pub fn from_columns(columns: [f32; CombatRatingsGameTableLikeCpp::VALUE_COLUMN_COUNT]) -> Self {
+        Self { columns }
+    }
+
+    pub fn column(&self, index: usize) -> f32 {
+        self.columns.get(index).copied().unwrap_or(0.0)
+    }
+}
+
+impl CombatRatingsGameTableLikeCpp {
+    pub const FILE_NAME: &'static str = "CombatRatings.txt";
+    pub const VALUE_COLUMN_COUNT: usize = 32;
+
+    pub fn load(data_dir: impl AsRef<Path>) -> Result<Self> {
+        Self::load_from_path(data_dir.as_ref().join("gt").join(Self::FILE_NAME))
+    }
+
+    pub fn load_from_path(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("GameTable file {} cannot be opened.", path.display()))?;
+        Self::parse_like_cpp(&content, path)
+    }
+
+    pub fn from_rows(rows: impl IntoIterator<Item = CombatRatingsEntryLikeCpp>) -> Self {
+        let mut stored = Vec::with_capacity(1);
+        stored.push(CombatRatingsEntryLikeCpp::default());
+        stored.extend(rows);
+        Self { rows: stored }
+    }
+
+    pub fn row(&self, level: u16) -> Option<&CombatRatingsEntryLikeCpp> {
+        self.rows.get(usize::from(level))
+    }
+
+    pub fn rating_multiplier_like_cpp(&self, level: u16, rating: u32) -> f32 {
+        self.row(level)
+            .map(|row| combat_rating_multiplier_like_cpp(row, rating))
+            .unwrap_or(1.0)
+    }
+
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    fn parse_like_cpp(content: &str, path: &Path) -> Result<Self> {
+        let mut lines = content.lines();
+        let Some(headers) = lines.next() else {
+            bail!("GameTable file {} is empty.", path.display());
+        };
+
+        let column_defs: Vec<&str> = headers
+            .split('\t')
+            .filter(|part| !part.is_empty())
+            .collect();
+        if column_defs.len().saturating_sub(1) != Self::VALUE_COLUMN_COUNT {
+            bail!(
+                "GameTable '{}' has different count of columns {} than expected by size of C++ structure ({}).",
+                path.display(),
+                column_defs.len().saturating_sub(1),
+                Self::VALUE_COLUMN_COUNT
+            );
+        }
+
+        let mut rows = vec![CombatRatingsEntryLikeCpp::default()];
+        for raw_line in lines {
+            let line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
+            let mut values: Vec<&str> = line.split('\t').collect();
+            if values.is_empty() || (values.len() == 1 && values[0].is_empty()) {
+                break;
+            }
+
+            while values.len() > 1 && values.last().is_some_and(|value| value.is_empty()) {
+                values.pop();
+            }
+
+            if values.len() <= 1 {
+                break;
+            }
+
+            if values.len() != column_defs.len() {
+                bail!("{} == {}", values.len(), column_defs.len());
+            }
+
+            let mut columns = [0.0f32; Self::VALUE_COLUMN_COUNT];
+            for (column, raw_value) in columns.iter_mut().zip(values.iter().skip(1)) {
+                *column = parse_float_like_cpp(raw_value);
+            }
+            rows.push(CombatRatingsEntryLikeCpp { columns });
+        }
+
+        Ok(Self { rows })
+    }
+}
+
+pub fn combat_rating_column_for_rating_like_cpp(
+    row: &CombatRatingsEntryLikeCpp,
+    rating: u32,
+) -> f32 {
+    match rating {
+        0 => row.column(CombatRatingsEntryLikeCpp::WEAPON_SKILL),
+        1 => row.column(CombatRatingsEntryLikeCpp::DEFENSE_SKILL),
+        2 => row.column(CombatRatingsEntryLikeCpp::DODGE),
+        3 => row.column(CombatRatingsEntryLikeCpp::PARRY),
+        4 => row.column(CombatRatingsEntryLikeCpp::BLOCK),
+        5 => row.column(CombatRatingsEntryLikeCpp::HIT_MELEE),
+        6 => row.column(CombatRatingsEntryLikeCpp::HIT_RANGED),
+        7 => row.column(CombatRatingsEntryLikeCpp::HIT_SPELL),
+        8 => row.column(CombatRatingsEntryLikeCpp::CRIT_MELEE),
+        9 => row.column(CombatRatingsEntryLikeCpp::CRIT_RANGED),
+        10 => row.column(CombatRatingsEntryLikeCpp::CRIT_SPELL),
+        11 => row.column(CombatRatingsEntryLikeCpp::HIT_TAKEN_MELEE),
+        12 => row.column(CombatRatingsEntryLikeCpp::HIT_TAKEN_RANGED),
+        13 => row.column(CombatRatingsEntryLikeCpp::HIT_TAKEN_SPELL),
+        // Mirrors C++ `GetGameTableColumnForCombatRating`, including the
+        // crit-taken cases intentionally selecting `HitTakenMelee`.
+        14..=16 => row.column(CombatRatingsEntryLikeCpp::HIT_TAKEN_MELEE),
+        17 => row.column(CombatRatingsEntryLikeCpp::HASTE_MELEE),
+        18 => row.column(CombatRatingsEntryLikeCpp::HASTE_RANGED),
+        19 => row.column(CombatRatingsEntryLikeCpp::HASTE_SPELL),
+        _ => 1.0,
+    }
+}
+
+pub fn combat_rating_multiplier_like_cpp(row: &CombatRatingsEntryLikeCpp, rating: u32) -> f32 {
+    let value = combat_rating_column_for_rating_like_cpp(row, rating);
+    if value == 0.0 { 1.0 } else { 1.0 / value }
 }
 
 impl ShieldBlockRegularGameTableLikeCpp {
@@ -296,6 +463,25 @@ mod tests {
         dir
     }
 
+    fn write_temp_combat_ratings(content: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        dir.push(format!(
+            "rustycore-combat-ratings-{}-{}",
+            std::process::id(),
+            unique
+        ));
+        fs::create_dir_all(dir.join("gt")).expect("create temp gt dir");
+        let path = dir
+            .join("gt")
+            .join(CombatRatingsGameTableLikeCpp::FILE_NAME);
+        fs::write(&path, content).expect("write temp CombatRatings");
+        dir
+    }
+
     #[test]
     fn battle_pet_xp_game_table_loads_rows_by_position_not_id_like_cpp() {
         let dir = write_temp_battle_pet_xp("ID\tWins\tXp\r\n23\t2\t50\r\n99\t3\t40\r\n\r\n");
@@ -325,6 +511,91 @@ mod tests {
     fn battle_pet_xp_game_table_rejects_wrong_column_count_like_cpp() {
         let dir = write_temp_battle_pet_xp("ID\tWins\n1\t2\n");
         let err = BattlePetXpGameTableLikeCpp::load(&dir).expect_err("column mismatch");
+
+        assert!(err.to_string().contains("different count of columns"));
+
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn combat_ratings_game_table_loads_rows_by_level_position_like_cpp() {
+        let dir = write_temp_combat_ratings(
+            "Level\tWeaponSkill\tDefenseSkill\tDodge\tParry\tBlock\tHitMelee\tHitRanged\tHitSpell\tCritMelee\tCritRanged\tCritSpell\tHitTakenMelee\tHitTakenRanged\tHitTakenSpell\tCritTakenMelee\tCritTakenRanged\tCritTakenSpell\tHasteMelee\tHasteRanged\tHasteSpell\tUnknown0\tUnknown1\tUnknown2\tUnknown3\tUnknown4\tUnknown5\tUnknown6\tUnknown7\tUnknown8\tUnknown9\tUnknown10\tUnknown11\r\n\
+             80\t8.197496\t4.918498\t45.250187\t45.250187\t16.394995\t32.789989\t32.789989\t26.231993\t45.905987\t45.905987\t45.905987\t32.789989\t32.789989\t26.231993\t94.271225\t94.271225\t94.271225\t32.789989\t32.789989\t32.789989\t8.197496\t8.197496\t8.197496\t8.197496\t15.395300\t0\t0\t0\t0\t0\t0\t0\r\n",
+        );
+        let table = CombatRatingsGameTableLikeCpp::load(&dir).expect("load table");
+
+        assert_eq!(table.len(), 2);
+        assert_eq!(table.row(0), Some(&CombatRatingsEntryLikeCpp::default()));
+        assert_eq!(table.row(80), None);
+        let row = table.row(1).expect("first data row is positional");
+        assert_eq!(combat_rating_column_for_rating_like_cpp(row, 8), 45.905987);
+        assert_eq!(
+            combat_rating_column_for_rating_like_cpp(row, 14),
+            32.789989,
+            "C++ maps CR_CRIT_TAKEN_* to HitTakenMelee in GetGameTableColumnForCombatRating"
+        );
+        assert!((combat_rating_multiplier_like_cpp(row, 8) - (1.0 / 45.905987)).abs() < 0.00001);
+        assert_eq!(
+            combat_rating_multiplier_like_cpp(row, 23),
+            1.0,
+            "ratings without a C++ table column use the default multiplier"
+        );
+
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn combat_ratings_fixture_level_80_matches_cpp_columns() {
+        let data_dir = Path::new("/home/server/woltk-server-core/Data");
+        let path = data_dir
+            .join("gt")
+            .join(CombatRatingsGameTableLikeCpp::FILE_NAME);
+        if !path.exists() {
+            eprintln!(
+                "Skipping test: CombatRatings fixture not found at {}",
+                path.display()
+            );
+            return;
+        }
+
+        let table = CombatRatingsGameTableLikeCpp::load(data_dir).expect("load CombatRatings");
+        let row = table.row(80).expect("level 80 row");
+        assert!((combat_rating_column_for_rating_like_cpp(row, 8) - 45.905987).abs() < 0.00001);
+        assert!((table.rating_multiplier_like_cpp(80, 2) - (1.0 / 45.250187)).abs() < 0.00001);
+        assert!((table.rating_multiplier_like_cpp(80, 4) - (1.0 / 16.394995)).abs() < 0.00001);
+    }
+
+    #[test]
+    fn combat_ratings_fixture_level_80_rating_bonus_is_table_derived_like_cpp() {
+        let data_dir = Path::new("/home/server/woltk-server-core/Data");
+        let path = data_dir
+            .join("gt")
+            .join(CombatRatingsGameTableLikeCpp::FILE_NAME);
+        if !path.exists() {
+            eprintln!(
+                "Skipping test: CombatRatings fixture not found at {}",
+                path.display()
+            );
+            return;
+        }
+
+        let table = CombatRatingsGameTableLikeCpp::load(data_dir).expect("load CombatRatings");
+        let crit_rating = 207.0f32;
+        let crit_bonus = crit_rating * table.rating_multiplier_like_cpp(80, 8);
+
+        assert!((crit_bonus - (207.0 / 45.905987)).abs() < 0.00001);
+        assert_eq!(
+            crit_rating * table.rating_multiplier_like_cpp(80, 23),
+            207.0,
+            "C++ ratings without a CombatRatings column keep the default 1.0 multiplier"
+        );
+    }
+
+    #[test]
+    fn combat_ratings_game_table_rejects_wrong_column_count_like_cpp() {
+        let dir = write_temp_combat_ratings("Level\tWeaponSkill\n1\t1\n");
+        let err = CombatRatingsGameTableLikeCpp::load(&dir).expect_err("column mismatch");
 
         assert!(err.to_string().contains("different count of columns"));
 

--- a/crates/wow-data/src/lib.rs
+++ b/crates/wow-data/src/lib.rs
@@ -187,8 +187,10 @@ pub use faction_change::{
     FactionChangeSideLikeCpp, FactionChangeStoreLikeCpp, FactionChangeValidationErrorLikeCpp,
 };
 pub use game_tables::{
-    BattlePetXpEntryLikeCpp, BattlePetXpGameTableLikeCpp, ShieldBlockRegularEntryLikeCpp,
+    BattlePetXpEntryLikeCpp, BattlePetXpGameTableLikeCpp, CombatRatingsEntryLikeCpp,
+    CombatRatingsGameTableLikeCpp, ShieldBlockRegularEntryLikeCpp,
     ShieldBlockRegularGameTableLikeCpp, battle_pet_xp_per_level_like_cpp,
+    combat_rating_column_for_rating_like_cpp, combat_rating_multiplier_like_cpp,
     shield_block_regular_column_for_quality_like_cpp,
 };
 pub use game_tele::{

--- a/crates/wow-network/src/accept.rs
+++ b/crates/wow-network/src/accept.rs
@@ -213,6 +213,7 @@ pub struct SessionResources {
     pub battle_pet_species_store: Option<Arc<wow_data::BattlePetSpeciesStore>>,
     pub battle_pet_species_state_store: Option<Arc<wow_data::BattlePetSpeciesStateStore>>,
     pub battle_pet_xp_game_table: Option<Arc<wow_data::BattlePetXpGameTableLikeCpp>>,
+    pub combat_ratings_game_table: Option<Arc<wow_data::CombatRatingsGameTableLikeCpp>>,
     pub shield_block_regular_game_table: Option<Arc<wow_data::ShieldBlockRegularGameTableLikeCpp>>,
     pub transmog_set_item_store: Option<Arc<wow_data::TransmogSetItemStore>>,
     pub item_price_base_store: Option<Arc<wow_data::ItemPriceBaseStore>>,

--- a/crates/wow-world/src/handlers/character.rs
+++ b/crates/wow-world/src/handlers/character.rs
@@ -12526,8 +12526,14 @@ impl WorldSession {
         let mut combat_ratings = [0i32; 32];
         combat_ratings[..25].copy_from_slice(&gear_combat_ratings);
 
-        // ── Percentage calculations (WotLK level 80 formulas) ──
-        let lvl = level as f32;
+        // ── Percentage calculations (WotLK represented formulas) ──
+        let combat_rating_bonus_like_cpp = |rating: u32| -> f32 {
+            gear_combat_ratings
+                .get(usize::try_from(rating).unwrap_or(usize::MAX))
+                .copied()
+                .unwrap_or(0) as f32
+                * self.combat_rating_multiplier_like_cpp(level, rating)
+        };
 
         // Crit from AGI: class-dependent AGI-to-crit ratio at level 80
         let agi_crit_ratio = match class {
@@ -12541,13 +12547,8 @@ impl WorldSession {
         };
         let crit_from_agi = total_agi as f32 / agi_crit_ratio;
 
-        // Crit from rating: ~45.91 rating per 1% at level 80
-        let crit_rating_per_pct = if lvl >= 80.0 {
-            45.91
-        } else {
-            (lvl * 0.574).max(1.0)
-        };
-        let crit_from_rating = gear_combat_ratings[8] as f32 / crit_rating_per_pct as f32;
+        // C++ `Player::GetRatingBonusValue(CR_CRIT_MELEE)`.
+        let crit_from_rating = combat_rating_bonus_like_cpp(8);
 
         // Base crit varies by class (roughly)
         let base_crit = match class {
@@ -12571,7 +12572,7 @@ impl WorldSession {
             _ => 160.0, // Non-casters
         };
         let spell_crit_from_int = total_int as f32 / int_crit_ratio;
-        let spell_crit_from_rating = gear_combat_ratings[10] as f32 / crit_rating_per_pct as f32;
+        let spell_crit_from_rating = combat_rating_bonus_like_cpp(10);
         let base_spell_crit = match class {
             8 => 0.91,  // Mage
             9 => 1.70,  // Warlock
@@ -12586,33 +12587,18 @@ impl WorldSession {
 
         // Dodge from AGI + rating
         let dodge_from_agi = total_agi as f32 / agi_crit_ratio; // simplified: same ratio
-        let dodge_rating_per_pct = if lvl >= 80.0 {
-            39.35
-        } else {
-            (lvl * 0.492).max(1.0)
-        };
-        let dodge_from_rating = gear_combat_ratings[2] as f32 / dodge_rating_per_pct as f32;
+        let dodge_from_rating = combat_rating_bonus_like_cpp(2);
         let dodge_pct = (dodge_from_agi + dodge_from_rating + 5.0).min(100.0); // 5% base
 
         // Parry from STR + rating (for classes that can parry)
-        let parry_rating_per_pct = if lvl >= 80.0 {
-            49.18
-        } else {
-            (lvl * 0.615).max(1.0)
-        };
-        let parry_from_rating = gear_combat_ratings[3] as f32 / parry_rating_per_pct as f32;
+        let parry_from_rating = combat_rating_bonus_like_cpp(3);
         let parry_pct = match class {
             1 | 2 | 4 | 6 => (5.0 + parry_from_rating).min(100.0), // 5% base for melee
             _ => parry_from_rating.min(100.0),
         };
 
         // Block from rating (only shield users)
-        let block_rating_per_pct = if lvl >= 80.0 {
-            16.39
-        } else {
-            (lvl * 0.205).max(1.0)
-        };
-        let block_from_rating = gear_combat_ratings[4] as f32 / block_rating_per_pct as f32;
+        let block_from_rating = combat_rating_bonus_like_cpp(4);
         let block_pct = match class {
             1 | 2 | 7 => (5.0 + block_from_rating).min(100.0), // 5% base
             _ => block_from_rating.min(100.0),
@@ -12644,13 +12630,7 @@ impl WorldSession {
         };
 
         // ── Expertise from rating ──
-        // CombatRating::Expertise = index 23, 15.77 rating per expertise at level 80
-        let expertise_rating_per_pct = if lvl >= 80.0 {
-            15.77
-        } else {
-            (lvl * 0.197).max(1.0)
-        };
-        let expertise_value = gear_combat_ratings[23] as f32 / expertise_rating_per_pct;
+        let expertise_value = combat_rating_bonus_like_cpp(23);
 
         // ── Dodge/Parry from attribute (for tooltip display) ──
         let dodge_from_attr = dodge_from_agi;

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -63,10 +63,10 @@ use wow_data::{
     BankBagSlotPricesStore, BattlePetBreedQualityStore, BattlePetBreedStateStore,
     BattlePetSpeciesStateStore, BattlePetSpeciesStore, BattlePetXpGameTableLikeCpp,
     BattlemasterListStore, ChrSpecializationStore, CinematicSequencesStore,
-    ConditionEntriesByTypeStore, CreatureAddonStoreLikeCpp, CreatureBaseStatsStoreLikeCpp,
-    CreatureClassificationHealthRatesLikeCpp, CreatureDifficultyStoreLikeCpp,
-    CreatureDisplayInfoExtraStore, CreatureDisplayInfoStore, CreatureEquipmentStoreLikeCpp,
-    CreatureModelDataStore, CreatureTemplateLifecycleStoreLikeCpp,
+    CombatRatingsGameTableLikeCpp, ConditionEntriesByTypeStore, CreatureAddonStoreLikeCpp,
+    CreatureBaseStatsStoreLikeCpp, CreatureClassificationHealthRatesLikeCpp,
+    CreatureDifficultyStoreLikeCpp, CreatureDisplayInfoExtraStore, CreatureDisplayInfoStore,
+    CreatureEquipmentStoreLikeCpp, CreatureModelDataStore, CreatureTemplateLifecycleStoreLikeCpp,
     CreatureTemplateMountStoreLikeCpp, CurrencyTypesEntry, CurrencyTypesStore,
     DISABLE_TYPE_BATTLEGROUND, DISABLE_TYPE_MAP, DifficultyStore, DisableMgrLikeCpp,
     DisableWorldObjectRefLikeCpp, DungeonEncounterStore, DurabilityCostsStore,
@@ -3769,6 +3769,9 @@ pub struct WorldSession {
     battle_pet_species_state_store: Option<Arc<BattlePetSpeciesStateStore>>,
     battle_pet_xp_game_table: Option<Arc<BattlePetXpGameTableLikeCpp>>,
 
+    // C++ `sCombatRatingsGameTable` used by `Player::GetRatingMultiplier`.
+    combat_ratings_game_table: Option<Arc<CombatRatingsGameTableLikeCpp>>,
+
     // C++ `sShieldBlockRegularGameTable` used by `ItemTemplate::GetShieldBlockValue`.
     shield_block_regular_game_table: Option<Arc<ShieldBlockRegularGameTableLikeCpp>>,
 
@@ -5744,6 +5747,7 @@ impl WorldSession {
             battle_pet_species_store: None,
             battle_pet_species_state_store: None,
             battle_pet_xp_game_table: None,
+            combat_ratings_game_table: None,
             shield_block_regular_game_table: None,
             transmog_set_item_store: None,
             item_price_base_store: None,
@@ -13886,11 +13890,22 @@ impl WorldSession {
         self.battle_pet_xp_game_table = Some(table);
     }
 
+    pub fn set_combat_ratings_game_table(&mut self, table: Arc<CombatRatingsGameTableLikeCpp>) {
+        self.combat_ratings_game_table = Some(table);
+    }
+
     pub fn set_shield_block_regular_game_table(
         &mut self,
         table: Arc<ShieldBlockRegularGameTableLikeCpp>,
     ) {
         self.shield_block_regular_game_table = Some(table);
+    }
+
+    pub(crate) fn combat_rating_multiplier_like_cpp(&self, level: u8, rating: u32) -> f32 {
+        self.combat_ratings_game_table
+            .as_ref()
+            .map(|table| table.rating_multiplier_like_cpp(u16::from(level), rating))
+            .unwrap_or(1.0)
     }
 
     pub(crate) fn battle_pet_calculate_stats_like_cpp(
@@ -53299,6 +53314,33 @@ mod tests {
         );
 
         (session, pkt_tx, send_rx)
+    }
+
+    #[test]
+    fn combat_rating_multiplier_uses_gt_table_like_cpp() {
+        let (mut session, _, _) = make_session();
+        assert_eq!(session.combat_rating_multiplier_like_cpp(80, 8), 1.0);
+
+        let mut columns = [0.0f32; wow_data::CombatRatingsGameTableLikeCpp::VALUE_COLUMN_COUNT];
+        columns[wow_data::CombatRatingsEntryLikeCpp::CRIT_MELEE] = 45.905987;
+        columns[wow_data::CombatRatingsEntryLikeCpp::DODGE] = 45.250187;
+        session.set_combat_ratings_game_table(Arc::new(
+            wow_data::CombatRatingsGameTableLikeCpp::from_rows([
+                wow_data::CombatRatingsEntryLikeCpp::from_columns(columns),
+            ]),
+        ));
+
+        assert!(
+            (session.combat_rating_multiplier_like_cpp(1, 8) - (1.0 / 45.905987)).abs() < 0.00001
+        );
+        assert!(
+            (session.combat_rating_multiplier_like_cpp(1, 2) - (1.0 / 45.250187)).abs() < 0.00001
+        );
+        assert_eq!(
+            session.combat_rating_multiplier_like_cpp(1, 23),
+            1.0,
+            "C++ ratings without a CombatRatings column use default multiplier"
+        );
     }
 
     #[test]

--- a/docs/migration/STATE.md
+++ b/docs/migration/STATE.md
@@ -109,7 +109,7 @@ observable mutation · **ABSENT**.
 |---|---|---|
 | Terrain height (GetHeightZ / ground correction) | **ABSENT** | creatures spawn at DB Z; no ground snap |
 | VMap line-of-sight | **STUB** (returns `true`) | `world_object.rs:1551`; spells/pathing tunnel walls |
-| Stat-formula GameTables (Gt* crit/dodge/HP) | **ABSENT** | combat/stat scaling unanchored |
+| Stat-formula GameTables (Gt* crit/dodge/HP) | **PARTIAL** | `CombatRatings.txt` now drives represented crit/dodge/parry/block rating scaling; HP/MP/regen/class stat tables still incomplete |
 | `ChrClasses`, `FactionTemplate`, `CharBaseInfo` stores | **ABSENT** | class scaling hardcoded; **NPC hostility checks broken** |
 | `SpellPower`/`SpellCastTimes`/`SpellCooldowns` stores | **PARTIAL** | loaded into represented spell metadata for normal difficulty; full C++ modifier and runtime integration still incomplete |
 | DBC/DB2 store coverage | **~110 / ~325 (34%)** | `cpp-db2-stores.tsv` |


### PR DESCRIPTION
Closes #73

## Summary

- Load `gt/CombatRatings.txt` as a C++-style GameTable with positional row indexing and a 32-column schema check.
- Add C++-anchored `rating_multiplier(level, rating)` handling using `Player::GetGameTableColumnForCombatRating` / `GetRatingMultiplier` behavior.
- Replace represented hardcoded crit/dodge/parry/block/expertise rating divisors in character stat updates with table-derived multipliers.
- Wire the CombatRatings GameTable through `world-server` session resources and document the partial stat GameTable coverage in `STATE.md`.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check HEAD`
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-data combat_ratings --lib`
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-world combat_rating_multiplier_uses_gt_table_like_cpp --lib`
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p world-server`
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p capture-diff`

Live capture check:

- Rust capture: `/tmp/rustycore-issue73-combat-ratings-20260630T190349Z/rust-s2c-00000146-counter54-0x27CB-UpdateObject-len506.bin`
- C++ golden: `crates/capture-diff/flows/login/cpp.pkt`
- Verified identical 128-byte `CombatRatings[32]` block for Luqedos: Rust offset `378`, C++ offset `42999`.
