### PR TITLE
[04] Add static VMap line-of-sight seam

### DIFF
--- a/crates/wow-map/src/lib.rs
+++ b/crates/wow-map/src/lib.rs
@@ -10,6 +10,7 @@ pub mod personal_phase;
 pub mod pool;
 pub mod spawn;
 pub mod terrain;
+pub mod vmap;
 
 use std::fmt;
 
@@ -78,6 +79,10 @@ pub use spawn::{
     SpawnGroupTemplateData, SpawnId, SpawnMapKey, SpawnObjectType, SpawnPosition, SpawnStore,
 };
 pub use terrain::{GridMapTerrain, VMAP_INVALID_HEIGHT_VALUE};
+pub use vmap::{
+    SharedStaticVMapLineOfSightProvider, StaticVMapLineOfSightProvider, VMapLineOfSightEndpoint,
+    VMapLineOfSightQuery, VMapPosition,
+};
 
 /// Key used by `MapManager` for world and instance map lookup.
 ///

--- a/crates/wow-map/src/terrain.rs
+++ b/crates/wow-map/src/terrain.rs
@@ -2,16 +2,19 @@
 //!
 //! Faithful port of the height-query half of C++ `TerrainInfo` (`TerrainMgr.cpp`)
 //! for WoW 3.4.3: it owns the per-grid `.map` tiles for one map and answers
-//! `GetGridHeight` / `GetStaticHeight` / `Map::GetHeight`. It plugs into [`Map`]
+//! `GetGridHeight` / `GetStaticHeight` / `Map::GetHeight`, plus a narrow static
+//! VMAP line-of-sight hook for `Map::isInLineOfSight`. It plugs into [`Map`]
 //! through the [`TerrainGridLoader`] + [`MapWorldObjectEnvironment`] seams so the
 //! `WorldObject -> WorldObjectEnvironment -> Map -> terrain` chain returns real
-//! ground heights instead of the [`NoopTerrainGridLoader`] sentinel.
+//! ground/LOS answers instead of the [`NoopTerrainGridLoader`] sentinel.
 //!
-//! Scope (issue [03]/#15): **grid terrain height only**. VMap, liquid level, the
-//! dynamic GO-floor tree, and mmaps are out of scope here — exactly the branches
-//! that, in C++, would otherwise contribute to `GetStaticHeight`/`GetGameObjectFloor`.
-//! Those collapse to "no value" the same way C++ does when VMap/liquid are
-//! disabled, so the height returned is the raw `.map` surface (+ holes).
+//! Scope: grid terrain height is file-backed. Static VMAP LOS is delegated to a
+//! provider seam because the BIH/VMO parser is not in this slice. Liquid level,
+//! the dynamic GO-floor/LOS tree, and mmaps are out of scope here - exactly the
+//! branches that, in C++, would otherwise contribute to
+//! `GetStaticHeight`/`GetGameObjectFloor`/dynamic `LINEOFSIGHT_CHECK_GOBJECT`.
+//! Missing providers collapse to "no value" or clear LOS the same way C++ does
+//! when VMAP/liquid/GO LOS are disabled.
 //!
 //! [`Map`]: crate::map::Map
 //! [`NoopTerrainGridLoader`]: crate::map::NoopTerrainGridLoader
@@ -25,6 +28,7 @@ use wow_entities::{INVALID_HEIGHT, LineOfSightQuery, WorldObject, WorldObjectHei
 
 use crate::grid_map::GridMap;
 use crate::map::{MapWorldObjectEnvironment, TerrainGridLoader};
+use crate::vmap::{SharedStaticVMapLineOfSightProvider, VMapLineOfSightQuery};
 
 // C++ Grids/GridDefines.h
 const SIZE_OF_GRIDS: f32 = 533.333_3;
@@ -50,6 +54,7 @@ const GROUND_HEIGHT_TOLERANCE: f32 = 0.05;
 pub struct GridMapTerrain {
     map_id: u32,
     data_dir: PathBuf,
+    static_vmap_los: Option<SharedStaticVMapLineOfSightProvider>,
     /// Key = raw tile index `(gx, gy)`; value `Some` = loaded, `None` = tried and
     /// absent/invalid (cached negative so we do not re-stat every query). An
     /// absent key means "not yet attempted".
@@ -65,8 +70,20 @@ impl GridMapTerrain {
         Self {
             map_id,
             data_dir: data_dir.as_ref().to_path_buf(),
+            static_vmap_los: None,
             grids: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Attach a static VMAP LOS provider. Without one, C++ `VMapManager2`'s
+    /// disabled/missing-tree behavior is clear LOS.
+    #[must_use]
+    pub fn with_static_vmap_line_of_sight(
+        mut self,
+        provider: SharedStaticVMapLineOfSightProvider,
+    ) -> Self {
+        self.static_vmap_los = Some(provider);
+        self
     }
 
     pub fn map_id(&self) -> u32 {
@@ -151,10 +168,23 @@ impl TerrainGridLoader for GridMapTerrain {
 }
 
 impl MapWorldObjectEnvironment for GridMapTerrain {
-    fn line_of_sight(&self, _query: LineOfSightQuery<'_>) -> bool {
-        // No VMap/dynamic tree in scope: C++ `Map::isInLineOfSight` with VMap
-        // disabled reports clear LOS. Real occlusion arrives with the VMap port.
-        true
+    fn line_of_sight(&self, query: LineOfSightQuery<'_>) -> bool {
+        // C++ `Map::isInLineOfSight` checks static VMAP first:
+        // `VMapManager2::isInLineOfSight` returns true when LOS is disabled, the
+        // map tree is missing, or the converted endpoints are identical. The
+        // dynamic GO tree branch remains unported; `query.options.check_dynamic`
+        // is intentionally not treated as geometry evidence here.
+        let Some(static_vmap_los) = &self.static_vmap_los else {
+            return true;
+        };
+
+        let vmap_query =
+            VMapLineOfSightQuery::from_world(self.map_id, query.from.position, query.to.position);
+        if vmap_query.same_internal_position_like_cpp() {
+            return true;
+        }
+
+        static_vmap_los.is_in_line_of_sight(vmap_query)
     }
 
     fn map_height(
@@ -182,10 +212,43 @@ impl MapWorldObjectEnvironment for GridMapTerrain {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
     use wow_constants::{TypeId, TypeMask};
+    use wow_entities::LineOfSightOptions;
 
     const Z_PROBE: f32 = 100_000.0; // MAX_HEIGHT-ish: always "above ground".
+
+    #[derive(Debug)]
+    struct RecordingStaticVMapLos {
+        result: bool,
+        calls: std::sync::Mutex<Vec<VMapLineOfSightQuery>>,
+    }
+
+    impl RecordingStaticVMapLos {
+        fn new(result: bool) -> Self {
+            Self {
+                result,
+                calls: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl crate::vmap::StaticVMapLineOfSightProvider for RecordingStaticVMapLos {
+        fn is_in_line_of_sight(&self, query: VMapLineOfSightQuery) -> bool {
+            self.calls
+                .lock()
+                .expect("recording vmap LOS calls poisoned")
+                .push(query);
+            self.result
+        }
+    }
+
+    fn player_world_object_at(position: Position) -> WorldObject {
+        let mut object = WorldObject::new(false, TypeId::Player, TypeMask::PLAYER | TypeMask::UNIT);
+        object.relocate(position);
+        object
+    }
 
     /// Unique scratch dir per test; cleaned on drop.
     struct TempMapsDir(PathBuf);
@@ -308,6 +371,98 @@ mod tests {
             WorldObjectHeightQuery::default(),
         );
         assert!((h - 33.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn line_of_sight_without_vmap_provider_reports_clear_like_cpp_disabled_vmap() {
+        let dir = TempMapsDir::new();
+        let terrain = GridMapTerrain::new(0, &dir.0);
+        let source = player_world_object_at(Position::new(1.0, 2.0, 3.0, 0.0));
+        let query = LineOfSightQuery::to_position_like_cpp(
+            &source,
+            Position::new(4.0, 5.0, 6.0, 0.0),
+            LineOfSightOptions::default(),
+        );
+
+        assert!(terrain.line_of_sight(query));
+    }
+
+    #[test]
+    fn line_of_sight_delegates_clear_result_to_static_vmap_provider_like_cpp() {
+        let dir = TempMapsDir::new();
+        let provider = Arc::new(RecordingStaticVMapLos::new(true));
+        let shared_provider: crate::vmap::SharedStaticVMapLineOfSightProvider = provider.clone();
+        let terrain =
+            GridMapTerrain::new(571, &dir.0).with_static_vmap_line_of_sight(shared_provider);
+        let source = player_world_object_at(Position::new(10.0, 20.0, 30.0, 0.0));
+        let query = LineOfSightQuery::to_position_like_cpp(
+            &source,
+            Position::new(15.0, 25.0, 35.0, 0.0),
+            LineOfSightOptions::default(),
+        );
+
+        assert!(terrain.line_of_sight(query));
+        let calls = provider
+            .calls
+            .lock()
+            .expect("recording vmap LOS calls poisoned");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].map_id, 571);
+        assert_eq!(calls[0].from.world.x, 10.0);
+        assert_eq!(calls[0].from.world.y, 20.0);
+        assert_eq!(calls[0].from.world.z, 30.0);
+        assert_eq!(calls[0].to.world.x, 15.0);
+        assert_eq!(calls[0].to.world.y, 25.0);
+        assert_eq!(calls[0].to.world.z, 35.0);
+    }
+
+    #[test]
+    fn line_of_sight_delegates_blocking_geometry_to_static_vmap_provider_like_cpp() {
+        let dir = TempMapsDir::new();
+        let provider = Arc::new(RecordingStaticVMapLos::new(false));
+        let shared_provider: crate::vmap::SharedStaticVMapLineOfSightProvider = provider.clone();
+        let terrain =
+            GridMapTerrain::new(0, &dir.0).with_static_vmap_line_of_sight(shared_provider);
+        let source = player_world_object_at(Position::new(-1.0, -2.0, 3.0, 0.0));
+        let query = LineOfSightQuery::to_position_like_cpp(
+            &source,
+            Position::new(-4.0, -5.0, 6.0, 0.0),
+            LineOfSightOptions::default(),
+        );
+
+        assert!(!terrain.line_of_sight(query));
+        assert_eq!(
+            provider
+                .calls
+                .lock()
+                .expect("recording vmap LOS calls poisoned")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn line_of_sight_same_endpoint_skips_static_vmap_provider_like_cpp() {
+        let dir = TempMapsDir::new();
+        let provider = Arc::new(RecordingStaticVMapLos::new(false));
+        let shared_provider: crate::vmap::SharedStaticVMapLineOfSightProvider = provider.clone();
+        let terrain =
+            GridMapTerrain::new(0, &dir.0).with_static_vmap_line_of_sight(shared_provider);
+        let source = player_world_object_at(Position::new(7.0, 8.0, 9.0, 0.0));
+        let query = LineOfSightQuery::to_position_like_cpp(
+            &source,
+            Position::new(7.0, 8.0, 9.0, 2.0),
+            LineOfSightOptions::default(),
+        );
+
+        assert!(terrain.line_of_sight(query));
+        assert!(
+            provider
+                .calls
+                .lock()
+                .expect("recording vmap LOS calls poisoned")
+                .is_empty()
+        );
     }
 
     /// Real-data smoke check (not run in CI — needs the server's `DataDir`).

--- a/crates/wow-map/src/vmap.rs
+++ b/crates/wow-map/src/vmap.rs
@@ -1,0 +1,134 @@
+//! Static VMap line-of-sight adapter.
+//!
+//! C++ anchors:
+//! - `Map::isInLineOfSight` (`server/game/Maps/Map.cpp`) checks static VMAP
+//!   first and rejects immediately when it is blocked.
+//! - `VMapManager2::isInLineOfSight` (`common/Collision/Management/VMapManager2.cpp`)
+//!   converts world coordinates to the VMAP internal representation before
+//!   querying `StaticMapTree::isInLineOfSight`.
+//! - `StaticMapTree::isInLineOfSight` (`common/Collision/Maps/MapTree.cpp`)
+//!   returns false when a BIH ray intersection hits blocking geometry.
+
+use std::fmt;
+
+use wow_core::Position;
+
+/// C++ `VMapManager2::convertPositionToInternalRep`: half of the 64x64 grid map.
+const VMAP_INTERNAL_MID: f32 = 0.5 * 64.0 * 533.333_333_33;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VMapPosition {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+impl VMapPosition {
+    #[must_use]
+    pub const fn from_world(position: Position) -> Self {
+        Self {
+            x: position.x,
+            y: position.y,
+            z: position.z,
+        }
+    }
+
+    #[must_use]
+    pub fn to_internal_rep_like_cpp(self) -> Self {
+        Self {
+            x: VMAP_INTERNAL_MID - self.x,
+            y: VMAP_INTERNAL_MID - self.y,
+            z: self.z,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VMapLineOfSightEndpoint {
+    pub world: VMapPosition,
+    pub internal: VMapPosition,
+}
+
+impl VMapLineOfSightEndpoint {
+    #[must_use]
+    pub fn from_world(position: Position) -> Self {
+        let world = VMapPosition::from_world(position);
+        Self {
+            world,
+            internal: world.to_internal_rep_like_cpp(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VMapLineOfSightQuery {
+    pub map_id: u32,
+    pub from: VMapLineOfSightEndpoint,
+    pub to: VMapLineOfSightEndpoint,
+}
+
+impl VMapLineOfSightQuery {
+    #[must_use]
+    pub fn from_world(map_id: u32, from: Position, to: Position) -> Self {
+        Self {
+            map_id,
+            from: VMapLineOfSightEndpoint::from_world(from),
+            to: VMapLineOfSightEndpoint::from_world(to),
+        }
+    }
+
+    #[must_use]
+    pub fn same_internal_position_like_cpp(&self) -> bool {
+        self.from.internal == self.to.internal
+    }
+}
+
+/// Static VMAP LOS provider. This is intentionally narrower than the full C++
+/// `VMapManager2`: loading, model ownership, height, liquid, and object-hit
+/// position remain separate future slices.
+pub trait StaticVMapLineOfSightProvider: fmt::Debug + Send + Sync {
+    fn is_in_line_of_sight(&self, query: VMapLineOfSightQuery) -> bool;
+}
+
+pub type SharedStaticVMapLineOfSightProvider = std::sync::Arc<dyn StaticVMapLineOfSightProvider>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vmap_los_query_converts_world_coordinates_to_internal_rep_like_cpp() {
+        let query = VMapLineOfSightQuery::from_world(
+            0,
+            Position::new(100.0, -200.0, 30.0, 1.0),
+            Position::new(-50.0, 25.0, 40.0, 2.0),
+        );
+
+        assert_eq!(query.map_id, 0);
+        assert_eq!(
+            query.from.world,
+            VMapPosition {
+                x: 100.0,
+                y: -200.0,
+                z: 30.0
+            }
+        );
+        assert!((query.from.internal.x - (VMAP_INTERNAL_MID - 100.0)).abs() < f32::EPSILON);
+        assert!((query.from.internal.y - (VMAP_INTERNAL_MID + 200.0)).abs() < f32::EPSILON);
+        assert_eq!(query.from.internal.z, 30.0);
+        assert!((query.to.internal.x - (VMAP_INTERNAL_MID + 50.0)).abs() < f32::EPSILON);
+        assert!((query.to.internal.y - (VMAP_INTERNAL_MID - 25.0)).abs() < f32::EPSILON);
+        assert_eq!(query.to.internal.z, 40.0);
+    }
+
+    #[test]
+    fn same_internal_position_matches_cpp_vmap_manager_short_circuit() {
+        let query = VMapLineOfSightQuery::from_world(
+            1,
+            Position::new(1.0, 2.0, 3.0, 0.0),
+            Position::new(1.0, 2.0, 3.0, 5.0),
+        );
+
+        assert!(query.same_internal_position_like_cpp());
+    }
+}

--- a/crates/wow-world/src/map_manager.rs
+++ b/crates/wow-world/src/map_manager.rs
@@ -21,7 +21,7 @@ use wow_entities::{
     PointMovementAction, PointMovementInform, RotateMovementUpdate, Z_OFFSET_FIND_HEIGHT,
     allowed_position_z_from_ground_like_cpp,
 };
-use wow_map::GridMapTerrain;
+use wow_map::{GridMapTerrain, SharedStaticVMapLineOfSightProvider};
 use wow_movement::generators::CreatureRandomMovementType as MovementCreatureRandomMovementType;
 use wow_movement::{
     MoveSpline, MoveSplineInit, MoveSplineLaunchInput, MoveSplineStopInput, MoveSplineStopResult,
@@ -3249,25 +3249,54 @@ impl RuntimeOutput {
 #[derive(Debug)]
 pub struct LiveTerrainHeights {
     data_dir: PathBuf,
+    static_vmap_los: Option<SharedStaticVMapLineOfSightProvider>,
     per_map: Mutex<HashMap<u32, Arc<GridMapTerrain>>>,
 }
 
 impl LiveTerrainHeights {
     #[must_use]
     pub fn new(data_dir: impl AsRef<Path>) -> Self {
+        Self::new_with_optional_static_vmap_line_of_sight(data_dir, None)
+    }
+
+    /// Build the live terrain cache with a static VMAP LOS provider wired into
+    /// every lazily-created map terrain.
+    ///
+    /// C++ startup creates/configures one `VMapManager2` and each map's
+    /// `TerrainInfo`/`Map::isInLineOfSight` consults it for static geometry. This
+    /// keeps the Rust live cache usable by a real provider once the VMAP
+    /// `StaticMapTree` parser owns model geometry; without a provider, LOS
+    /// remains C++'s disabled/missing-tree clear fallback.
+    #[must_use]
+    pub fn new_with_static_vmap_line_of_sight(
+        data_dir: impl AsRef<Path>,
+        provider: SharedStaticVMapLineOfSightProvider,
+    ) -> Self {
+        Self::new_with_optional_static_vmap_line_of_sight(data_dir, Some(provider))
+    }
+
+    #[must_use]
+    fn new_with_optional_static_vmap_line_of_sight(
+        data_dir: impl AsRef<Path>,
+        static_vmap_los: Option<SharedStaticVMapLineOfSightProvider>,
+    ) -> Self {
         Self {
             data_dir: data_dir.as_ref().to_path_buf(),
+            static_vmap_los,
             per_map: Mutex::new(HashMap::new()),
         }
     }
 
     fn terrain_for_map(&self, map_id: u32) -> Arc<GridMapTerrain> {
         let mut per_map = self.per_map.lock().expect("live terrain cache poisoned");
-        Arc::clone(
-            per_map
-                .entry(map_id)
-                .or_insert_with(|| Arc::new(GridMapTerrain::new(map_id, &self.data_dir))),
-        )
+        Arc::clone(per_map.entry(map_id).or_insert_with(|| {
+            let terrain = GridMapTerrain::new(map_id, &self.data_dir);
+            let terrain = match &self.static_vmap_los {
+                Some(provider) => terrain.with_static_vmap_line_of_sight(Arc::clone(provider)),
+                None => terrain,
+            };
+            Arc::new(terrain)
+        }))
     }
 
     /// C++ `Map::GetHeight` (no VMap/GO-floor): the raw `.map` ground at `(x, y)`,
@@ -4299,6 +4328,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
     use wow_constants::{CreatureFlagsExtra, PhaseFlags};
     use wow_core::guid::HighGuid;
+    use wow_map::map::MapWorldObjectEnvironment;
 
     fn unique_temp_data_dir(test_name: &str) -> PathBuf {
         let unique = SystemTime::now()
@@ -4361,6 +4391,66 @@ mod tests {
             0,
             0,
         )
+    }
+
+    #[derive(Debug)]
+    struct RecordingLiveStaticVMapLos {
+        result: bool,
+        calls: std::sync::Mutex<Vec<wow_map::VMapLineOfSightQuery>>,
+    }
+
+    impl RecordingLiveStaticVMapLos {
+        fn new(result: bool) -> Self {
+            Self {
+                result,
+                calls: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl wow_map::StaticVMapLineOfSightProvider for RecordingLiveStaticVMapLos {
+        fn is_in_line_of_sight(&self, query: wow_map::VMapLineOfSightQuery) -> bool {
+            self.calls
+                .lock()
+                .expect("recording live vmap LOS calls poisoned")
+                .push(query);
+            self.result
+        }
+    }
+
+    #[test]
+    fn live_terrain_wires_static_vmap_los_provider_into_map_cache_like_cpp() {
+        let dir = unique_temp_data_dir("live-vmap-los-provider");
+        let provider = Arc::new(RecordingLiveStaticVMapLos::new(false));
+        let shared_provider: SharedStaticVMapLineOfSightProvider = provider.clone();
+        let terrain_cache =
+            LiveTerrainHeights::new_with_static_vmap_line_of_sight(&dir, shared_provider);
+
+        let terrain = terrain_cache.terrain_for_map(1);
+        let mut source = wow_entities::WorldObject::new(
+            false,
+            wow_constants::TypeId::Unit,
+            wow_constants::TypeMask::UNIT,
+        );
+        source.relocate(Position::new(10.0, 10.0, 1.0, 0.0));
+        let query = wow_entities::LineOfSightQuery::to_position_like_cpp(
+            &source,
+            Position::new(20.0, 10.0, 1.0, 0.0),
+            wow_entities::LineOfSightOptions::default(),
+        );
+
+        assert!(
+            !terrain.line_of_sight(query),
+            "live terrain must not bypass an installed static VMAP LOS provider"
+        );
+        let calls = provider
+            .calls
+            .lock()
+            .expect("recording live vmap LOS calls poisoned");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].map_id, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
Refs #16

QA pending: do not merge as a full #16 closeout until real VMAP geometry LOS exists, capture-clean comparison is available, manual/runtime validation is complete, CI passes, and Codex reviewer verdict is green.

Summary:
- Adds a C++-anchored static VMap LOS provider seam.
- Replaces the unconditional terrain LOS true path when a provider is available.
- Wires an installed static VMAP LOS provider through the live `LiveTerrainHeights` map cache so runtime-created `GridMapTerrain` instances do not silently bypass it.
- Keeps C++ disabled/missing-tree fallback behavior when no provider is installed.

Validation reported locally:
- cargo fmt --all -- --check
- PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-map --lib
- PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-world live_terrain_wires_static_vmap_los_provider_into_map_cache_like_cpp --lib
- PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p world-server
- git diff --check

Manual QA pending:
- This PR can be smoke-tested for no regression, but it still does not provide real VMAP BIH/VMO geometry blocking by itself. Geometry-blocked LOS vs C++ remains the hard acceptance item for closing #16.