### PR TITLE
[52] Persist innkeeper homebind

### DIFF
--- a/crates/wow-data/src/spell.rs
+++ b/crates/wow-data/src/spell.rs
@@ -486,6 +486,7 @@ pub mod aura_types {
 
 /// Selected `Targets` ids from C++ `SpellImplicitTargetInfo::_data`.
 pub mod implicit_targets {
+    pub const TARGET_DEST_HOME: u32 = 9;
     pub const TARGET_DEST_DB: u32 = 17;
     pub const TARGET_DEST_NEARBY_ENTRY: u32 = 46;
     pub const TARGET_DEST_NEARBY_ENTRY_2: u32 = 107;

--- a/crates/wow-map/src/map.rs
+++ b/crates/wow-map/src/map.rs
@@ -13071,6 +13071,31 @@ where
         self.map_object_by_kind(guid, &[AccessorObjectKind::Transport])
     }
 
+    /// Return the typed canonical transport that currently owns a passenger.
+    ///
+    /// C++ `WorldObject::GetTransGUID` is backed by the object's transport
+    /// movement state. The canonical Rust transport runtime owns passenger
+    /// membership on `Transport`, so spell destination resolution uses this
+    /// map-local lookup instead of guessing from a generic transport object.
+    pub fn get_typed_transport_for_passenger_like_cpp(
+        &self,
+        passenger_guid: ObjectGuid,
+    ) -> Option<&wow_entities::Transport> {
+        self.map_objects.values().find_map(|record| {
+            let transport = record.transport()?;
+            (transport.passengers().contains(&passenger_guid)
+                || transport.static_passengers().contains(&passenger_guid))
+            .then_some(transport)
+        })
+    }
+
+    pub fn get_typed_transport_like_cpp(
+        &self,
+        guid: ObjectGuid,
+    ) -> Option<&wow_entities::Transport> {
+        self.map_objects.get(&guid)?.transport()
+    }
+
     pub fn get_dynamic_object(&self, guid: ObjectGuid) -> Option<&WorldObject> {
         self.map_object_by_kind(guid, &[AccessorObjectKind::DynamicObject])
     }

--- a/crates/wow-packet/src/packets/misc.rs
+++ b/crates/wow-packet/src/packets/misc.rs
@@ -3080,8 +3080,8 @@ pub struct BindPointUpdate {
     pub x: f32,
     pub y: f32,
     pub z: f32,
-    pub map_id: i32,
-    pub area_id: i32,
+    pub map_id: u32,
+    pub area_id: u32,
 }
 
 impl ServerPacket for BindPointUpdate {
@@ -3091,8 +3091,8 @@ impl ServerPacket for BindPointUpdate {
         pkt.write_float(self.x);
         pkt.write_float(self.y);
         pkt.write_float(self.z);
-        pkt.write_int32(self.map_id);
-        pkt.write_int32(self.area_id);
+        pkt.write_uint32(self.map_id);
+        pkt.write_uint32(self.area_id);
     }
 }
 
@@ -10759,6 +10759,22 @@ mod tests {
         assert_eq!(bytes.len(), 22);
         let opcode = u16::from_le_bytes([bytes[0], bytes[1]]);
         assert_eq!(opcode, 0x257d);
+    }
+
+    #[test]
+    fn bind_point_update_preserves_full_uint32_area_like_cpp() {
+        let bytes = BindPointUpdate {
+            x: 1.0,
+            y: 2.0,
+            z: 3.0,
+            map_id: 571,
+            area_id: u32::MAX,
+        }
+        .to_bytes();
+        assert_eq!(
+            u32::from_le_bytes(bytes[18..22].try_into().unwrap()),
+            u32::MAX
+        );
     }
 
     #[test]

--- a/crates/wow-packet/src/packets/spell.rs
+++ b/crates/wow-packet/src/packets/spell.rs
@@ -581,13 +581,19 @@ impl ClientPacket for SpellClick {
 
 /// Write a minimal `SpellCastData` (used by both SpellStart and SpellGo).
 ///
-/// C# ref: `SpellCastData.Write()` in SpellPackets.cs.
+/// C++ refs: `WorldPackets::Spells::SpellCastData` in `SpellPackets.h` and
+/// `WorldPackets::Spells::operator<<(ByteBuffer&, SpellCastData const&)` in
+/// `SpellPackets.cpp`. The fixed fields, bit counts, target data, and trailing
+/// vectors below follow that serializer in the same order.
 ///
 /// Parameters
-/// - `caster`      : player ObjectGuid
+/// - `caster`      : unit ObjectGuid written as both CasterGUID and CasterUnit
 /// - `cast_id`     : echo of the client's cast_id
+/// - `original_cast_id`: original cast ObjectGuid, or empty when absent
 /// - `spell_id`    : spell being cast
 /// - `visual`      : spell visual IDs
+/// - `cast_flags`  : C++ `SpellCastData::CastFlags`
+/// - `cast_flags_ex`: C++ `SpellCastData::CastFlagsEx`
 /// - `cast_time_ms`: 0 for instant
 /// - `target`      : SpellTargetData (unit + flags)
 /// - `hit_targets` : list of GUIDs that were hit (empty for visual-only)
@@ -606,7 +612,7 @@ fn write_spell_cast_data(
 ) {
     // CasterGUID, CasterUnit, CastID, OriginalCastID
     pkt.write_packed_guid(caster);
-    pkt.write_packed_guid(caster); // CasterUnit = same for player spells
+    pkt.write_packed_guid(caster); // This helper currently represents unit casters.
     pkt.write_packed_guid(cast_id);
     pkt.write_packed_guid(original_cast_id);
 

--- a/crates/wow-packet/src/packets/spell.rs
+++ b/crates/wow-packet/src/packets/spell.rs
@@ -598,6 +598,7 @@ fn write_spell_cast_data(
     original_cast_id: &ObjectGuid,
     spell_id: i32,
     visual: &SpellCastVisual,
+    cast_flags: u32,
     cast_flags_ex: u32,
     cast_time_ms: u32,
     target: &SpellTargetData,
@@ -614,7 +615,7 @@ fn write_spell_cast_data(
     visual.write(pkt);
 
     // CastFlags, CastFlagsEx, CastTime
-    pkt.write_uint32(0); // CastFlags
+    pkt.write_uint32(cast_flags);
     pkt.write_uint32(cast_flags_ex);
     pkt.write_uint32(cast_time_ms);
 
@@ -701,6 +702,7 @@ impl ServerPacket for SpellStartPkt {
             &self.original_cast_id,
             self.spell_id,
             &self.visual,
+            0,
             self.cast_flags_ex,
             self.cast_time_ms,
             &self.target,
@@ -721,7 +723,11 @@ pub struct SpellGoPkt {
     pub original_cast_id: ObjectGuid,
     pub spell_id: i32,
     pub visual: SpellCastVisual,
+    pub cast_flags: u32,
     pub cast_flags_ex: u32,
+    /// C++ `SpellCastData::CastTime`; for `SMSG_SPELL_GO` this is the
+    /// server's wrapping `getMSTime()` timestamp, not the cast duration.
+    pub cast_time_ms: u32,
     pub target: SpellTargetData,
     /// GUIDs that were hit by the spell.
     pub hit_targets: Vec<ObjectGuid>,
@@ -739,8 +745,9 @@ impl ServerPacket for SpellGoPkt {
             &self.original_cast_id,
             self.spell_id,
             &self.visual,
+            self.cast_flags,
             self.cast_flags_ex,
-            0, // CastTime
+            self.cast_time_ms,
             &self.target,
             &self.hit_targets,
         );
@@ -1300,7 +1307,9 @@ mod tests {
             original_cast_id: client_cast_id,
             spell_id: 12_345,
             visual: SpellCastVisual::default(),
+            cast_flags: 0x0004_0101,
             cast_flags_ex: 0x08000,
+            cast_time_ms: 0x1234_5678,
             target: SpellTargetData::default(),
             hit_targets: Vec::new(),
         }
@@ -1316,7 +1325,8 @@ mod tests {
         let visual = SpellCastVisual::read(&mut pkt).unwrap();
         assert_eq!(visual.spell_visual_id, 0);
         assert_eq!(visual.script_visual_id, 0);
-        assert_eq!(pkt.read_uint32().unwrap(), 0);
+        assert_eq!(pkt.read_uint32().unwrap(), 0x0004_0101);
         assert_eq!(pkt.read_uint32().unwrap(), 0x08000);
+        assert_eq!(pkt.read_uint32().unwrap(), 0x1234_5678);
     }
 }

--- a/crates/wow-world/src/handlers/character.rs
+++ b/crates/wow-world/src/handlers/character.rs
@@ -10828,7 +10828,7 @@ impl WorldSession {
         }
         // C++ closes gossip after attempting the triggered cast, even if the
         // spell execution itself cannot complete.
-        self.send_packet(&GossipComplete {
+        self.send_packet_realm(&GossipComplete {
             suppress_sound: false,
         });
     }
@@ -20467,7 +20467,9 @@ mod tests {
 
     #[tokio::test]
     async fn binder_activate_sets_current_homebind_and_sends_bind_packets_like_cpp() {
-        let (mut session, send_rx, canonical) = make_bank_slot_session(16);
+        let (mut session, instance_rx, canonical) = make_bank_slot_session(16);
+        let (realm_tx, realm_rx) = flume::bounded::<Vec<u8>>(16);
+        session.install_realm_send_channel_for_test(realm_tx);
         let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 30);
         insert_banker_creature(&canonical, innkeeper, NPCFlags1::INNKEEPER.bits());
         session.set_player_zone_area_like_cpp(12, 34);
@@ -20489,18 +20491,21 @@ mod tests {
                 position: Position::new(0.0, 0.0, 0.0, 0.0),
             })
         );
-        let packets: Vec<Vec<u8>> = send_rx.try_iter().collect();
+        let packets: Vec<Vec<u8>> = instance_rx.try_iter().collect();
         assert_eq!(
             packets
                 .iter()
                 .filter_map(|bytes| WorldPacket::from_bytes(bytes).server_opcode())
                 .collect::<Vec<_>>(),
-            vec![
-                ServerOpcodes::SpellGo,
-                ServerOpcodes::BindPointUpdate,
-                ServerOpcodes::PlayerBound,
-                ServerOpcodes::GossipComplete,
-            ]
+            vec![ServerOpcodes::SpellGo, ServerOpcodes::BindPointUpdate,]
+        );
+        assert_eq!(
+            realm_rx
+                .try_iter()
+                .filter_map(|bytes| WorldPacket::from_bytes(&bytes).server_opcode())
+                .collect::<Vec<_>>(),
+            vec![ServerOpcodes::PlayerBound, ServerOpcodes::GossipComplete],
+            "C++ routes PlayerBound and GossipComplete on realm"
         );
         let mut spell_go = WorldPacket::from_bytes(&packets[0]);
         assert_eq!(

--- a/crates/wow-world/src/handlers/character.rs
+++ b/crates/wow-world/src/handlers/character.rs
@@ -57,6 +57,7 @@ use wow_packet::packets::item::*;
 use wow_packet::packets::loot::LootReleaseAll;
 use wow_packet::packets::misc::*;
 use wow_packet::packets::quest::QuestGiverStatusMultiple;
+use wow_packet::packets::spell::{SpellCastVisual, SpellTargetData};
 use wow_packet::packets::update::*;
 use wow_packet::{ClientPacket, WorldPacket};
 
@@ -69,7 +70,7 @@ use crate::session::{
     CharacterPetSpellChargeRowLikeCpp, CharacterPetSpellCooldownRowLikeCpp,
     CharacterPetSpellRowLikeCpp, CharacterPetStableRowLikeCpp, RepresentedAlterAppearanceLikeCpp,
     RepresentedBankItemMoveLikeCpp, RepresentedConfirmBarbersChoiceLikeCpp,
-    RepresentedGameObjectUseState, RepresentedHomebindLikeCpp,
+    RepresentedGameObjectUseState, RepresentedHomebindLikeCpp, SpellCastMetadata,
 };
 
 // ── Handler registration ────────────────────────────────────────────
@@ -10769,6 +10770,9 @@ impl WorldSession {
             );
             return;
         };
+        // C++ HandleBinderActivateOpcode removes feign death before
+        // SendBindPoint performs its instanceable-map rejection.
+        self.remove_represented_feign_death_if_needed_like_cpp();
         if self.player_current_map_instanceable_like_cpp() {
             debug!(
                 innkeeper_guid = ?hello.unit,
@@ -10777,18 +10781,56 @@ impl WorldSession {
             );
             return;
         }
-        self.remove_represented_feign_death_if_needed_like_cpp();
 
-        // C++ SendBindPoint has the creature cast spell 3286 on the player.
-        // The represented spell hook stores the same current-location bind.
-        if self
-            .set_homebind_to_current_location_like_cpp(hello.unit)
-            .await
-        {
-            self.send_packet(&GossipComplete {
-                suppress_sound: false,
-            });
+        // C++ SendBindPoint calls innkeeper->CastSpell(player, 3286, true).
+        // Route the triggered creature cast through the represented spell
+        // pipeline so SpellGo, EffectBind, persistence, and bind packets keep
+        // their C++ ordering and caster identity.
+        const BIND_SPELL_ID_LIKE_CPP: i32 = 3286;
+        const CAST_FLAG_PENDING_LIKE_CPP: u32 = 0x0000_0001;
+        const CAST_FLAG_UNKNOWN_9_LIKE_CPP: u32 = 0x0000_0100;
+        const CAST_FLAG_NO_GCD_LIKE_CPP: u32 = 0x0004_0000;
+        const BIND_SPELL_GO_CAST_FLAGS_LIKE_CPP: u32 =
+            CAST_FLAG_UNKNOWN_9_LIKE_CPP | CAST_FLAG_PENDING_LIKE_CPP | CAST_FLAG_NO_GCD_LIKE_CPP;
+        if let Some(player_guid) = self.player_guid() {
+            let cast_id = self.next_represented_spell_cast_guid_like_cpp(BIND_SPELL_ID_LIKE_CPP);
+            if let Err(error) = self
+                .execute_spell_with_visual_and_target_data_with_metadata(
+                    BIND_SPELL_ID_LIKE_CPP,
+                    player_guid,
+                    cast_id,
+                    SpellCastVisual::default(),
+                    SpellTargetData {
+                        flags: 0x2,
+                        unit: player_guid,
+                        item: ObjectGuid::EMPTY,
+                        ..SpellTargetData::default()
+                    },
+                    SpellCastMetadata {
+                        caster_guid_override: Some(hello.unit),
+                        // C++ Spell::SendSpellGo starts with UNKNOWN_9, adds
+                        // PENDING for this non-client triggered cast, and
+                        // adds NO_GCD because spell 3286 has no
+                        // StartRecoveryTime row.
+                        cast_flags: BIND_SPELL_GO_CAST_FLAGS_LIKE_CPP,
+                        ..SpellCastMetadata::default()
+                    },
+                )
+                .await
+            {
+                warn!(
+                    innkeeper_guid = ?hello.unit,
+                    account = self.account_id,
+                    error,
+                    "BinderActivate bind spell failed"
+                );
+            }
         }
+        // C++ closes gossip after attempting the triggered cast, even if the
+        // spell execution itself cannot complete.
+        self.send_packet(&GossipComplete {
+            suppress_sound: false,
+        });
     }
 
     /// CMSG_TABARD_VENDOR_ACTIVATE — player talks to a tabard designer.
@@ -16221,7 +16263,8 @@ impl WorldSession {
 mod tests {
     use super::*;
     use crate::session::{
-        InventoryItem, RepresentedHomebindLikeCpp, RepresentedTaxiFlightNodeLikeCpp,
+        AuraApplication, InventoryItem, RepresentedAuraEffectLikeCpp, RepresentedHomebindLikeCpp,
+        RepresentedTaxiFlightNodeLikeCpp,
     };
     use wow_constants::{ItemClass, ServerOpcodes};
     use wow_data::character_progression::{
@@ -19588,6 +19631,68 @@ mod tests {
         (session, send_rx, canonical)
     }
 
+    fn install_bind_spell_fixture(session: &mut WorldSession) {
+        let mut spell_store = wow_data::SpellStore::new();
+        spell_store.insert(
+            3286,
+            wow_data::SpellInfo {
+                spell_id: 3286,
+                cast_time_ms: 0,
+                cooldown_ms: 0,
+                recovery_time_ms: 0,
+                effect_type: wow_data::spell::spell_effect_types::SPELL_EFFECT_BIND,
+                effect_base_points: 0,
+                effect_bonus_coefficient: 0.0,
+                aura_type: None,
+                display_flags: 0,
+                requires_spell_focus: 0,
+                power_costs: Vec::new(),
+                effects: vec![wow_data::SpellEffectInfo {
+                    effect_index: 0,
+                    effect: wow_data::spell::spell_effect_types::SPELL_EFFECT_BIND,
+                    ..Default::default()
+                }],
+            },
+        );
+        session.set_spell_store(Arc::new(spell_store));
+    }
+
+    fn make_binder_observer(
+        guid_counter: u32,
+        position: Position,
+        innkeeper: ObjectGuid,
+        visible: bool,
+        registry: &Arc<wow_network::PlayerRegistry>,
+        canonical: &Arc<std::sync::Mutex<wow_map::MapManager>>,
+    ) -> (WorldSession, flume::Receiver<Vec<u8>>) {
+        let (mut observer, send_rx) = make_session_with_send_capacity(4);
+        let guid = ObjectGuid::create_player(1, i64::from(guid_counter));
+        observer.set_canonical_map_manager(Arc::clone(canonical));
+        observer.attach_player_controller_like_cpp(crate::session::SessionPlayerController::new(
+            guid,
+            format!("Observer{guid_counter}"),
+            position,
+            571,
+            1,
+            1,
+            80,
+            0,
+        ));
+        observer.set_state(crate::session::SessionState::LoggedIn);
+        observer.set_player_registry(Arc::clone(registry));
+        if visible {
+            observer.client_visible_guids_like_cpp.insert(innkeeper);
+        }
+        observer.register_in_player_registry();
+        let mut info = registry.get_mut(&guid).expect("observer registry entry");
+        info.is_in_world = true;
+        info.map_id = 571;
+        info.instance_id = 0;
+        info.position = position;
+        drop(info);
+        (observer, send_rx)
+    }
+
     fn install_bank_move_item_fixture(
         session: &mut WorldSession,
         entry_id: u32,
@@ -20362,14 +20467,19 @@ mod tests {
 
     #[tokio::test]
     async fn binder_activate_sets_current_homebind_and_sends_bind_packets_like_cpp() {
-        let (mut session, send_rx, canonical) = make_bank_slot_session(4);
+        let (mut session, send_rx, canonical) = make_bank_slot_session(16);
         let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 30);
         insert_banker_creature(&canonical, innkeeper, NPCFlags1::INNKEEPER.bits());
         session.set_player_zone_area_like_cpp(12, 34);
+        install_bind_spell_fixture(&mut session);
+        let _ = WorldSession::game_time_ms_like_cpp();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let cast_time_lower_bound = WorldSession::game_time_ms_like_cpp();
 
         session
             .handle_binder_activate(Hello { unit: innkeeper })
             .await;
+        let cast_time_upper_bound = WorldSession::game_time_ms_like_cpp();
 
         assert_eq!(
             session.represented_homebind_like_cpp(),
@@ -20379,21 +20489,169 @@ mod tests {
                 position: Position::new(0.0, 0.0, 0.0, 0.0),
             })
         );
+        let packets: Vec<Vec<u8>> = send_rx.try_iter().collect();
         assert_eq!(
-            drain_server_opcodes(&send_rx),
+            packets
+                .iter()
+                .filter_map(|bytes| WorldPacket::from_bytes(bytes).server_opcode())
+                .collect::<Vec<_>>(),
             vec![
+                ServerOpcodes::SpellGo,
                 ServerOpcodes::BindPointUpdate,
                 ServerOpcodes::PlayerBound,
                 ServerOpcodes::GossipComplete,
             ]
         );
+        let mut spell_go = WorldPacket::from_bytes(&packets[0]);
+        assert_eq!(
+            spell_go.read_uint16().expect("SpellGo opcode"),
+            ServerOpcodes::SpellGo as u16
+        );
+        assert_eq!(
+            spell_go.read_packed_guid().expect("SpellGo caster"),
+            innkeeper,
+            "C++ creature CastSpell keeps the innkeeper as visible caster"
+        );
+        assert_eq!(
+            spell_go.read_packed_guid().expect("SpellGo caster unit"),
+            innkeeper
+        );
+        let _ = spell_go.read_packed_guid().expect("SpellGo cast id");
+        let _ = spell_go
+            .read_packed_guid()
+            .expect("SpellGo original cast id");
+        assert_eq!(spell_go.read_int32().expect("SpellGo spell id"), 3286);
+        let _ = SpellCastVisual::read(&mut spell_go).expect("SpellGo visual");
+        assert_eq!(
+            spell_go.read_uint32().expect("SpellGo cast flags"),
+            0x0004_0101,
+            "C++ bind SpellGo carries UNKNOWN_9 | PENDING | NO_GCD"
+        );
+        assert_eq!(spell_go.read_uint32().expect("SpellGo cast flags ex"), 0);
+        let cast_time_ms = spell_go.read_uint32().expect("SpellGo cast time");
+        assert!(
+            (cast_time_lower_bound..=cast_time_upper_bound).contains(&cast_time_ms),
+            "C++ SpellGo CastTime is the wrapping getMSTime() server timestamp"
+        );
+    }
+
+    #[tokio::test]
+    async fn binder_activate_fans_spell_go_to_visible_nearby_observers_like_cpp() {
+        let (mut session, sender_rx, canonical) = make_bank_slot_session(16);
+        let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 32);
+        insert_banker_creature(&canonical, innkeeper, NPCFlags1::INNKEEPER.bits());
+        session.set_player_zone_area_like_cpp(12, 34);
+        install_bind_spell_fixture(&mut session);
+
+        let registry = Arc::new(wow_network::PlayerRegistry::default());
+        session.set_player_registry(Arc::clone(&registry));
+        let (mut nearby_visible, nearby_visible_rx) = make_binder_observer(
+            43,
+            Position::new(10.0, 0.0, 0.0, 0.0),
+            innkeeper,
+            true,
+            &registry,
+            &canonical,
+        );
+        let (mut nearby_hidden, nearby_hidden_rx) = make_binder_observer(
+            44,
+            Position::new(12.0, 0.0, 0.0, 0.0),
+            innkeeper,
+            false,
+            &registry,
+            &canonical,
+        );
+        let (mut distant_visible, distant_visible_rx) = make_binder_observer(
+            45,
+            Position::new(5_000.0, 0.0, 0.0, 0.0),
+            innkeeper,
+            true,
+            &registry,
+            &canonical,
+        );
+
+        session
+            .handle_binder_activate(Hello { unit: innkeeper })
+            .await;
+        let activating_player_spell_go = sender_rx.try_recv().expect("activator SpellGo");
+
+        nearby_visible
+            .process_represented_session_commands_like_cpp()
+            .await;
+        nearby_hidden
+            .process_represented_session_commands_like_cpp()
+            .await;
+        distant_visible
+            .process_represented_session_commands_like_cpp()
+            .await;
+
+        assert_eq!(
+            nearby_visible_rx
+                .try_recv()
+                .expect("visible nearby observer SpellGo"),
+            activating_player_spell_go
+        );
+        assert!(nearby_visible_rx.try_recv().is_err());
+        assert!(
+            nearby_hidden_rx.try_recv().is_err(),
+            "C++ HaveAtClient gate rejects a non-visible innkeeper"
+        );
+        assert!(
+            distant_visible_rx.try_recv().is_err(),
+            "C++ MessageDistDeliverer rejects observers outside visibility range"
+        );
     }
 
     #[tokio::test]
     async fn binder_activate_rejects_instanceable_map_like_cpp() {
-        let (mut session, send_rx, canonical) = make_bank_slot_session(1);
+        let (mut session, send_rx, canonical) = make_bank_slot_session(2);
         let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 31);
         insert_banker_creature(&canonical, innkeeper, NPCFlags1::INNKEEPER.bits());
+        let player_guid = session.player_guid().expect("player guid");
+        let mut player = wow_entities::Player::new(Some(1), false);
+        player
+            .unit_mut()
+            .world_mut()
+            .object_mut()
+            .create(player_guid);
+        player.unit_mut().world_mut().set_map(571, 0).unwrap();
+        player
+            .unit_mut()
+            .world_mut()
+            .relocate(Position::new(0.0, 0.0, 0.0, 0.0));
+        player.unit_mut().world_mut().object_mut().add_to_world();
+        player
+            .unit_mut()
+            .add_unit_state(wow_constants::unit::UnitState::DIED.bits());
+        canonical
+            .lock()
+            .unwrap()
+            .create_world_map(571, 0)
+            .map_mut()
+            .insert_map_object_record(wow_entities::MapObjectRecord::new_player(player).unwrap())
+            .unwrap();
+        const FEIGN_DEATH_SLOT: u8 = 7;
+        session.visible_auras.insert(
+            FEIGN_DEATH_SLOT,
+            AuraApplication {
+                spell_id: 5384,
+                caster_guid: player_guid,
+                slot: FEIGN_DEATH_SLOT,
+                duration_total: 0,
+                duration_remaining: 0,
+                stack_count: 1,
+                aura_flags: 0,
+                effect_mask: 1,
+                aura_interrupt_flags: 0,
+                aura_interrupt_flags2: 0,
+                represented_effect: Some(RepresentedAuraEffectLikeCpp::FeignDeath),
+                represented_amount: 0,
+                represented_effect_amounts: Vec::new(),
+                represented_misc_value: None,
+                represented_multiplier: 1.0,
+                applied_at: std::time::Instant::now(),
+            },
+        );
         session.set_map_store(Arc::new(wow_data::MapStore::from_entries([
             wow_data::MapEntry {
                 id: 571,
@@ -20411,7 +20669,20 @@ mod tests {
             .await;
 
         assert!(session.represented_homebind_like_cpp().is_none());
-        assert!(send_rx.try_recv().is_err());
+        assert_eq!(
+            drain_server_opcodes(&send_rx),
+            vec![ServerOpcodes::AuraUpdate],
+            "C++ removes feign death before SendBindPoint rejects an instanceable map"
+        );
+        assert!(!session.visible_auras.contains_key(&FEIGN_DEATH_SLOT));
+        assert_eq!(
+            session
+                .mutate_canonical_player_like_cpp(|player| player
+                    .unit()
+                    .has_unit_state(wow_constants::unit::UnitState::DIED.bits()))
+                .expect("canonical player"),
+            false
+        );
     }
 
     #[tokio::test]

--- a/crates/wow-world/src/handlers/character.rs
+++ b/crates/wow-world/src/handlers/character.rs
@@ -17096,7 +17096,7 @@ mod tests {
         assert_eq!(bind_update.x, homebind.position.x);
         assert_eq!(bind_update.y, homebind.position.y);
         assert_eq!(bind_update.z, homebind.position.z);
-        assert_eq!(bind_update.map_id, homebind.map_id as i32);
+        assert_eq!(bind_update.map_id, homebind.map_id);
         assert_eq!(bind_update.area_id, 12);
 
         assert_eq!(

--- a/crates/wow-world/src/handlers/character.rs
+++ b/crates/wow-world/src/handlers/character.rs
@@ -69,7 +69,7 @@ use crate::session::{
     CharacterPetSpellChargeRowLikeCpp, CharacterPetSpellCooldownRowLikeCpp,
     CharacterPetSpellRowLikeCpp, CharacterPetStableRowLikeCpp, RepresentedAlterAppearanceLikeCpp,
     RepresentedBankItemMoveLikeCpp, RepresentedConfirmBarbersChoiceLikeCpp,
-    RepresentedGameObjectUseState,
+    RepresentedGameObjectUseState, RepresentedHomebindLikeCpp,
 };
 
 // ── Handler registration ────────────────────────────────────────────
@@ -4933,6 +4933,34 @@ impl WorldSession {
         // (`Player::SendInitialPacketsAfterAddToMap`). Seed from DB until
         // that post-add terrain pass runs.
         self.set_player_zone_area_like_cpp(zone as u32, zone as u32);
+        {
+            let mut homebind_stmt = char_db.prepare(CharStatements::SEL_CHARACTER_HOMEBIND);
+            homebind_stmt.set_u64(0, guid.counter() as u64);
+            match char_db.query(&homebind_stmt).await {
+                Ok(homebind_result) => {
+                    if !homebind_result.is_empty() {
+                        let homebind = RepresentedHomebindLikeCpp {
+                            map_id: u32::from(homebind_result.try_read::<u16>(0).unwrap_or(0)),
+                            area_id: u32::from(homebind_result.try_read::<u16>(1).unwrap_or(0)),
+                            position: Position::new(
+                                homebind_result.try_read(2).unwrap_or(0.0),
+                                homebind_result.try_read(3).unwrap_or(0.0),
+                                homebind_result.try_read(4).unwrap_or(0.0),
+                                homebind_result.try_read(5).unwrap_or(0.0),
+                            ),
+                        };
+                        self.set_represented_homebind_like_cpp(homebind);
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        player_guid = guid.counter(),
+                        %error,
+                        "failed to load represented character_homebind row"
+                    );
+                }
+            }
+        }
         self.set_represented_guild_id_like_cpp(result.try_read::<u64>(11).unwrap_or(0));
         self.load_represented_player_difficulties_like_cpp(
             result.try_read::<u32>(44).unwrap_or(0),
@@ -10740,16 +10768,34 @@ impl WorldSession {
     }
 
     /// CMSG_BINDER_ACTIVATE — player sets hearthstone at innkeeper.
-    /// C++ ref: `HandleBinderActivateOpcode`
-    /// (`Handlers/NPCHandler.cpp:373-381`).
+    /// C++ refs: `WorldSession::HandleBinderActivateOpcode` /
+    /// `WorldSession::SendBindPoint` (`Handlers/NPCHandler.cpp:373-402`).
     pub async fn handle_binder_activate(&mut self, hello: Hello) {
-        use wow_packet::packets::misc::NpcInteractionOpenResult;
         info!(
             "BinderActivate {:?} account {}",
             hello.unit, self.account_id
         );
-        // TODO: actually set hearthstone bind point in DB.
-        self.send_packet(&NpcInteractionOpenResult::new(hello.unit, 20)); // Binder
+        if !self.player_is_alive_like_cpp() {
+            return;
+        }
+        let Some(_innkeeper) = self.represented_npc_can_interact_with_like_cpp(
+            hello.unit,
+            NPCFlags1::INNKEEPER.bits(),
+            0,
+        ) else {
+            debug!(
+                innkeeper_guid = ?hello.unit,
+                account = self.account_id,
+                "BinderActivate rejected: NPC missing, out of range, dead, or lacks INNKEEPER flag"
+            );
+            return;
+        };
+
+        // C++ SendBindPoint has the creature cast spell 3286 on the player.
+        // The represented spell hook stores the same current-location bind.
+        let _ = self
+            .set_homebind_to_current_location_like_cpp(hello.unit)
+            .await;
     }
 
     /// CMSG_TABARD_VENDOR_ACTIVATE — player talks to a tabard designer.
@@ -20319,6 +20365,46 @@ mod tests {
             Some(source_guid)
         );
         assert_eq!(session.represented_non_bank_item_count_like_cpp(703), 0);
+    }
+
+    #[tokio::test]
+    async fn binder_activate_sets_current_homebind_and_sends_bind_packets_like_cpp() {
+        let (mut session, send_rx, canonical) = make_bank_slot_session(4);
+        let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 30);
+        insert_banker_creature(&canonical, innkeeper, NPCFlags1::INNKEEPER.bits());
+        session.set_player_zone_area_like_cpp(12, 34);
+
+        session
+            .handle_binder_activate(Hello { unit: innkeeper })
+            .await;
+
+        assert_eq!(
+            session.represented_homebind_like_cpp(),
+            Some(RepresentedHomebindLikeCpp {
+                map_id: 571,
+                area_id: 34,
+                position: Position::new(0.0, 0.0, 0.0, 0.0),
+            })
+        );
+        assert_eq!(
+            drain_server_opcodes(&send_rx),
+            vec![ServerOpcodes::BindPointUpdate, ServerOpcodes::PlayerBound]
+        );
+    }
+
+    #[tokio::test]
+    async fn binder_activate_rejects_non_innkeeper_like_cpp() {
+        let (mut session, send_rx, canonical) = make_bank_slot_session(1);
+        let creature = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 31);
+        insert_banker_creature(&canonical, creature, NPCFlags1::BANKER.bits());
+        session.set_player_zone_area_like_cpp(12, 34);
+
+        session
+            .handle_binder_activate(Hello { unit: creature })
+            .await;
+
+        assert!(session.represented_homebind_like_cpp().is_none());
+        assert!(send_rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/crates/wow-world/src/handlers/character.rs
+++ b/crates/wow-world/src/handlers/character.rs
@@ -4950,6 +4950,14 @@ impl WorldSession {
                             ),
                         };
                         self.set_represented_homebind_like_cpp(homebind);
+                    } else {
+                        let homebind = RepresentedHomebindLikeCpp {
+                            map_id: u32::try_from(map_id).unwrap_or(0),
+                            area_id: u32::try_from(zone).unwrap_or(0),
+                            position,
+                        };
+                        self.seed_represented_homebind_from_load_like_cpp(homebind)
+                            .await;
                     }
                 }
                 Err(error) => {
@@ -10790,12 +10798,25 @@ impl WorldSession {
             );
             return;
         };
+        if self.player_current_map_instanceable_like_cpp() {
+            debug!(
+                innkeeper_guid = ?hello.unit,
+                map_id = self.player_map_id_like_cpp(),
+                "BinderActivate rejected: current map is instanceable like C++ SendBindPoint"
+            );
+            return;
+        }
 
         // C++ SendBindPoint has the creature cast spell 3286 on the player.
         // The represented spell hook stores the same current-location bind.
-        let _ = self
+        if self
             .set_homebind_to_current_location_like_cpp(hello.unit)
-            .await;
+            .await
+        {
+            self.send_packet(&GossipComplete {
+                suppress_sound: false,
+            });
+        }
     }
 
     /// CMSG_TABARD_VENDOR_ACTIVATE — player talks to a tabard designer.
@@ -20388,8 +20409,37 @@ mod tests {
         );
         assert_eq!(
             drain_server_opcodes(&send_rx),
-            vec![ServerOpcodes::BindPointUpdate, ServerOpcodes::PlayerBound]
+            vec![
+                ServerOpcodes::BindPointUpdate,
+                ServerOpcodes::PlayerBound,
+                ServerOpcodes::GossipComplete,
+            ]
         );
+    }
+
+    #[tokio::test]
+    async fn binder_activate_rejects_instanceable_map_like_cpp() {
+        let (mut session, send_rx, canonical) = make_bank_slot_session(1);
+        let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 31);
+        insert_banker_creature(&canonical, innkeeper, NPCFlags1::INNKEEPER.bits());
+        session.set_map_store(Arc::new(wow_data::MapStore::from_entries([
+            wow_data::MapEntry {
+                id: 571,
+                instance_type: wow_data::map::MAP_INSTANCE,
+                expansion_id: 2,
+                parent_map_id: -1,
+                cosmetic_parent_map_id: -1,
+                flags1: 0,
+                flags2: 0,
+            },
+        ])));
+
+        session
+            .handle_binder_activate(Hello { unit: innkeeper })
+            .await;
+
+        assert!(session.represented_homebind_like_cpp().is_none());
+        assert!(send_rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/crates/wow-world/src/handlers/character.rs
+++ b/crates/wow-world/src/handlers/character.rs
@@ -10755,7 +10755,7 @@ impl WorldSession {
             "BinderActivate {:?} account {}",
             hello.unit, self.account_id
         );
-        if !self.player_is_alive_like_cpp() {
+        if !self.player_is_strictly_in_world_like_cpp() || !self.player_is_alive_like_cpp() {
             return;
         }
         let Some(_innkeeper) = self.represented_npc_can_interact_with_like_cpp(
@@ -20703,6 +20703,70 @@ mod tests {
 
         assert!(session.represented_homebind_like_cpp().is_none());
         assert!(send_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn binder_activate_rejects_player_outside_world_like_cpp() {
+        let (mut session, send_rx, canonical) = make_bank_slot_session(1);
+        let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 33);
+        insert_banker_creature(&canonical, innkeeper, NPCFlags1::INNKEEPER.bits());
+        session.set_player_zone_area_like_cpp(12, 34);
+        install_bind_spell_fixture(&mut session);
+        assert!(
+            session
+                .mutate_canonical_player_like_cpp(|player| {
+                    player
+                        .unit_mut()
+                        .world_mut()
+                        .object_mut()
+                        .remove_from_world();
+                })
+                .is_some(),
+            "canonical player fixture"
+        );
+        assert!(session.player_is_alive_like_cpp());
+
+        session
+            .handle_binder_activate(Hello { unit: innkeeper })
+            .await;
+
+        assert!(session.represented_homebind_like_cpp().is_none());
+        assert!(
+            send_rx.try_recv().is_err(),
+            "C++ returns before interaction, bind mutation, and packets when Player::IsInWorld is false"
+        );
+    }
+
+    #[tokio::test]
+    async fn binder_activate_rejects_player_missing_from_canonical_world_like_cpp() {
+        let (mut session, send_rx, canonical) = make_bank_slot_session(1);
+        let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 34);
+        insert_banker_creature(&canonical, innkeeper, NPCFlags1::INNKEEPER.bits());
+        session.set_player_zone_area_like_cpp(12, 34);
+        install_bind_spell_fixture(&mut session);
+        let player_guid = session.player_guid().expect("player guid");
+        assert!(
+            canonical
+                .lock()
+                .unwrap()
+                .find_map_mut(571, 0)
+                .expect("canonical map")
+                .map_mut()
+                .remove_map_object(player_guid)
+                .is_some(),
+            "remove canonical player fixture"
+        );
+        assert!(session.player_is_alive_like_cpp());
+
+        session
+            .handle_binder_activate(Hello { unit: innkeeper })
+            .await;
+
+        assert!(session.represented_homebind_like_cpp().is_none());
+        assert!(
+            send_rx.try_recv().is_err(),
+            "C++ Player::IsInWorld is false after removal even while the session still has an alive player controller"
+        );
     }
 
     #[tokio::test]

--- a/crates/wow-world/src/handlers/character.rs
+++ b/crates/wow-world/src/handlers/character.rs
@@ -4933,42 +4933,13 @@ impl WorldSession {
         // (`Player::SendInitialPacketsAfterAddToMap`). Seed from DB until
         // that post-add terrain pass runs.
         self.set_player_zone_area_like_cpp(zone as u32, zone as u32);
-        {
-            let mut homebind_stmt = char_db.prepare(CharStatements::SEL_CHARACTER_HOMEBIND);
-            homebind_stmt.set_u64(0, guid.counter() as u64);
-            match char_db.query(&homebind_stmt).await {
-                Ok(homebind_result) => {
-                    if !homebind_result.is_empty() {
-                        let homebind = RepresentedHomebindLikeCpp {
-                            map_id: u32::from(homebind_result.try_read::<u16>(0).unwrap_or(0)),
-                            area_id: u32::from(homebind_result.try_read::<u16>(1).unwrap_or(0)),
-                            position: Position::new(
-                                homebind_result.try_read(2).unwrap_or(0.0),
-                                homebind_result.try_read(3).unwrap_or(0.0),
-                                homebind_result.try_read(4).unwrap_or(0.0),
-                                homebind_result.try_read(5).unwrap_or(0.0),
-                            ),
-                        };
-                        self.set_represented_homebind_like_cpp(homebind);
-                    } else {
-                        let homebind = RepresentedHomebindLikeCpp {
-                            map_id: u32::try_from(map_id).unwrap_or(0),
-                            area_id: u32::try_from(zone).unwrap_or(0),
-                            position,
-                        };
-                        self.seed_represented_homebind_from_load_like_cpp(homebind)
-                            .await;
-                    }
-                }
-                Err(error) => {
-                    warn!(
-                        player_guid = guid.counter(),
-                        %error,
-                        "failed to load represented character_homebind row"
-                    );
-                }
-            }
-        }
+        self.set_represented_homebind_like_cpp(RepresentedHomebindLikeCpp {
+            map_id: login_homebind.map_id,
+            area_id: login_homebind
+                .bind_area_id
+                .expect("validated character homebind must have an area ID"),
+            position: login_homebind.position,
+        });
         self.set_represented_guild_id_like_cpp(result.try_read::<u64>(11).unwrap_or(0));
         self.load_represented_player_difficulties_like_cpp(
             result.try_read::<u32>(44).unwrap_or(0),
@@ -10806,6 +10777,7 @@ impl WorldSession {
             );
             return;
         }
+        self.remove_represented_feign_death_if_needed_like_cpp();
 
         // C++ SendBindPoint has the creature cast spell 3286 on the player.
         // The represented spell hook stores the same current-location bind.

--- a/crates/wow-world/src/handlers/character.rs
+++ b/crates/wow-world/src/handlers/character.rs
@@ -576,8 +576,8 @@ fn login_bind_point_update_like_cpp(homebind: CharacterLoginLocationLikeCpp) -> 
         x: homebind.position.x,
         y: homebind.position.y,
         z: homebind.position.z,
-        map_id: i32::try_from(homebind.map_id).expect("character homebind map ID must fit packet"),
-        area_id: i32::try_from(bind_area_id).expect("character homebind area ID must fit packet"),
+        map_id: homebind.map_id,
+        area_id: bind_area_id,
     }
 }
 

--- a/crates/wow-world/src/handlers/character.rs
+++ b/crates/wow-world/src/handlers/character.rs
@@ -19631,6 +19631,32 @@ mod tests {
         (session, send_rx, canonical)
     }
 
+    fn insert_bank_test_player_in_world(
+        session: &WorldSession,
+        canonical: &Arc<std::sync::Mutex<wow_map::MapManager>>,
+    ) {
+        let player_guid = session.player_guid().expect("player guid");
+        let mut player = wow_entities::Player::new(Some(1), false);
+        player
+            .unit_mut()
+            .world_mut()
+            .object_mut()
+            .create(player_guid);
+        player.unit_mut().world_mut().set_map(571, 0).unwrap();
+        player
+            .unit_mut()
+            .world_mut()
+            .relocate(Position::new(0.0, 0.0, 0.0, 0.0));
+        player.unit_mut().world_mut().object_mut().add_to_world();
+        canonical
+            .lock()
+            .unwrap()
+            .create_world_map(571, 0)
+            .map_mut()
+            .insert_map_object_record(wow_entities::MapObjectRecord::new_player(player).unwrap())
+            .unwrap();
+    }
+
     fn install_bind_spell_fixture(session: &mut WorldSession) {
         let mut spell_store = wow_data::SpellStore::new();
         spell_store.insert(
@@ -20468,6 +20494,7 @@ mod tests {
     #[tokio::test]
     async fn binder_activate_sets_current_homebind_and_sends_bind_packets_like_cpp() {
         let (mut session, instance_rx, canonical) = make_bank_slot_session(16);
+        insert_bank_test_player_in_world(&session, &canonical);
         let (realm_tx, realm_rx) = flume::bounded::<Vec<u8>>(16);
         session.install_realm_send_channel_for_test(realm_tx);
         let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 30);
@@ -20543,6 +20570,7 @@ mod tests {
     #[tokio::test]
     async fn binder_activate_fans_spell_go_to_visible_nearby_observers_like_cpp() {
         let (mut session, sender_rx, canonical) = make_bank_slot_session(16);
+        insert_bank_test_player_in_world(&session, &canonical);
         let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 32);
         insert_banker_creature(&canonical, innkeeper, NPCFlags1::INNKEEPER.bits());
         session.set_player_zone_area_like_cpp(12, 34);
@@ -20693,6 +20721,7 @@ mod tests {
     #[tokio::test]
     async fn binder_activate_rejects_non_innkeeper_like_cpp() {
         let (mut session, send_rx, canonical) = make_bank_slot_session(1);
+        insert_bank_test_player_in_world(&session, &canonical);
         let creature = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 31);
         insert_banker_creature(&canonical, creature, NPCFlags1::BANKER.bits());
         session.set_player_zone_area_like_cpp(12, 34);
@@ -20708,6 +20737,7 @@ mod tests {
     #[tokio::test]
     async fn binder_activate_rejects_player_outside_world_like_cpp() {
         let (mut session, send_rx, canonical) = make_bank_slot_session(1);
+        insert_bank_test_player_in_world(&session, &canonical);
         let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 33);
         insert_banker_creature(&canonical, innkeeper, NPCFlags1::INNKEEPER.bits());
         session.set_player_zone_area_like_cpp(12, 34);
@@ -20740,6 +20770,7 @@ mod tests {
     #[tokio::test]
     async fn binder_activate_rejects_player_missing_from_canonical_world_like_cpp() {
         let (mut session, send_rx, canonical) = make_bank_slot_session(1);
+        insert_bank_test_player_in_world(&session, &canonical);
         let innkeeper = ObjectGuid::create_world_object(HighGuid::Creature, 0, 1, 571, 0, 2456, 34);
         insert_banker_creature(&canonical, innkeeper, NPCFlags1::INNKEEPER.bits());
         session.set_player_zone_area_like_cpp(12, 34);

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -52257,6 +52257,7 @@ impl WorldSession {
                         ),
                     wow_data::spell::implicit_targets::TARGET_DEST_DB => self
                         .represented_db_caster_destination_target_data_like_cpp(
+                            caster_guid,
                             &spell_info,
                             &isolated_effect,
                             &selection_input,
@@ -53923,59 +53924,7 @@ impl WorldSession {
             let homebind = self.represented_homebind_like_cpp()?;
             (homebind.map_id, ObjectGuid::EMPTY, homebind.position)
         } else {
-            let map_key = self
-                .current_canonical_player_map_key_like_cpp()
-                .unwrap_or_else(|| {
-                    wow_map::MapKey::new(u32::from(self.player_map_id_like_cpp()), 0)
-                });
-            let legacy_map_id = u16::try_from(map_key.map_id).ok()?;
-            let (transport, position) = self
-                .canonical_map_manager
-                .as_ref()
-                .and_then(|manager| {
-                    let manager = manager.lock().ok()?;
-                    let map = manager.find_map(map_key.map_id, map_key.instance_id)?;
-                    let map = map.map();
-                    let creature = map.get_typed_creature(caster_guid)?;
-                    let world_position = creature.unit().world().position();
-                    if let Some(vehicle_base_guid) =
-                        creature.unit().subsystems().vehicle.vehicle_guid
-                    {
-                        let vehicle_base_position = map
-                            .get_typed_player(vehicle_base_guid)
-                            .map(|player| player.unit().world().position())
-                            .or_else(|| {
-                                map.get_typed_creature(vehicle_base_guid)
-                                    .map(|creature| creature.unit().world().position())
-                            })?;
-                        Some((
-                            vehicle_base_guid,
-                            wow_entities::calculate_passenger_offset(
-                                world_position,
-                                vehicle_base_position,
-                            ),
-                        ))
-                    } else if let Some(transport) =
-                        map.get_typed_transport_for_passenger_like_cpp(caster_guid)
-                    {
-                        Some((
-                            transport.world().guid(),
-                            transport.calculate_passenger_offset(world_position),
-                        ))
-                    } else {
-                        Some((ObjectGuid::EMPTY, world_position))
-                    }
-                })
-                .or_else(|| {
-                    self.map_manager.as_ref().and_then(|manager| {
-                        manager
-                            .read()
-                            .unwrap_or_else(|poisoned| poisoned.into_inner())
-                            .find_creature(legacy_map_id, map_key.instance_id, caster_guid)
-                            .map(|creature| (ObjectGuid::EMPTY, creature.position()))
-                    })
-                })?;
-            (map_key.map_id, transport, position)
+            self.represented_effective_caster_destination_like_cpp(caster_guid)?
         };
         let mut target_data = target_data.clone();
         target_data.flags |= 0x0000_0040; // C++ TARGET_FLAG_DEST_LOCATION
@@ -53985,6 +53934,71 @@ impl WorldSession {
         });
         target_data.map_id = Some(i32::try_from(map_id).unwrap_or(i32::MAX));
         Some(target_data)
+    }
+
+    fn represented_effective_caster_destination_like_cpp(
+        &self,
+        caster_guid: ObjectGuid,
+    ) -> Option<(u32, ObjectGuid, Position)> {
+        let map_key = self
+            .current_canonical_player_map_key_like_cpp()
+            .unwrap_or_else(|| wow_map::MapKey::new(u32::from(self.player_map_id_like_cpp()), 0));
+        let legacy_map_id = u16::try_from(map_key.map_id).ok()?;
+        let canonical_destination = self.canonical_map_manager.as_ref().and_then(|manager| {
+            let manager = manager.lock().ok()?;
+            let map = manager.find_map(map_key.map_id, map_key.instance_id)?;
+            let map = map.map();
+            let (world_position, vehicle_base_guid) = if Some(caster_guid) == self.player_guid() {
+                let player = map.get_typed_player(caster_guid)?;
+                (
+                    player.unit().world().position(),
+                    player.unit().subsystems().vehicle.vehicle_guid,
+                )
+            } else {
+                let creature = map.get_typed_creature(caster_guid)?;
+                (
+                    creature.unit().world().position(),
+                    creature.unit().subsystems().vehicle.vehicle_guid,
+                )
+            };
+            if let Some(vehicle_base_guid) = vehicle_base_guid {
+                let vehicle_base_position = map
+                    .get_typed_player(vehicle_base_guid)
+                    .map(|player| player.unit().world().position())
+                    .or_else(|| {
+                        map.get_typed_creature(vehicle_base_guid)
+                            .map(|creature| creature.unit().world().position())
+                    })?;
+                Some((
+                    vehicle_base_guid,
+                    wow_entities::calculate_passenger_offset(world_position, vehicle_base_position),
+                ))
+            } else if let Some(transport) =
+                map.get_typed_transport_for_passenger_like_cpp(caster_guid)
+            {
+                Some((
+                    transport.world().guid(),
+                    transport.calculate_passenger_offset(world_position),
+                ))
+            } else {
+                Some((ObjectGuid::EMPTY, world_position))
+            }
+        });
+        let (transport, position) = canonical_destination.or_else(|| {
+            if Some(caster_guid) == self.player_guid() {
+                self.player_position_like_cpp()
+                    .map(|position| (ObjectGuid::EMPTY, position))
+            } else {
+                self.map_manager.as_ref().and_then(|manager| {
+                    manager
+                        .read()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .find_creature(legacy_map_id, map_key.instance_id, caster_guid)
+                        .map(|creature| (ObjectGuid::EMPTY, creature.position()))
+                })
+            }
+        })?;
+        Some((map_key.map_id, transport, position))
     }
 
     fn represented_transport_destination_world_position_like_cpp(
@@ -54014,6 +54028,7 @@ impl WorldSession {
 
     fn represented_db_caster_destination_target_data_like_cpp(
         &self,
+        caster_guid: ObjectGuid,
         spell_info: &wow_data::SpellInfo,
         effect: &wow_data::SpellEffectInfo,
         target_data: &SpellTargetData,
@@ -54042,23 +54057,29 @@ impl WorldSession {
                     | wow_data::spell::spell_effect_types::SPELL_EFFECT_BIND
             )
         });
-        let (position, map_id) = if let Some(target_position) = target_position {
+        // C++ initializes SpellDestination from *m_caster before applying the
+        // optional DB/object overrides. This must use the effective caster,
+        // including triggered creature casts and transport offsets.
+        let (caster_map_id, caster_transport, caster_position) =
+            self.represented_effective_caster_destination_like_cpp(caster_guid)?;
+        let (position, map_id, transport) = if let Some(target_position) = target_position {
             if cross_map_allowed {
                 (
                     target_position.position,
                     Some(i32::from(target_position.target_map_id)),
+                    ObjectGuid::EMPTY,
                 )
-            } else if target_position.target_map_id == self.player_map_id_like_cpp() {
-                (target_position.position, None)
+            } else if u32::from(target_position.target_map_id) == caster_map_id {
+                (target_position.position, None, ObjectGuid::EMPTY)
             } else {
-                (self.player_position_like_cpp()?, None)
+                (caster_position, None, caster_transport)
             }
         } else if let Some(target_position) =
             self.represented_object_target_position_like_cpp(target_data)
         {
-            (target_position, None)
+            (target_position, None, ObjectGuid::EMPTY)
         } else {
-            (self.player_position_like_cpp()?, None)
+            (caster_position, None, caster_transport)
         };
         let position = self.apply_spell_destination_facing_override_like_cpp(
             spell_info.spell_id,
@@ -54069,7 +54090,7 @@ impl WorldSession {
         let mut target_data = target_data.clone();
         target_data.flags |= 0x0000_0040; // C++ TARGET_FLAG_DEST_LOCATION
         target_data.dst_location = Some(wow_packet::packets::spell::TargetLocation {
-            transport: ObjectGuid::EMPTY,
+            transport,
             position,
         });
         target_data.map_id = map_id;
@@ -73014,6 +73035,86 @@ mod tests {
         assert_eq!(damage_log.read_int32().expect("resisted"), 0);
         assert_eq!(damage_log.read_int32().expect("absorbed"), 0);
         assert!(!damage_log.has_bit().expect("has log data"));
+    }
+
+    #[tokio::test]
+    async fn creature_cast_db_destination_without_row_keeps_effective_caster_like_cpp() {
+        let (mut session, _, send_rx) = make_session();
+        let spell_id = 86_903_i32;
+        let template_entry = 9021_u32;
+        let player_guid = ObjectGuid::create_player(1, 7021);
+        let creature_guid = test_creature_guid(7022);
+        let player_position = Position::new(240.0, 340.0, 48.0, 0.25);
+        let creature_position = Position::new(246.0, 344.0, 49.0, 1.75);
+        let canonical = shared_canonical_map_manager();
+        let mut summon_effect =
+            summon_object_wild_effect_like_cpp(i32::try_from(template_entry).unwrap());
+        summon_effect.implicit_target_1 = wow_data::spell::implicit_targets::TARGET_DEST_DB;
+        let spell_info = gameobject_summon_spell_info_like_cpp(spell_id, 0, vec![summon_effect]);
+
+        configure_gameobject_summon_live_session_like_cpp(
+            &mut session,
+            &canonical,
+            player_guid,
+            player_position,
+            summon_go_template_store_like_cpp(template_entry),
+            spell_info,
+        );
+        add_canonical_test_creature_on_map(
+            &canonical,
+            creature_guid,
+            9022,
+            creature_position,
+            571,
+            0,
+            0,
+        );
+
+        session
+            .execute_spell_with_visual_and_target_data_with_metadata(
+                spell_id,
+                player_guid,
+                ObjectGuid::EMPTY,
+                wow_packet::packets::spell::SpellCastVisual::default(),
+                SpellTargetData::default(),
+                SpellCastMetadata {
+                    caster_guid_override: Some(creature_guid),
+                    ..SpellCastMetadata::default()
+                },
+            )
+            .await
+            .expect("creature TARGET_DEST_DB cast should execute without a DB row");
+
+        let manager = canonical.lock().unwrap();
+        let managed = manager.find_map(571, 0).expect("canonical map");
+        let summoned = session
+            .client_visible_guids_like_cpp
+            .iter()
+            .copied()
+            .filter(ObjectGuid::is_game_object)
+            .find_map(|guid| managed.map().get_typed_game_object(guid))
+            .expect("creature-cast summon should be visible");
+        assert_eq!(
+            summoned.world().position(),
+            creature_position,
+            "C++ TARGET_DEST_DB starts from SpellDestination(*m_caster), not the logged-in player"
+        );
+        drop(manager);
+
+        let bytes = send_rx.try_recv().expect("creature-cast SpellGo");
+        let packet_target = decode_spell_go_target_data_like_cpp(&bytes, spell_id);
+        assert_eq!(
+            packet_target
+                .dst_location
+                .expect("effective caster destination")
+                .position,
+            Position::new(
+                creature_position.x,
+                creature_position.y,
+                creature_position.z,
+                0.0,
+            )
+        );
     }
 
     #[tokio::test]

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -53626,7 +53626,7 @@ impl WorldSession {
             map_id: i32::try_from(homebind.map_id).unwrap_or(i32::MAX),
             area_id: i32::try_from(homebind.area_id).unwrap_or(i32::MAX),
         });
-        self.send_packet(&wow_packet::packets::misc::PlayerBound {
+        self.send_packet_realm(&wow_packet::packets::misc::PlayerBound {
             binder_id,
             area_id: homebind.area_id,
         });

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -1669,6 +1669,12 @@ pub(crate) struct RepresentedHomebindLikeCpp {
     pub position: wow_core::Position,
 }
 
+struct HomebindPersistenceJobLikeCpp {
+    char_db: Arc<CharacterDatabase>,
+    update_stmt: PreparedStatement,
+    guid_counter: u64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct RepresentedResurrectionRequestLikeCpp {
     pub resurrecter: wow_core::ObjectGuid,
@@ -3914,6 +3920,11 @@ pub struct WorldSession {
 
     // Character database
     char_db: Option<Arc<CharacterDatabase>>,
+    // FIFO sender for C++ CharacterDatabase.Execute-style detached homebind
+    // writes. Its single worker drains queued jobs after session teardown and
+    // preserves call order.
+    homebind_persistence_tx_like_cpp:
+        Option<tokio::sync::mpsc::UnboundedSender<HomebindPersistenceJobLikeCpp>>,
 
     // Login database (for realmcharacters updates)
     login_db: Option<Arc<LoginDatabase>>,
@@ -5954,6 +5965,7 @@ impl WorldSession {
             represented_runtime_rng_like_cpp: StdRng::from_entropy(),
             dispatch_table: build_dispatch_table(),
             char_db: None,
+            homebind_persistence_tx_like_cpp: None,
             login_db: None,
             world_db: None,
             bank_bag_slot_prices_store: None,
@@ -53657,8 +53669,7 @@ impl WorldSession {
                 area_id,
                 position,
             },
-        )
-        .await;
+        );
     }
 
     pub(crate) fn player_current_map_instanceable_like_cpp(&self) -> bool {
@@ -53668,13 +53679,13 @@ impl WorldSession {
             .is_some_and(|entry| entry.instance_type != wow_data::map::MAP_COMMON)
     }
 
-    async fn set_homebind_like_cpp(
+    fn set_homebind_like_cpp(
         &mut self,
         binder_id: ObjectGuid,
         homebind: RepresentedHomebindLikeCpp,
     ) {
         self.represented_homebind_like_cpp = Some(homebind);
-        self.persist_player_homebind_like_cpp(homebind).await;
+        self.persist_player_homebind_like_cpp(homebind);
 
         self.send_packet(&wow_packet::packets::misc::BindPointUpdate {
             x: homebind.position.x,
@@ -53704,7 +53715,7 @@ impl WorldSession {
         stmt
     }
 
-    async fn persist_player_homebind_like_cpp(&self, homebind: RepresentedHomebindLikeCpp) {
+    fn persist_player_homebind_like_cpp(&mut self, homebind: RepresentedHomebindLikeCpp) {
         let (Some(player_guid), Some(char_db)) =
             (self.player_guid(), self.char_db().map(Arc::clone))
         else {
@@ -53713,11 +53724,39 @@ impl WorldSession {
         let guid_counter = player_guid.counter() as u64;
         let update_stmt =
             Self::build_player_homebind_update_statement_like_cpp(homebind, guid_counter);
-        if let Err(error) = char_db.execute(&update_stmt).await {
+        // C++ Player::SetHomebind queues CharacterDatabase.Execute(stmt) on
+        // the ordered database worker and immediately sends the bind packets.
+        // Send it to one FIFO worker so SQL latency stays off the packet path
+        // without allowing an older bind to finish after a newer one.
+        let persistence_tx = self
+            .homebind_persistence_tx_like_cpp
+            .get_or_insert_with(|| {
+                let (tx, mut rx) =
+                    tokio::sync::mpsc::unbounded_channel::<HomebindPersistenceJobLikeCpp>();
+                tokio::spawn(async move {
+                    while let Some(job) = rx.recv().await {
+                        if let Err(error) = job.char_db.execute(&job.update_stmt).await {
+                            warn!(
+                                player_guid = job.guid_counter,
+                                %error,
+                                "failed to update represented player homebind"
+                            );
+                        }
+                    }
+                });
+                tx
+            });
+        if persistence_tx
+            .send(HomebindPersistenceJobLikeCpp {
+                char_db,
+                update_stmt,
+                guid_counter,
+            })
+            .is_err()
+        {
             warn!(
                 player_guid = guid_counter,
-                %error,
-                "failed to update represented player homebind"
+                "represented homebind database worker stopped"
             );
         }
     }

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -52218,6 +52218,70 @@ impl WorldSession {
             return Ok(());
         }
 
+        // C++ `Spell::SelectSpellTargets` resolves implicit destinations in
+        // effect/target order before `Spell::SendSpellGo`; later selections
+        // replace earlier ones through `SpellCastTargets::ModDst`.
+        let mut target_data = target_data;
+        let mut represented_implicit_destination = false;
+        let mut effect_target_data_like_cpp = Vec::new();
+        for effect in spell_info.effects() {
+            if effect.effect == 0 {
+                continue;
+            }
+            for implicit_target in [effect.implicit_target_1, effect.implicit_target_2] {
+                let mut isolated_effect = effect.clone();
+                isolated_effect.implicit_target_1 = implicit_target;
+                isolated_effect.implicit_target_2 = 0;
+                let mut selection_input = target_data.clone();
+                selection_input.flags &= !0x0000_0040;
+                selection_input.dst_location = None;
+                selection_input.map_id = None;
+                let selected = match implicit_target {
+                    wow_data::spell::implicit_targets::TARGET_DEST_HOME => self
+                        .represented_home_destination_target_data_like_cpp(
+                            &isolated_effect,
+                            &selection_input,
+                        ),
+                    wow_data::spell::implicit_targets::TARGET_DEST_DB => self
+                        .represented_db_caster_destination_target_data_like_cpp(
+                            &spell_info,
+                            &isolated_effect,
+                            &selection_input,
+                        ),
+                    wow_data::spell::implicit_targets::TARGET_DEST_NEARBY_ENTRY
+                    | wow_data::spell::implicit_targets::TARGET_DEST_NEARBY_ENTRY_2
+                    | wow_data::spell::implicit_targets::TARGET_DEST_NEARBY_ENTRY_OR_DB => self
+                        .represented_focus_destination_target_data_like_cpp(
+                            spell_id,
+                            &isolated_effect,
+                            &selection_input,
+                            represented_focus_object,
+                        )
+                        .or_else(|| {
+                            self.represented_nearby_entry_destination_target_data_like_cpp(
+                                spell_id,
+                                &isolated_effect,
+                                &selection_input,
+                            )
+                        }),
+                    _ => None,
+                };
+                if let Some(selected) = selected {
+                    target_data = selected;
+                    represented_implicit_destination = true;
+                }
+            }
+            // C++ snapshots `m_targets.GetDst()` into
+            // `m_destTargets[EffectIndex]` after selecting each effect.
+            effect_target_data_like_cpp.push((effect.effect_index, target_data.clone()));
+        }
+        let mut spell_go_target_data = target_data.clone();
+        if represented_implicit_destination {
+            // C++ retains map identity on SpellDestination for effect
+            // execution, while SpellCastTargets::Write emits DstLocation XYZ.
+            spell_go_target_data.map_id = None;
+        }
+
         // Send SMSG_SPELL_GO
         use wow_packet::packets::spell::SpellGoPkt;
 
@@ -52231,7 +52295,7 @@ impl WorldSession {
             cast_flags: metadata.cast_flags,
             cast_flags_ex: metadata.cast_flags_ex,
             cast_time_ms: Self::game_time_ms_like_cpp(),
-            target: target_data.clone(),
+            target: spell_go_target_data,
             hit_targets: vec![target_guid],
         };
         self.send_packet(&go_pkt);
@@ -52245,10 +52309,15 @@ impl WorldSession {
         let mut force_visibility_after_add_farsight = false;
         for effect in spell_info.effects() {
             if effect.effect == wow_data::spell::spell_effect_types::SPELL_EFFECT_ADD_FARSIGHT {
+                let effect_target_data = effect_target_data_like_cpp
+                    .iter()
+                    .find(|(effect_index, _)| *effect_index == effect.effect_index)
+                    .map(|(_, target_data)| target_data)
+                    .unwrap_or(&target_data);
                 if let Some(outcome) = self.apply_effect_add_farsight_like_cpp(
                     spell_id,
                     effect,
-                    &target_data,
+                    effect_target_data,
                     spell_visual_id,
                     spell_info.cast_time_ms,
                 ) {
@@ -52262,19 +52331,10 @@ impl WorldSession {
         }
 
         for effect in spell_info.effects() {
-            let represented_home_target_data =
-                self.represented_home_destination_target_data_like_cpp(effect, &target_data);
-            let represented_db_target_data = self
-                .represented_db_caster_destination_target_data_like_cpp(
-                    &spell_info,
-                    effect,
-                    represented_home_target_data
-                        .as_ref()
-                        .unwrap_or(&target_data),
-                );
-            let effect_target_data = represented_db_target_data
-                .as_ref()
-                .or(represented_home_target_data.as_ref())
+            let effect_target_data = effect_target_data_like_cpp
+                .iter()
+                .find(|(effect_index, _)| *effect_index == effect.effect_index)
+                .map(|(_, target_data)| target_data)
                 .unwrap_or(&target_data);
             self.apply_effect_teleport_units_like_cpp(effect, target_guid, effect_target_data)
                 .await;
@@ -52306,32 +52366,10 @@ impl WorldSession {
 
         let mut force_visibility_after_gameobject_summon = false;
         for effect in spell_info.effects() {
-            let represented_focus_target_data = self
-                .represented_focus_destination_target_data_like_cpp(
-                    spell_id,
-                    effect,
-                    &target_data,
-                    represented_focus_object,
-                );
-            let represented_db_target_data = if represented_focus_target_data.is_none() {
-                self.represented_db_caster_destination_target_data_like_cpp(
-                    &spell_info,
-                    effect,
-                    &target_data,
-                )
-                .or_else(|| {
-                    self.represented_nearby_entry_destination_target_data_like_cpp(
-                        spell_id,
-                        effect,
-                        &target_data,
-                    )
-                })
-            } else {
-                None
-            };
-            let effect_target_data = represented_focus_target_data
-                .as_ref()
-                .or(represented_db_target_data.as_ref())
+            let effect_target_data = effect_target_data_like_cpp
+                .iter()
+                .find(|(effect_index, _)| *effect_index == effect.effect_index)
+                .map(|(_, target_data)| target_data)
                 .unwrap_or(&target_data);
             if let Some(outcome) = self.apply_effect_summon_object_wild_with_focus_like_cpp(
                 spell_id,
@@ -52394,6 +52432,11 @@ impl WorldSession {
             direct_effect_trigger_spell,
         ) in direct_spell_effects_like_cpp
         {
+            let direct_effect_target_data = effect_target_data_like_cpp
+                .iter()
+                .find(|(effect_index, _)| *effect_index == direct_effect_index)
+                .map(|(_, target_data)| target_data)
+                .unwrap_or(&target_data);
             match direct_effect_type {
                 x if wow_data::spell::spell_effect_types::is_cpp_null_or_unused_noop(x) => {}
                 x if x == wow_data::spell::spell_effect_types::SPELL_EFFECT_INSTAKILL => {
@@ -52510,7 +52553,7 @@ impl WorldSession {
                     self.apply_distract_effect_like_cpp(
                         direct_effect_base_points,
                         target_guid,
-                        &target_data,
+                        direct_effect_target_data,
                     )?;
                 }
                 x if x
@@ -52571,7 +52614,7 @@ impl WorldSession {
                 {
                     self.apply_change_raid_marker_effect_like_cpp(
                         direct_effect_base_points,
-                        &target_data,
+                        direct_effect_target_data,
                     );
                 }
                 x if x == wow_data::spell::spell_effect_types::SPELL_EFFECT_LEARN_SPELL => {
@@ -53747,6 +53790,7 @@ impl WorldSession {
         );
 
         let mut target_data = target_data.clone();
+        target_data.flags |= 0x0000_0040; // C++ TARGET_FLAG_DEST_LOCATION
         target_data.dst_location = Some(wow_packet::packets::spell::TargetLocation {
             transport: ObjectGuid::EMPTY,
             position: focus_position,
@@ -53806,20 +53850,19 @@ impl WorldSession {
         effect: &wow_data::SpellEffectInfo,
         target_data: &SpellTargetData,
     ) -> Option<SpellTargetData> {
-        if target_data.dst_location.is_some()
-            || !matches!(
-                effect.implicit_target_1,
-                wow_data::spell::implicit_targets::TARGET_DEST_HOME
-            ) && !matches!(
-                effect.implicit_target_2,
-                wow_data::spell::implicit_targets::TARGET_DEST_HOME
-            )
-        {
+        if !matches!(
+            effect.implicit_target_1,
+            wow_data::spell::implicit_targets::TARGET_DEST_HOME
+        ) && !matches!(
+            effect.implicit_target_2,
+            wow_data::spell::implicit_targets::TARGET_DEST_HOME
+        ) {
             return None;
         }
 
         let homebind = self.represented_homebind_like_cpp()?;
         let mut target_data = target_data.clone();
+        target_data.flags |= 0x0000_0040; // C++ TARGET_FLAG_DEST_LOCATION
         target_data.dst_location = Some(wow_packet::packets::spell::TargetLocation {
             transport: ObjectGuid::EMPTY,
             position: homebind.position,
@@ -53883,6 +53926,7 @@ impl WorldSession {
         );
 
         let mut target_data = target_data.clone();
+        target_data.flags |= 0x0000_0040; // C++ TARGET_FLAG_DEST_LOCATION
         target_data.dst_location = Some(wow_packet::packets::spell::TargetLocation {
             transport: ObjectGuid::EMPTY,
             position,
@@ -53965,6 +54009,7 @@ impl WorldSession {
             self.apply_spell_destination_facing_override_like_cpp(spell_id, effect, randomized)
         };
         let mut target_data = target_data.clone();
+        target_data.flags |= 0x0000_0040; // C++ TARGET_FLAG_DEST_LOCATION
         target_data.dst_location = Some(wow_packet::packets::spell::TargetLocation {
             transport: ObjectGuid::EMPTY,
             position,
@@ -71848,9 +71893,45 @@ mod tests {
         assert_eq!(session.state, SessionState::Transfer);
     }
 
+    fn decode_spell_go_target_data_like_cpp(
+        bytes: &[u8],
+        expected_spell_id: i32,
+    ) -> SpellTargetData {
+        let mut spell_go = WorldPacket::from_bytes(bytes);
+        assert_eq!(
+            spell_go.read_uint16().expect("SpellGo opcode"),
+            ServerOpcodes::SpellGo as u16
+        );
+        for label in ["caster", "caster unit", "cast id", "original cast id"] {
+            spell_go.read_packed_guid().expect(label);
+        }
+        assert_eq!(spell_go.read_int32().expect("spell id"), expected_spell_id);
+        wow_packet::packets::spell::SpellCastVisual::read(&mut spell_go).expect("spell visual");
+        spell_go.read_uint32().expect("cast flags");
+        spell_go.read_uint32().expect("cast flags ex");
+        spell_go.read_uint32().expect("cast time");
+        spell_go.read_int32().expect("missile travel time");
+        spell_go.read_float().expect("missile pitch");
+        spell_go.read_uint8().expect("destination cast index");
+        spell_go.read_uint32().expect("immunity school");
+        spell_go.read_uint32().expect("immunity value");
+        spell_go.read_uint32().expect("heal prediction points");
+        spell_go.read_uint8().expect("heal prediction type");
+        spell_go.read_packed_guid().expect("heal prediction beacon");
+        spell_go.read_bits(16).expect("hit target count");
+        spell_go.read_bits(16).expect("miss target count");
+        spell_go.read_bits(16).expect("miss status count");
+        spell_go.read_bits(9).expect("remaining power count");
+        spell_go.read_bit().expect("remaining runes presence");
+        spell_go.read_bits(16).expect("target point count");
+        spell_go.read_bit().expect("ammo display presence");
+        spell_go.read_bit().expect("ammo inventory presence");
+        SpellTargetData::read(&mut spell_go).expect("SpellGo target data")
+    }
+
     #[tokio::test]
     async fn teleport_units_target_dest_home_uses_represented_homebind_like_cpp() {
-        let (mut session, _, _send_rx) = make_session();
+        let (mut session, _, send_rx) = make_session();
         let spell_id = 8690_i32;
         let player_guid = ObjectGuid::create_player(1, 7040);
         let player_position = Position::new(300.0, 400.0, 60.0, 0.5);
@@ -71894,13 +71975,137 @@ mod tests {
                     spell_visual_id: 8690,
                     script_visual_id: 0,
                 },
-                SpellTargetData::default(),
+                SpellTargetData {
+                    flags: 0x0000_0040,
+                    dst_location: Some(wow_packet::packets::spell::TargetLocation {
+                        transport: ObjectGuid::EMPTY,
+                        position: Position::new(999.0, 998.0, 997.0, 0.0),
+                    }),
+                    map_id: Some(571),
+                    ..SpellTargetData::default()
+                },
             )
             .await
             .expect("TARGET_DEST_HOME hearthstone teleport should execute");
 
+        let bytes = send_rx.try_recv().expect("hearthstone SpellGo");
+        let packet_target = decode_spell_go_target_data_like_cpp(&bytes, spell_id);
+        assert_ne!(packet_target.flags & 0x0000_0040, 0);
+        assert_eq!(
+            packet_target
+                .dst_location
+                .expect("resolved home destination")
+                .position,
+            Position::new(home_position.x, home_position.y, home_position.z, 0.0),
+            "C++ SelectSpellTargets resolves TARGET_DEST_HOME before SpellGo"
+        );
+        assert_eq!(packet_target.map_id, None);
         assert_eq!(session.pending_teleport, Some((1, home_position)));
         assert_eq!(session.state, SessionState::Transfer);
+    }
+
+    #[tokio::test]
+    async fn implicit_destination_selection_uses_cpp_effect_order_before_spell_go() {
+        let (mut session, _, send_rx) = make_session();
+        let spell_id = 86_901_i32;
+        let player_guid = ObjectGuid::create_player(1, 7042);
+        let player_position = Position::new(310.0, 410.0, 62.0, 0.5);
+        let home_position = Position::new(40.0, 50.0, 60.0, 1.25);
+        let db_destination = Position::new(70.0, 80.0, 90.0, 2.5);
+        let canonical = shared_canonical_map_manager();
+        let home_effect = wow_data::SpellEffectInfo {
+            effect_index: 0,
+            effect: wow_data::spell::spell_effect_types::SPELL_EFFECT_BIND,
+            implicit_target_1: wow_data::spell::implicit_targets::TARGET_DEST_HOME,
+            ..Default::default()
+        };
+        let db_effect = wow_data::SpellEffectInfo {
+            effect_index: 1,
+            effect: wow_data::spell::spell_effect_types::SPELL_EFFECT_TELEPORT_UNITS,
+            implicit_target_1: wow_data::spell::implicit_targets::TARGET_DEST_DB,
+            ..Default::default()
+        };
+        let empty_home_effect = wow_data::SpellEffectInfo {
+            effect_index: 2,
+            effect: 0,
+            implicit_target_1: wow_data::spell::implicit_targets::TARGET_DEST_HOME,
+            ..Default::default()
+        };
+        let spell_info = teleport_units_spell_info_like_cpp(
+            spell_id,
+            vec![home_effect, db_effect.clone(), empty_home_effect],
+        );
+
+        session.set_canonical_map_manager(Arc::clone(&canonical));
+        session.attach_player_controller_like_cpp(SessionPlayerController::new(
+            player_guid,
+            "OrderedDestination".to_string(),
+            player_position,
+            571,
+            1,
+            1,
+            80,
+            0,
+        ));
+        session.set_represented_homebind_like_cpp(RepresentedHomebindLikeCpp {
+            map_id: 1,
+            area_id: 1519,
+            position: home_position,
+        });
+        add_canonical_test_player_on_map(&canonical, player_guid, player_position, 571, 0);
+        let mut spell_store = wow_data::SpellStore::new();
+        spell_store.insert(spell_id, spell_info.clone());
+        session.set_spell_store(Arc::new(spell_store));
+        let mut target_spell_store = wow_data::SpellStore::new();
+        target_spell_store.insert(spell_id, spell_info);
+        session.set_spell_target_position_store(Arc::new(
+            wow_data::SpellTargetPositionStoreLikeCpp::from_rows_like_cpp(
+                [wow_data::SpellTargetPositionRowLikeCpp {
+                    spell_id: spell_id as u32,
+                    effect_index: db_effect.effect_index,
+                    target_map_id: 1,
+                    x: db_destination.x,
+                    y: db_destination.y,
+                    z: db_destination.z,
+                    orientation: Some(db_destination.orientation),
+                }],
+                &target_spell_store,
+                |map_id| matches!(map_id, 1 | 571),
+            ),
+        ));
+
+        session
+            .execute_spell_with_visual_and_target_data(
+                spell_id,
+                player_guid,
+                ObjectGuid::EMPTY,
+                wow_packet::packets::spell::SpellCastVisual::default(),
+                SpellTargetData::default(),
+            )
+            .await
+            .expect("ordered HOME then DB teleport should execute");
+
+        let bytes = send_rx.try_recv().expect("ordered destination SpellGo");
+        let packet_target = decode_spell_go_target_data_like_cpp(&bytes, spell_id);
+        assert_ne!(packet_target.flags & 0x0000_0040, 0);
+        assert_eq!(
+            packet_target
+                .dst_location
+                .expect("resolved final DB destination")
+                .position,
+            Position::new(db_destination.x, db_destination.y, db_destination.z, 0.0),
+            "later TARGET_DEST_DB replaces earlier TARGET_DEST_HOME like C++ ModDst"
+        );
+        assert_eq!(packet_target.map_id, None);
+        assert_eq!(
+            session
+                .represented_homebind_like_cpp()
+                .expect("bind effect home snapshot")
+                .position,
+            home_position,
+            "effect 0 BIND keeps its HOME snapshot while later TELEPORT uses DB"
+        );
+        assert_eq!(session.pending_teleport, Some((1, db_destination)));
     }
 
     #[tokio::test]

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -73106,8 +73106,8 @@ mod tests {
             creature_guid,
             9022,
             creature_position,
-            571,
             0,
+            571,
             0,
         );
 

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -27511,7 +27511,7 @@ impl WorldSession {
         self.pending_invites.as_ref()
     }
 
-    fn player_is_in_world_for_registry_like_cpp(&self) -> bool {
+    pub(crate) fn player_is_in_world_for_registry_like_cpp(&self) -> bool {
         let Some(guid) = self.player_guid() else {
             return false;
         };
@@ -27535,6 +27535,28 @@ impl WorldSession {
         // Registry insertion happens only after successful character login; logout/disconnect
         // unregisters instead of leaving a false/stale row behind.
         true
+    }
+
+    pub(crate) fn player_is_strictly_in_world_like_cpp(&self) -> bool {
+        let Some(guid) = self.player_guid() else {
+            return false;
+        };
+        let Some(manager) = self
+            .canonical_map_manager
+            .as_ref()
+            .and_then(|manager| manager.lock().ok())
+        else {
+            return false;
+        };
+        let mut is_in_world = None;
+        manager.do_for_all_maps(|managed| {
+            if is_in_world.is_none()
+                && let Some(player) = managed.map().get_typed_player(guid)
+            {
+                is_in_world = Some(player.unit().world().object().is_in_world());
+            }
+        });
+        is_in_world.unwrap_or(false)
     }
 
     pub(crate) fn player_unit_state_for_registry_like_cpp(&self) -> u32 {

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -4690,8 +4690,8 @@ pub struct WorldSession {
         Option<(u32, wow_core::Position, TeleportToOptionsLikeCpp)>,
     /// Represented zone/area for the pending near-teleport destination.
     near_teleport_destination_zone_area_like_cpp: Option<(u32, u32)>,
-    /// C++ `Player::m_homebind` / `m_homebindAreaId` represented until
-    /// `character_homebind` loading/saving is wired into the player runtime.
+    /// C++ `Player::m_homebind` / `m_homebindAreaId` represented until full
+    /// player-owned load validation/fallback replaces the session field.
     represented_homebind_like_cpp: Option<RepresentedHomebindLikeCpp>,
     /// C++ `Player::_resurrectionData`, represented until real Player/Spell
     /// resurrection request ownership exists.
@@ -52187,16 +52187,24 @@ impl WorldSession {
         }
 
         for effect in spell_info.effects() {
+            let represented_home_target_data =
+                self.represented_home_destination_target_data_like_cpp(effect, &target_data);
             let represented_db_target_data = self
                 .represented_db_caster_destination_target_data_like_cpp(
                     &spell_info,
                     effect,
-                    &target_data,
+                    represented_home_target_data
+                        .as_ref()
+                        .unwrap_or(&target_data),
                 );
-            let effect_target_data = represented_db_target_data.as_ref().unwrap_or(&target_data);
+            let effect_target_data = represented_db_target_data
+                .as_ref()
+                .or(represented_home_target_data.as_ref())
+                .unwrap_or(&target_data);
             self.apply_effect_teleport_units_like_cpp(effect, target_guid, effect_target_data)
                 .await;
-            self.apply_effect_bind_like_cpp(effect, player_guid, target_guid, effect_target_data);
+            self.apply_effect_bind_like_cpp(effect, player_guid, target_guid, effect_target_data)
+                .await;
         }
 
         if spell_info.effects().is_empty() {
@@ -52217,7 +52225,8 @@ impl WorldSession {
                 player_guid,
                 target_guid,
                 &target_data,
-            );
+            )
+            .await;
         }
 
         let mut force_visibility_after_gameobject_summon = false;
@@ -53469,7 +53478,7 @@ impl WorldSession {
         self.teleport_to(target_map, destination).await;
     }
 
-    fn apply_effect_bind_like_cpp(
+    async fn apply_effect_bind_like_cpp(
         &mut self,
         effect: &wow_data::SpellEffectInfo,
         caster_guid: ObjectGuid,
@@ -53507,30 +53516,129 @@ impl WorldSession {
             .and_then(|map_id| u32::try_from(map_id).ok())
             .unwrap_or_else(|| u32::from(self.player_map_id_like_cpp()));
 
-        self.represented_homebind_like_cpp = Some(RepresentedHomebindLikeCpp {
-            map_id,
-            area_id,
-            position,
-        });
+        self.set_homebind_like_cpp(
+            caster_guid,
+            RepresentedHomebindLikeCpp {
+                map_id,
+                area_id,
+                position,
+            },
+        )
+        .await;
+    }
+
+    pub(crate) async fn set_homebind_to_current_location_like_cpp(
+        &mut self,
+        binder_id: ObjectGuid,
+    ) -> bool {
+        let Some(position) = self.player_position_like_cpp() else {
+            return false;
+        };
+        let (_, area_id) = self.player_zone_area_like_cpp();
+        let map_id = u32::from(self.player_map_id_like_cpp());
+        self.set_homebind_like_cpp(
+            binder_id,
+            RepresentedHomebindLikeCpp {
+                map_id,
+                area_id,
+                position,
+            },
+        )
+        .await;
+        true
+    }
+
+    async fn set_homebind_like_cpp(
+        &mut self,
+        binder_id: ObjectGuid,
+        homebind: RepresentedHomebindLikeCpp,
+    ) {
+        self.represented_homebind_like_cpp = Some(homebind);
+        self.persist_player_homebind_like_cpp(homebind).await;
 
         self.send_packet(&wow_packet::packets::misc::BindPointUpdate {
-            x: position.x,
-            y: position.y,
-            z: position.z,
-            map_id: i32::try_from(map_id).unwrap_or(i32::MAX),
-            area_id: i32::try_from(area_id).unwrap_or(i32::MAX),
+            x: homebind.position.x,
+            y: homebind.position.y,
+            z: homebind.position.z,
+            map_id: i32::try_from(homebind.map_id).unwrap_or(i32::MAX),
+            area_id: i32::try_from(homebind.area_id).unwrap_or(i32::MAX),
         });
         self.send_packet(&wow_packet::packets::misc::PlayerBound {
-            binder_id: caster_guid,
-            area_id,
+            binder_id,
+            area_id: homebind.area_id,
         });
+    }
+
+    fn build_player_homebind_update_statement_like_cpp(
+        homebind: RepresentedHomebindLikeCpp,
+        guid_counter: u64,
+    ) -> PreparedStatement {
+        let mut stmt = PreparedStatement::new(CharStatements::UPD_PLAYER_HOMEBIND.sql());
+        stmt.set_u16(0, u16::try_from(homebind.map_id).unwrap_or(u16::MAX));
+        stmt.set_u16(1, u16::try_from(homebind.area_id).unwrap_or(u16::MAX));
+        stmt.set_f32(2, homebind.position.x);
+        stmt.set_f32(3, homebind.position.y);
+        stmt.set_f32(4, homebind.position.z);
+        stmt.set_f32(5, homebind.position.orientation);
+        stmt.set_u64(6, guid_counter);
+        stmt
+    }
+
+    fn build_player_homebind_insert_statement_like_cpp(
+        homebind: RepresentedHomebindLikeCpp,
+        guid_counter: u64,
+    ) -> PreparedStatement {
+        let mut stmt = PreparedStatement::new(CharStatements::INS_PLAYER_HOMEBIND.sql());
+        stmt.set_u64(0, guid_counter);
+        stmt.set_u16(1, u16::try_from(homebind.map_id).unwrap_or(u16::MAX));
+        stmt.set_u16(2, u16::try_from(homebind.area_id).unwrap_or(u16::MAX));
+        stmt.set_f32(3, homebind.position.x);
+        stmt.set_f32(4, homebind.position.y);
+        stmt.set_f32(5, homebind.position.z);
+        stmt.set_f32(6, homebind.position.orientation);
+        stmt
+    }
+
+    async fn persist_player_homebind_like_cpp(&self, homebind: RepresentedHomebindLikeCpp) {
+        let (Some(player_guid), Some(char_db)) =
+            (self.player_guid(), self.char_db().map(Arc::clone))
+        else {
+            return;
+        };
+        let guid_counter = player_guid.counter() as u64;
+        let update_stmt =
+            Self::build_player_homebind_update_statement_like_cpp(homebind, guid_counter);
+        match char_db.execute(&update_stmt).await {
+            Ok(0) => {
+                // C++ Player::_LoadHomebind creates a missing row before
+                // Player::SetHomebind later uses CHAR_UPD_PLAYER_HOMEBIND.
+                // Rust's represented login path can still lack that invariant,
+                // so recover it here without changing the C++ update bind order.
+                let insert_stmt =
+                    Self::build_player_homebind_insert_statement_like_cpp(homebind, guid_counter);
+                if let Err(error) = char_db.execute(&insert_stmt).await {
+                    warn!(
+                        player_guid = guid_counter,
+                        %error,
+                        "failed to insert represented player homebind after update affected zero rows"
+                    );
+                }
+            }
+            Ok(_) => {}
+            Err(error) => {
+                warn!(
+                    player_guid = guid_counter,
+                    %error,
+                    "failed to update represented player homebind"
+                );
+            }
+        }
     }
 
     pub(crate) fn represented_homebind_like_cpp(&self) -> Option<RepresentedHomebindLikeCpp> {
         self.represented_homebind_like_cpp
     }
 
-    #[cfg(test)]
     pub(crate) fn set_represented_homebind_like_cpp(
         &mut self,
         homebind: RepresentedHomebindLikeCpp,
@@ -53661,6 +53769,33 @@ impl WorldSession {
         map.map()
             .get_typed_dynamic_object(target_guid)
             .map(|dynamic_object| dynamic_object.world().position())
+    }
+
+    fn represented_home_destination_target_data_like_cpp(
+        &self,
+        effect: &wow_data::SpellEffectInfo,
+        target_data: &SpellTargetData,
+    ) -> Option<SpellTargetData> {
+        if target_data.dst_location.is_some()
+            || !matches!(
+                effect.implicit_target_1,
+                wow_data::spell::implicit_targets::TARGET_DEST_HOME
+            ) && !matches!(
+                effect.implicit_target_2,
+                wow_data::spell::implicit_targets::TARGET_DEST_HOME
+            )
+        {
+            return None;
+        }
+
+        let homebind = self.represented_homebind_like_cpp()?;
+        let mut target_data = target_data.clone();
+        target_data.dst_location = Some(wow_packet::packets::spell::TargetLocation {
+            transport: ObjectGuid::EMPTY,
+            position: homebind.position,
+        });
+        target_data.map_id = Some(i32::try_from(homebind.map_id).unwrap_or(i32::MAX));
+        Some(target_data)
     }
 
     fn represented_db_caster_destination_target_data_like_cpp(
@@ -71681,6 +71816,110 @@ mod tests {
             "C++ EffectTeleportUnits accepts cross-map TARGET_DEST_DB, fills missing orientation from unitTarget, and calls Player::TeleportTo"
         );
         assert_eq!(session.state, SessionState::Transfer);
+    }
+
+    #[tokio::test]
+    async fn teleport_units_target_dest_home_uses_represented_homebind_like_cpp() {
+        let (mut session, _, _send_rx) = make_session();
+        let spell_id = 8690_i32;
+        let player_guid = ObjectGuid::create_player(1, 7040);
+        let player_position = Position::new(300.0, 400.0, 60.0, 0.5);
+        let home_position = Position::new(40.0, 50.0, 60.0, 1.25);
+        let canonical = shared_canonical_map_manager();
+        let hearth_effect = wow_data::SpellEffectInfo {
+            effect_index: 0,
+            effect: wow_data::spell::spell_effect_types::SPELL_EFFECT_TELEPORT_UNITS,
+            implicit_target_1: wow_data::spell::implicit_targets::TARGET_DEST_HOME,
+            ..Default::default()
+        };
+        let spell_info = teleport_units_spell_info_like_cpp(spell_id, vec![hearth_effect]);
+
+        session.set_canonical_map_manager(Arc::clone(&canonical));
+        session.attach_player_controller_like_cpp(SessionPlayerController::new(
+            player_guid,
+            "HearthHome".to_string(),
+            player_position,
+            571,
+            1,
+            1,
+            80,
+            0,
+        ));
+        session.set_represented_homebind_like_cpp(RepresentedHomebindLikeCpp {
+            map_id: 1,
+            area_id: 1519,
+            position: home_position,
+        });
+        add_canonical_test_player_on_map(&canonical, player_guid, player_position, 571, 0);
+        let mut spell_store = wow_data::SpellStore::new();
+        spell_store.insert(spell_id, spell_info);
+        session.set_spell_store(Arc::new(spell_store));
+
+        session
+            .execute_spell_with_visual_and_target_data(
+                spell_id,
+                player_guid,
+                ObjectGuid::EMPTY,
+                wow_packet::packets::spell::SpellCastVisual {
+                    spell_visual_id: 8690,
+                    script_visual_id: 0,
+                },
+                SpellTargetData::default(),
+            )
+            .await
+            .expect("TARGET_DEST_HOME hearthstone teleport should execute");
+
+        assert_eq!(session.pending_teleport, Some((1, home_position)));
+        assert_eq!(session.state, SessionState::Transfer);
+    }
+
+    #[tokio::test]
+    async fn teleport_units_target_dest_home_without_homebind_is_noop_boundary_like_cpp() {
+        let (mut session, _, _send_rx) = make_session();
+        let spell_id = 8690_i32;
+        let player_guid = ObjectGuid::create_player(1, 7041);
+        let player_position = Position::new(301.0, 401.0, 61.0, 0.5);
+        let canonical = shared_canonical_map_manager();
+        let hearth_effect = wow_data::SpellEffectInfo {
+            effect_index: 0,
+            effect: wow_data::spell::spell_effect_types::SPELL_EFFECT_TELEPORT_UNITS,
+            implicit_target_1: wow_data::spell::implicit_targets::TARGET_DEST_HOME,
+            ..Default::default()
+        };
+        let spell_info = teleport_units_spell_info_like_cpp(spell_id, vec![hearth_effect]);
+
+        session.set_canonical_map_manager(Arc::clone(&canonical));
+        session.attach_player_controller_like_cpp(SessionPlayerController::new(
+            player_guid,
+            "HearthNoHome".to_string(),
+            player_position,
+            571,
+            1,
+            1,
+            80,
+            0,
+        ));
+        add_canonical_test_player_on_map(&canonical, player_guid, player_position, 571, 0);
+        let mut spell_store = wow_data::SpellStore::new();
+        spell_store.insert(spell_id, spell_info);
+        session.set_spell_store(Arc::new(spell_store));
+
+        session
+            .execute_spell_with_visual_and_target_data(
+                spell_id,
+                player_guid,
+                ObjectGuid::EMPTY,
+                wow_packet::packets::spell::SpellCastVisual {
+                    spell_visual_id: 8690,
+                    script_visual_id: 0,
+                },
+                SpellTargetData::default(),
+            )
+            .await
+            .expect("missing represented homebind keeps current bounded no-op");
+
+        assert_eq!(session.pending_teleport, None);
+        assert_ne!(session.state, SessionState::Transfer);
     }
 
     #[tokio::test]
@@ -104242,6 +104481,58 @@ mod tests {
         assert!(
             matches!(stmt.params()[1], wow_database::SqlParam::U64(v) if v == guid.counter() as u64)
         );
+    }
+
+    #[test]
+    fn player_homebind_update_statement_matches_cpp_bind_order() {
+        let guid = ObjectGuid::create_player(1, 5007);
+        let homebind = RepresentedHomebindLikeCpp {
+            map_id: 571,
+            area_id: 495,
+            position: Position::new(11.0, 22.0, 33.0, 1.5),
+        };
+
+        let stmt = WorldSession::build_player_homebind_update_statement_like_cpp(
+            homebind,
+            guid.counter() as u64,
+        );
+
+        assert_eq!(stmt.sql(), CharStatements::UPD_PLAYER_HOMEBIND.sql());
+        assert!(matches!(stmt.params()[0], wow_database::SqlParam::U16(571)));
+        assert!(matches!(stmt.params()[1], wow_database::SqlParam::U16(495)));
+        assert!(matches!(stmt.params()[2], wow_database::SqlParam::F32(v) if v == 11.0));
+        assert!(matches!(stmt.params()[3], wow_database::SqlParam::F32(v) if v == 22.0));
+        assert!(matches!(stmt.params()[4], wow_database::SqlParam::F32(v) if v == 33.0));
+        assert!(matches!(stmt.params()[5], wow_database::SqlParam::F32(v) if v == 1.5));
+        assert!(
+            matches!(stmt.params()[6], wow_database::SqlParam::U64(v) if v == guid.counter() as u64)
+        );
+    }
+
+    #[test]
+    fn player_homebind_insert_statement_matches_cpp_load_fallback_bind_order() {
+        let guid = ObjectGuid::create_player(1, 5008);
+        let homebind = RepresentedHomebindLikeCpp {
+            map_id: 0,
+            area_id: 12,
+            position: Position::new(-1.0, -2.0, 3.0, 4.0),
+        };
+
+        let stmt = WorldSession::build_player_homebind_insert_statement_like_cpp(
+            homebind,
+            guid.counter() as u64,
+        );
+
+        assert_eq!(stmt.sql(), CharStatements::INS_PLAYER_HOMEBIND.sql());
+        assert!(
+            matches!(stmt.params()[0], wow_database::SqlParam::U64(v) if v == guid.counter() as u64)
+        );
+        assert!(matches!(stmt.params()[1], wow_database::SqlParam::U16(0)));
+        assert!(matches!(stmt.params()[2], wow_database::SqlParam::U16(12)));
+        assert!(matches!(stmt.params()[3], wow_database::SqlParam::F32(v) if v == -1.0));
+        assert!(matches!(stmt.params()[4], wow_database::SqlParam::F32(v) if v == -2.0));
+        assert!(matches!(stmt.params()[5], wow_database::SqlParam::F32(v) if v == 3.0));
+        assert!(matches!(stmt.params()[6], wow_database::SqlParam::F32(v) if v == 4.0));
     }
 
     #[test]

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -53548,6 +53548,21 @@ impl WorldSession {
         true
     }
 
+    pub(crate) fn player_current_map_instanceable_like_cpp(&self) -> bool {
+        let map_id = u32::from(self.player_map_id_like_cpp());
+        self.map_store()
+            .and_then(|store| store.get(map_id))
+            .is_some_and(|entry| entry.instance_type != wow_data::map::MAP_COMMON)
+    }
+
+    pub(crate) async fn seed_represented_homebind_from_load_like_cpp(
+        &mut self,
+        homebind: RepresentedHomebindLikeCpp,
+    ) {
+        self.represented_homebind_like_cpp = Some(homebind);
+        self.persist_player_homebind_like_cpp(homebind).await;
+    }
+
     async fn set_homebind_like_cpp(
         &mut self,
         binder_id: ObjectGuid,

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -3706,6 +3706,11 @@ pub struct SpellCastBattlePetItemModifiersLikeCpp {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SpellCastMetadata {
     pub from_client: bool,
+    /// Overrides the visible/effect caster for represented triggered casts.
+    /// Normal player casts leave this empty and use the logged-in player GUID.
+    pub caster_guid_override: Option<ObjectGuid>,
+    /// C++ `SpellCastData::CastFlags` for the emitted `SMSG_SPELL_GO`.
+    pub cast_flags: u32,
     pub misc: [i32; 2],
     pub cast_item_entry: Option<u32>,
     pub cast_item_battle_pet_modifiers: Option<SpellCastBattlePetItemModifiersLikeCpp>,
@@ -3720,6 +3725,8 @@ impl Default for SpellCastMetadata {
     fn default() -> Self {
         Self {
             from_client: false,
+            caster_guid_override: None,
+            cast_flags: 0,
             misc: [0, 0],
             cast_item_entry: None,
             cast_item_battle_pet_modifiers: None,
@@ -11691,7 +11698,9 @@ impl WorldSession {
             original_cast_id: cast_id,
             spell_id,
             visual: SpellCastVisual::default(),
+            cast_flags: 0,
             cast_flags_ex: 0,
+            cast_time_ms: Self::game_time_ms_like_cpp(),
             target: SpellTargetData {
                 flags: 0x2,
                 unit: target_guid,
@@ -27409,6 +27418,63 @@ impl WorldSession {
                 SendIfVisibleLikeCppCommand {
                     queued_at: Instant::now(),
                     source_guid: guid,
+                    map_id,
+                    instance_id,
+                    packet_bytes: bytes.clone(),
+                },
+            ));
+        }
+    }
+
+    /// Route a creature-originated packet through the existing
+    /// `MessageDistDeliverer`-style candidate and per-session visibility gates.
+    /// The activating session receives its direct packet separately; this
+    /// queues only nearby observers, matching `WorldObject::SendMessageToSet`.
+    pub(crate) fn broadcast_creature_packet_to_visible_set_like_cpp(
+        &self,
+        source_guid: ObjectGuid,
+        bytes: Vec<u8>,
+    ) {
+        let (Some(registry), Some(source)) = (
+            self.player_registry(),
+            self.canonical_creature_access_like_cpp(source_guid),
+        ) else {
+            return;
+        };
+        let player_guid = self.player_guid().unwrap_or(ObjectGuid::EMPTY);
+        let map_id = self.player_map_id_like_cpp();
+        let instance_id = self
+            .current_canonical_player_map_key_like_cpp()
+            .map(|key| key.instance_id)
+            .unwrap_or(0);
+        let range_sq =
+            crate::map_manager::VISIBILITY_RADIUS * crate::map_manager::VISIBILITY_RADIUS;
+
+        let candidates: Vec<_> = registry
+            .iter()
+            .filter_map(|entry| {
+                let (other_guid, other_info): (&ObjectGuid, &PlayerBroadcastInfo) = entry.pair();
+                if *other_guid == player_guid
+                    || !other_info.is_in_world
+                    || other_info.map_id != map_id
+                    || other_info.instance_id != instance_id
+                {
+                    return None;
+                }
+                let dx = other_info.position.x - source.position.x;
+                let dy = other_info.position.y - source.position.y;
+                if dx * dx + dy * dy > range_sq {
+                    return None;
+                }
+                Some(other_info.command_tx.clone())
+            })
+            .collect();
+
+        for command_tx in candidates {
+            let _ = command_tx.try_send(SessionCommand::SendIfVisibleLikeCpp(
+                SendIfVisibleLikeCppCommand {
+                    queued_at: Instant::now(),
+                    source_guid,
                     map_id,
                     instance_id,
                     packet_bytes: bytes.clone(),
@@ -52005,6 +52071,7 @@ impl WorldSession {
         metadata: SpellCastMetadata,
     ) -> Result<(), &'static str> {
         let player_guid = self.player_guid().ok_or("No player GUID")?;
+        let caster_guid = metadata.caster_guid_override.unwrap_or(player_guid);
 
         // Obtener SpellInfo
         let spell_info = self
@@ -52156,16 +52223,24 @@ impl WorldSession {
 
         let spell_visual_id = spell_visual.spell_visual_id;
         let go_pkt = SpellGoPkt {
-            caster: player_guid,
+            caster: caster_guid,
             cast_id,
             original_cast_id: metadata.original_cast_id_or(cast_id),
             spell_id,
             visual: spell_visual,
+            cast_flags: metadata.cast_flags,
             cast_flags_ex: metadata.cast_flags_ex,
+            cast_time_ms: Self::game_time_ms_like_cpp(),
             target: target_data.clone(),
             hit_targets: vec![target_guid],
         };
         self.send_packet(&go_pkt);
+        if caster_guid != player_guid && caster_guid.is_any_type_creature() {
+            self.broadcast_creature_packet_to_visible_set_like_cpp(
+                caster_guid,
+                wow_packet::ServerPacket::to_bytes(&go_pkt),
+            );
+        }
 
         let mut force_visibility_after_add_farsight = false;
         for effect in spell_info.effects() {
@@ -52203,7 +52278,7 @@ impl WorldSession {
                 .unwrap_or(&target_data);
             self.apply_effect_teleport_units_like_cpp(effect, target_guid, effect_target_data)
                 .await;
-            self.apply_effect_bind_like_cpp(effect, player_guid, target_guid, effect_target_data)
+            self.apply_effect_bind_like_cpp(effect, caster_guid, target_guid, effect_target_data)
                 .await;
         }
 
@@ -52222,7 +52297,7 @@ impl WorldSession {
             .await;
             self.apply_effect_bind_like_cpp(
                 &primary_effect_like_cpp,
-                player_guid,
+                caster_guid,
                 target_guid,
                 &target_data,
             )
@@ -52936,23 +53011,25 @@ impl WorldSession {
             }
         }
 
-        // Set global cooldown
-        self.last_spell_cast_time = Some(Instant::now());
+        if caster_guid == player_guid {
+            // This represented cooldown state belongs to the session player.
+            // A triggered creature cast (for example innkeeper bind spell
+            // 3286) must not start or advertise a player cooldown.
+            self.last_spell_cast_time = Some(Instant::now());
+            self.last_spell_cast_time_per_spell
+                .insert(spell_id, Instant::now());
+            self.record_cast_character_spell_cooldown_like_cpp(
+                spell_id,
+                spell_info.recovery_time_ms.max(spell_info.cooldown_ms),
+            );
 
-        // Set per-spell cooldown
-        self.last_spell_cast_time_per_spell
-            .insert(spell_id, Instant::now());
-        self.record_cast_character_spell_cooldown_like_cpp(
-            spell_id,
-            spell_info.recovery_time_ms.max(spell_info.cooldown_ms),
-        );
-
-        // Notify client so action bar shows the cooldown animation
-        use wow_packet::packets::spell::CooldownEvent;
-        self.send_packet(&CooldownEvent {
-            spell_id,
-            is_pet: false,
-        });
+            // Notify the owning player so the action bar shows the cooldown.
+            use wow_packet::packets::spell::CooldownEvent;
+            self.send_packet(&CooldownEvent {
+                spell_id,
+                is_pet: false,
+            });
+        }
 
         Ok(())
     }
@@ -53525,27 +53602,6 @@ impl WorldSession {
             },
         )
         .await;
-    }
-
-    pub(crate) async fn set_homebind_to_current_location_like_cpp(
-        &mut self,
-        binder_id: ObjectGuid,
-    ) -> bool {
-        let Some(position) = self.player_position_like_cpp() else {
-            return false;
-        };
-        let (_, area_id) = self.player_zone_area_like_cpp();
-        let map_id = u32::from(self.player_map_id_like_cpp());
-        self.set_homebind_like_cpp(
-            binder_id,
-            RepresentedHomebindLikeCpp {
-                map_id,
-                area_id,
-                position,
-            },
-        )
-        .await;
-        true
     }
 
     pub(crate) fn player_current_map_instanceable_like_cpp(&self) -> bool {

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -53666,11 +53666,7 @@ impl WorldSession {
         }
 
         let (_, current_area_id) = self.player_zone_area_like_cpp();
-        let area_id = if effect.effect_misc_value_1 != 0 {
-            u32::try_from(effect.effect_misc_value_1).unwrap_or(current_area_id)
-        } else {
-            current_area_id
-        };
+        let area_id = Self::bind_area_id_like_cpp(effect.effect_misc_value_1, current_area_id);
 
         let Some(current_position) = self.player_position_like_cpp() else {
             return;
@@ -53695,6 +53691,16 @@ impl WorldSession {
         );
     }
 
+    fn bind_area_id_like_cpp(effect_misc_value: i32, current_area_id: u32) -> u32 {
+        if effect_misc_value != 0 {
+            // C++ assigns the signed SpellEffectInfo::MiscValue directly to
+            // uint32 areaId, preserving the underlying 32-bit value.
+            effect_misc_value as u32
+        } else {
+            current_area_id
+        }
+    }
+
     pub(crate) fn player_current_map_instanceable_like_cpp(&self) -> bool {
         let map_id = u32::from(self.player_map_id_like_cpp());
         self.map_store()
@@ -53714,8 +53720,8 @@ impl WorldSession {
             x: homebind.position.x,
             y: homebind.position.y,
             z: homebind.position.z,
-            map_id: i32::try_from(homebind.map_id).unwrap_or(i32::MAX),
-            area_id: i32::try_from(homebind.area_id).unwrap_or(i32::MAX),
+            map_id: homebind.map_id,
+            area_id: homebind.area_id,
         });
         self.send_packet_realm(&wow_packet::packets::misc::PlayerBound {
             binder_id,
@@ -53728,8 +53734,10 @@ impl WorldSession {
         guid_counter: u64,
     ) -> PreparedStatement {
         let mut stmt = PreparedStatement::new(CharStatements::UPD_PLAYER_HOMEBIND.sql());
-        stmt.set_u16(0, u16::try_from(homebind.map_id).unwrap_or(u16::MAX));
-        stmt.set_u16(1, u16::try_from(homebind.area_id).unwrap_or(u16::MAX));
+        // C++ PreparedStatement::setUInt16 receives these uint32 fields and
+        // narrows modulo 2^16 at the call boundary.
+        stmt.set_u16(0, homebind.map_id as u16);
+        stmt.set_u16(1, homebind.area_id as u16);
         stmt.set_f32(2, homebind.position.x);
         stmt.set_f32(3, homebind.position.y);
         stmt.set_f32(4, homebind.position.z);
@@ -72753,6 +72761,17 @@ mod tests {
         let opcodes = drain_server_opcodes(&send_rx);
         assert!(opcodes.contains(&ServerOpcodes::BindPointUpdate));
         assert!(opcodes.contains(&ServerOpcodes::PlayerBound));
+    }
+
+    #[test]
+    fn bind_misc_area_preserves_cpp_uint32_conversion() {
+        assert_eq!(WorldSession::bind_area_id_like_cpp(777, 34), 777);
+        assert_eq!(WorldSession::bind_area_id_like_cpp(0, 34), 34);
+        assert_eq!(
+            WorldSession::bind_area_id_like_cpp(-1, 34),
+            u32::MAX,
+            "C++ assignment from int32 MiscValue to uint32 areaId preserves all 32 bits"
+        );
     }
 
     #[tokio::test]
@@ -105210,6 +105229,23 @@ mod tests {
         assert!(
             matches!(stmt.params()[6], wow_database::SqlParam::U64(v) if v == guid.counter() as u64)
         );
+
+        let narrowed = WorldSession::build_player_homebind_update_statement_like_cpp(
+            RepresentedHomebindLikeCpp {
+                map_id: u32::MAX - 2,
+                area_id: u32::MAX - 1,
+                position: Position::ZERO,
+            },
+            guid.counter() as u64,
+        );
+        assert!(matches!(
+            narrowed.params()[0],
+            wow_database::SqlParam::U16(65_533)
+        ));
+        assert!(matches!(
+            narrowed.params()[1],
+            wow_database::SqlParam::U16(65_534)
+        ));
     }
 
     #[test]

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -53555,14 +53555,6 @@ impl WorldSession {
             .is_some_and(|entry| entry.instance_type != wow_data::map::MAP_COMMON)
     }
 
-    pub(crate) async fn seed_represented_homebind_from_load_like_cpp(
-        &mut self,
-        homebind: RepresentedHomebindLikeCpp,
-    ) {
-        self.represented_homebind_like_cpp = Some(homebind);
-        self.persist_player_homebind_like_cpp(homebind).await;
-    }
-
     async fn set_homebind_like_cpp(
         &mut self,
         binder_id: ObjectGuid,
@@ -53599,21 +53591,6 @@ impl WorldSession {
         stmt
     }
 
-    fn build_player_homebind_insert_statement_like_cpp(
-        homebind: RepresentedHomebindLikeCpp,
-        guid_counter: u64,
-    ) -> PreparedStatement {
-        let mut stmt = PreparedStatement::new(CharStatements::INS_PLAYER_HOMEBIND.sql());
-        stmt.set_u64(0, guid_counter);
-        stmt.set_u16(1, u16::try_from(homebind.map_id).unwrap_or(u16::MAX));
-        stmt.set_u16(2, u16::try_from(homebind.area_id).unwrap_or(u16::MAX));
-        stmt.set_f32(3, homebind.position.x);
-        stmt.set_f32(4, homebind.position.y);
-        stmt.set_f32(5, homebind.position.z);
-        stmt.set_f32(6, homebind.position.orientation);
-        stmt
-    }
-
     async fn persist_player_homebind_like_cpp(&self, homebind: RepresentedHomebindLikeCpp) {
         let (Some(player_guid), Some(char_db)) =
             (self.player_guid(), self.char_db().map(Arc::clone))
@@ -53623,30 +53600,12 @@ impl WorldSession {
         let guid_counter = player_guid.counter() as u64;
         let update_stmt =
             Self::build_player_homebind_update_statement_like_cpp(homebind, guid_counter);
-        match char_db.execute(&update_stmt).await {
-            Ok(0) => {
-                // C++ Player::_LoadHomebind creates a missing row before
-                // Player::SetHomebind later uses CHAR_UPD_PLAYER_HOMEBIND.
-                // Rust's represented login path can still lack that invariant,
-                // so recover it here without changing the C++ update bind order.
-                let insert_stmt =
-                    Self::build_player_homebind_insert_statement_like_cpp(homebind, guid_counter);
-                if let Err(error) = char_db.execute(&insert_stmt).await {
-                    warn!(
-                        player_guid = guid_counter,
-                        %error,
-                        "failed to insert represented player homebind after update affected zero rows"
-                    );
-                }
-            }
-            Ok(_) => {}
-            Err(error) => {
-                warn!(
-                    player_guid = guid_counter,
-                    %error,
-                    "failed to update represented player homebind"
-                );
-            }
+        if let Err(error) = char_db.execute(&update_stmt).await {
+            warn!(
+                player_guid = guid_counter,
+                %error,
+                "failed to update represented player homebind"
+            );
         }
     }
 
@@ -104522,32 +104481,6 @@ mod tests {
         assert!(
             matches!(stmt.params()[6], wow_database::SqlParam::U64(v) if v == guid.counter() as u64)
         );
-    }
-
-    #[test]
-    fn player_homebind_insert_statement_matches_cpp_load_fallback_bind_order() {
-        let guid = ObjectGuid::create_player(1, 5008);
-        let homebind = RepresentedHomebindLikeCpp {
-            map_id: 0,
-            area_id: 12,
-            position: Position::new(-1.0, -2.0, 3.0, 4.0),
-        };
-
-        let stmt = WorldSession::build_player_homebind_insert_statement_like_cpp(
-            homebind,
-            guid.counter() as u64,
-        );
-
-        assert_eq!(stmt.sql(), CharStatements::INS_PLAYER_HOMEBIND.sql());
-        assert!(
-            matches!(stmt.params()[0], wow_database::SqlParam::U64(v) if v == guid.counter() as u64)
-        );
-        assert!(matches!(stmt.params()[1], wow_database::SqlParam::U16(0)));
-        assert!(matches!(stmt.params()[2], wow_database::SqlParam::U16(12)));
-        assert!(matches!(stmt.params()[3], wow_database::SqlParam::F32(v) if v == -1.0));
-        assert!(matches!(stmt.params()[4], wow_database::SqlParam::F32(v) if v == -2.0));
-        assert!(matches!(stmt.params()[5], wow_database::SqlParam::F32(v) if v == 3.0));
-        assert!(matches!(stmt.params()[6], wow_database::SqlParam::F32(v) if v == 4.0));
     }
 
     #[test]

--- a/crates/wow-world/src/session.rs
+++ b/crates/wow-world/src/session.rs
@@ -52239,6 +52239,7 @@ impl WorldSession {
                 let selected = match implicit_target {
                     wow_data::spell::implicit_targets::TARGET_DEST_HOME => self
                         .represented_home_destination_target_data_like_cpp(
+                            caster_guid,
                             &isolated_effect,
                             &selection_input,
                         ),
@@ -52273,7 +52274,20 @@ impl WorldSession {
             }
             // C++ snapshots `m_targets.GetDst()` into
             // `m_destTargets[EffectIndex]` after selecting each effect.
-            effect_target_data_like_cpp.push((effect.effect_index, target_data.clone()));
+            let mut effect_target_data = target_data.clone();
+            if let Some(destination) = effect_target_data.dst_location.as_mut()
+                && !destination.transport.is_empty()
+                && let Some(world_position) = self
+                    .represented_transport_destination_world_position_like_cpp(
+                        destination.transport,
+                        destination.position,
+                    )
+            {
+                // C++ serializes `_transportOffset` but keeps `_position` as
+                // world coordinates for effect execution.
+                destination.position = world_position;
+            }
+            effect_target_data_like_cpp.push((effect.effect_index, effect_target_data));
         }
         let mut spell_go_target_data = target_data.clone();
         if represented_implicit_destination {
@@ -53847,6 +53861,7 @@ impl WorldSession {
 
     fn represented_home_destination_target_data_like_cpp(
         &self,
+        caster_guid: ObjectGuid,
         effect: &wow_data::SpellEffectInfo,
         target_data: &SpellTargetData,
     ) -> Option<SpellTargetData> {
@@ -53860,15 +53875,102 @@ impl WorldSession {
             return None;
         }
 
-        let homebind = self.represented_homebind_like_cpp()?;
+        // C++ starts `SelectImplicitCasterDestTargets` from
+        // `SpellDestination(*m_caster)`, then replaces it with `m_homebind`
+        // only when the effective caster is a Player. A triggered creature
+        // cast must therefore keep the creature's own position rather than
+        // borrowing the logged-in session player's homebind.
+        let (map_id, transport, position) = if Some(caster_guid) == self.player_guid() {
+            let homebind = self.represented_homebind_like_cpp()?;
+            (homebind.map_id, ObjectGuid::EMPTY, homebind.position)
+        } else {
+            let map_key = self
+                .current_canonical_player_map_key_like_cpp()
+                .unwrap_or_else(|| {
+                    wow_map::MapKey::new(u32::from(self.player_map_id_like_cpp()), 0)
+                });
+            let legacy_map_id = u16::try_from(map_key.map_id).ok()?;
+            let (transport, position) = self
+                .canonical_map_manager
+                .as_ref()
+                .and_then(|manager| {
+                    let manager = manager.lock().ok()?;
+                    let map = manager.find_map(map_key.map_id, map_key.instance_id)?;
+                    let map = map.map();
+                    let creature = map.get_typed_creature(caster_guid)?;
+                    let world_position = creature.unit().world().position();
+                    if let Some(vehicle_base_guid) =
+                        creature.unit().subsystems().vehicle.vehicle_guid
+                    {
+                        let vehicle_base_position = map
+                            .get_typed_player(vehicle_base_guid)
+                            .map(|player| player.unit().world().position())
+                            .or_else(|| {
+                                map.get_typed_creature(vehicle_base_guid)
+                                    .map(|creature| creature.unit().world().position())
+                            })?;
+                        Some((
+                            vehicle_base_guid,
+                            wow_entities::calculate_passenger_offset(
+                                world_position,
+                                vehicle_base_position,
+                            ),
+                        ))
+                    } else if let Some(transport) =
+                        map.get_typed_transport_for_passenger_like_cpp(caster_guid)
+                    {
+                        Some((
+                            transport.world().guid(),
+                            transport.calculate_passenger_offset(world_position),
+                        ))
+                    } else {
+                        Some((ObjectGuid::EMPTY, world_position))
+                    }
+                })
+                .or_else(|| {
+                    self.map_manager.as_ref().and_then(|manager| {
+                        manager
+                            .read()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .find_creature(legacy_map_id, map_key.instance_id, caster_guid)
+                            .map(|creature| (ObjectGuid::EMPTY, creature.position()))
+                    })
+                })?;
+            (map_key.map_id, transport, position)
+        };
         let mut target_data = target_data.clone();
         target_data.flags |= 0x0000_0040; // C++ TARGET_FLAG_DEST_LOCATION
         target_data.dst_location = Some(wow_packet::packets::spell::TargetLocation {
-            transport: ObjectGuid::EMPTY,
-            position: homebind.position,
+            transport,
+            position,
         });
-        target_data.map_id = Some(i32::try_from(homebind.map_id).unwrap_or(i32::MAX));
+        target_data.map_id = Some(i32::try_from(map_id).unwrap_or(i32::MAX));
         Some(target_data)
+    }
+
+    fn represented_transport_destination_world_position_like_cpp(
+        &self,
+        transport_guid: ObjectGuid,
+        transport_offset: Position,
+    ) -> Option<Position> {
+        let map_key = self.current_canonical_player_map_key_like_cpp()?;
+        let manager = self.canonical_map_manager.as_ref()?.lock().ok()?;
+        let map = manager.find_map(map_key.map_id, map_key.instance_id)?;
+        let map = map.map();
+        if let Some(transport) = map.get_typed_transport_like_cpp(transport_guid) {
+            return Some(transport.calculate_passenger_position(transport_offset));
+        }
+        let vehicle_base_position = map
+            .get_typed_player(transport_guid)
+            .map(|player| player.unit().world().position())
+            .or_else(|| {
+                map.get_typed_creature(transport_guid)
+                    .map(|creature| creature.unit().world().position())
+            })?;
+        Some(wow_entities::calculate_passenger_position(
+            transport_offset,
+            vehicle_base_position,
+        ))
     }
 
     fn represented_db_caster_destination_target_data_like_cpp(
@@ -72002,6 +72104,210 @@ mod tests {
         assert_eq!(packet_target.map_id, None);
         assert_eq!(session.pending_teleport, Some((1, home_position)));
         assert_eq!(session.state, SessionState::Transfer);
+    }
+
+    #[tokio::test]
+    async fn creature_cast_target_dest_home_keeps_creature_destination_like_cpp() {
+        let (mut session, _, send_rx) = make_session();
+        let spell_id = 86_902_i32;
+        let player_guid = ObjectGuid::create_player(1, 7043);
+        let creature_guid = test_creature_guid(7043);
+        let vehicle_base_guid = test_vehicle_guid(7044);
+        let transport_guid =
+            ObjectGuid::create_transport(wow_core::guid::HighGuid::Transport, 7043);
+        let instance_id = 42_u32;
+        let player_position = Position::new(10.0, 20.0, 30.0, 0.5);
+        let creature_position = Position::new(70.0, 80.0, 90.0, 1.5);
+        let vehicle_base_position = Position::new(60.0, 65.0, 75.0, 0.75);
+        let vehicle_offset =
+            wow_entities::calculate_passenger_offset(creature_position, vehicle_base_position);
+        let transport_position = Position::new(50.0, 60.0, 70.0, 0.5);
+        let stale_instance_copy_position = Position::new(270.0, 280.0, 290.0, 2.0);
+        let base_map_copy_position = Position::new(170.0, 180.0, 190.0, 2.5);
+        let home_position = Position::new(40.0, 50.0, 60.0, 1.25);
+        let home_effect = wow_data::SpellEffectInfo {
+            effect_index: 0,
+            effect: wow_data::spell::spell_effect_types::SPELL_EFFECT_TELEPORT_UNITS,
+            implicit_target_1: wow_data::spell::implicit_targets::TARGET_DEST_HOME,
+            ..Default::default()
+        };
+
+        session.attach_player_controller_like_cpp(SessionPlayerController::new(
+            player_guid,
+            "CreatureHomeCaster".to_string(),
+            player_position,
+            0,
+            1,
+            1,
+            80,
+            0,
+        ));
+        session.set_represented_homebind_like_cpp(RepresentedHomebindLikeCpp {
+            map_id: 1,
+            area_id: 1519,
+            position: home_position,
+        });
+        let canonical = shared_canonical_map_manager();
+        add_canonical_test_player_on_map(&canonical, player_guid, player_position, 0, instance_id);
+        add_canonical_test_creature_on_map(
+            &canonical,
+            creature_guid,
+            9001,
+            creature_position,
+            0,
+            0,
+            instance_id,
+        );
+        add_canonical_test_creature_on_map(
+            &canonical,
+            vehicle_base_guid,
+            9002,
+            vehicle_base_position,
+            0,
+            0,
+            instance_id,
+        );
+        {
+            canonical
+                .lock()
+                .unwrap()
+                .find_map_mut(0, instance_id)
+                .unwrap()
+                .map_mut()
+                .get_typed_creature_mut(creature_guid)
+                .unwrap()
+                .unit_mut()
+                .subsystems_mut()
+                .vehicle
+                .enter_vehicle(vehicle_base_guid, Some(0));
+            let mut transport = wow_entities::Transport::new();
+            transport.world_mut().object_mut().create(transport_guid);
+            transport.world_mut().set_map(0, instance_id).unwrap();
+            transport.world_mut().relocate(transport_position);
+            transport.world_mut().object_mut().add_to_world();
+            assert!(transport.add_passenger(creature_guid));
+            canonical
+                .lock()
+                .unwrap()
+                .find_map_mut(0, instance_id)
+                .unwrap()
+                .map_mut()
+                .insert_map_object_record(
+                    wow_entities::MapObjectRecord::new_transport(transport).unwrap(),
+                )
+                .unwrap();
+        }
+        session.set_canonical_map_manager(canonical);
+        let explicit_transport_offset = Position::new(5.0, -3.0, 2.0, 0.25);
+        assert_eq!(
+            session.represented_transport_destination_world_position_like_cpp(
+                transport_guid,
+                explicit_transport_offset,
+            ),
+            Some(wow_entities::calculate_passenger_position(
+                explicit_transport_offset,
+                transport_position,
+            )),
+            "an explicit transported destination resolves its own offset, not the caster position"
+        );
+        let manager = shared_map_manager();
+        {
+            let mut manager_guard = manager.write().unwrap();
+            for (copy_instance_id, position) in [
+                (0_u32, base_map_copy_position),
+                (instance_id, stale_instance_copy_position),
+            ] {
+                let (grid_x, grid_y) =
+                    crate::map_manager::world_to_grid_coords(position.x, position.y);
+                assert!(manager_guard.add_creature(
+                    0,
+                    copy_instance_id,
+                    grid_x,
+                    grid_y,
+                    crate::map_manager::WorldCreature::new(
+                        creature_guid,
+                        9001,
+                        position,
+                        100,
+                        2,
+                        3,
+                        5,
+                        20.0,
+                        100,
+                        14,
+                        0,
+                        0,
+                    ),
+                ));
+            }
+        }
+        session.set_map_manager(manager);
+        let mut spell_store = wow_data::SpellStore::new();
+        spell_store.insert(
+            spell_id,
+            teleport_units_spell_info_like_cpp(spell_id, vec![home_effect]),
+        );
+        session.set_spell_store(Arc::new(spell_store));
+
+        session
+            .execute_spell_with_visual_and_target_data_with_metadata(
+                spell_id,
+                player_guid,
+                ObjectGuid::EMPTY,
+                wow_packet::packets::spell::SpellCastVisual::default(),
+                SpellTargetData::default(),
+                SpellCastMetadata {
+                    caster_guid_override: Some(creature_guid),
+                    ..SpellCastMetadata::default()
+                },
+            )
+            .await
+            .expect("creature TARGET_DEST_HOME cast should execute");
+
+        let bytes = send_rx.try_recv().expect("creature-cast SpellGo");
+        let packet_target = decode_spell_go_target_data_like_cpp(&bytes, spell_id);
+        let packet_destination = packet_target
+            .dst_location
+            .expect("creature's initial destination")
+            .clone();
+        assert_eq!(
+            packet_destination.transport, vehicle_base_guid,
+            "C++ Unit::GetTransGUID prioritizes the vehicle base over an ordinary transport"
+        );
+        assert_eq!(
+            packet_destination.position,
+            Position::new(vehicle_offset.x, vehicle_offset.y, vehicle_offset.z, 0.0),
+            "C++ SpellCastTargets::Write serializes the caster vehicle offset"
+        );
+        assert_ne!(
+            packet_destination.position,
+            Position::new(home_position.x, home_position.y, home_position.z, 0.0)
+        );
+        assert_ne!(
+            packet_destination.position,
+            Position::new(
+                stale_instance_copy_position.x,
+                stale_instance_copy_position.y,
+                stale_instance_copy_position.z,
+                0.0
+            ),
+            "the canonical caster validated by the interaction path wins over a stale legacy copy"
+        );
+        assert_ne!(
+            packet_destination.position,
+            Position::new(
+                base_map_copy_position.x,
+                base_map_copy_position.y,
+                base_map_copy_position.z,
+                0.0
+            ),
+            "the same runtime GUID in instance 0 must not shadow the effective caster"
+        );
+        assert_eq!(
+            session.pending_teleport_save_destination_like_cpp(),
+            Some((0_u16, creature_position)),
+            "effect execution keeps the global SpellDestination position"
+        );
     }
 
     #[tokio::test]

--- a/tools/wow-test-bot/README.md
+++ b/tools/wow-test-bot/README.md
@@ -31,6 +31,15 @@ test item for the local bot character, opens a neutral banker, deposits the
 item, logs out and authenticates again, withdraws it, logs out again, verifies
 both DB transitions, then deletes the item and restores the original position.
 
+For an innkeeper bind round-trip, set `WOW_BOT_HOMEBIND_SMOKE=1`. The bot relocates one local
+test character beside a faction-friendly continent innkeeper, sends
+`CMSG_BINDER_ACTIVATE`, requires `SMSG_SPELL_GO`, `SMSG_BIND_POINT_UPDATE`,
+`SMSG_PLAYER_BOUND`, and `SMSG_GOSSIP_COMPLETE`, verifies
+`character_homebind`, authenticates again, re-verifies persistence, and restores
+the original position and homebind row. It discovers the map-owned low GUID
+counter from the login `SMSG_UPDATE_OBJECT` stream;
+`WOW_BOT_HOMEBIND_RUNTIME_COUNTER` remains an optional capture override.
+
 For a full occupied-slot inventory-swap round-trip, set
 `WOW_BOT_INVENTORY_SWAP_SMOKE=1`. The bot creates two different isolated items
 in two free backpack slots, sends the real `CMSG_SWAP_INV_ITEM`, logs out and

--- a/tools/wow-test-bot/RUSTYCORE_SMOKE.md
+++ b/tools/wow-test-bot/RUSTYCORE_SMOKE.md
@@ -64,6 +64,21 @@ accounts; cleanup removes only the generated item and restores the original
 character position. `WOW_BOT_BANK_ITEM_ENTRY` (default `2589`) and
 `WOW_BOT_BANK_TIMEOUT_SECS` are optional overrides.
 
+## Innkeeper homebind persistence smoke
+
+```bash
+WOW_BOT_HOMEBIND_SMOKE=1 \
+./run_rustycore_login_smoke.sh
+```
+
+The pass requires the triggered bind spell plus all three bind/gossip response
+packets, a matching `character_homebind` row, and a second complete
+authentication/login that observes the same persisted row. Setup is restricted
+to `@bot.local` accounts and cleanup restores the original character position
+and homebind exactly.
+`WOW_BOT_HOMEBIND_RUNTIME_COUNTER` is an optional override; the current
+default discovers the map-owned low counter from the login update stream.
+
 ## Direct inventory swap persistence smoke
 
 ```bash
@@ -245,7 +260,7 @@ interaction-distance checks.
 
 For DB-spawned creatures, `world.creature.guid` is the persistent spawn
 identity while the live `ObjectGuid` low counter is map-generated. Quest and
-bank modes therefore accept an explicit runtime counter instead of pretending
+bank mode therefore accepts an explicit runtime counter instead of pretending
 the two identities are interchangeable.
 
 ## Known notes

--- a/tools/wow-test-bot/run_rustycore_login_smoke.sh
+++ b/tools/wow-test-bot/run_rustycore_login_smoke.sh
@@ -58,6 +58,7 @@ log_path="${WOW_BOT_LOG:-/tmp/rustycore-bot-login-only.log}"
 quest_timeout_secs="${WOW_BOT_QUEST_TIMEOUT_SECS:-5}"
 stand_state_timeout_secs="${WOW_BOT_STAND_STATE_TIMEOUT_SECS:-5}"
 bank_timeout_secs="${WOW_BOT_BANK_TIMEOUT_SECS:-8}"
+homebind_timeout_secs="${WOW_BOT_HOMEBIND_TIMEOUT_SECS:-8}"
 inventory_swap_timeout_secs="${WOW_BOT_INVENTORY_SWAP_TIMEOUT_SECS:-8}"
 ensure_accounts="${WOW_BOT_ENSURE_TEST_ACCOUNTS:-1}"
 
@@ -83,12 +84,16 @@ bank_requested=0
 if [[ "${WOW_BOT_BANK_SMOKE:-0}" =~ ^(1|true|TRUE|yes|YES|on|ON)$ ]]; then
   bank_requested=1
 fi
+homebind_requested=0
+if [[ "${WOW_BOT_HOMEBIND_SMOKE:-0}" =~ ^(1|true|TRUE|yes|YES|on|ON)$ ]]; then
+  homebind_requested=1
+fi
 inventory_swap_requested=0
 if [[ "${WOW_BOT_INVENTORY_SWAP_SMOKE:-0}" =~ ^(1|true|TRUE|yes|YES|on|ON)$ ]]; then
   inventory_swap_requested=1
 fi
-if ((stand_state_requested + quest_requested + bank_requested + inventory_swap_requested > 1)); then
-  echo "Stand-state, quest, bank, and inventory-swap smoke are separate modes" >&2
+if ((stand_state_requested + quest_requested + bank_requested + homebind_requested + inventory_swap_requested > 1)); then
+  echo "Stand-state, quest, bank, homebind, and inventory-swap smoke are separate modes" >&2
   exit 2
 fi
 
@@ -106,6 +111,13 @@ elif ((bank_requested)); then
   mode_args=(--bank-smoke --bank-runtime-counter "$WOW_BOT_BANK_RUNTIME_COUNTER" --bank-timeout "$bank_timeout_secs")
   if [[ -n "${WOW_BOT_BANK_ITEM_ENTRY:-}" ]]; then
     mode_args+=(--bank-item-entry "$WOW_BOT_BANK_ITEM_ENTRY")
+  fi
+elif ((homebind_requested)); then
+  report_path="${WOW_BOT_REPORT:-/tmp/rustycore-bot-homebind-smoke-report.json}"
+  log_path="${WOW_BOT_LOG:-/tmp/rustycore-bot-homebind-smoke.log}"
+  mode_args=(--homebind-smoke --homebind-timeout "$homebind_timeout_secs")
+  if [[ -n "${WOW_BOT_HOMEBIND_RUNTIME_COUNTER:-}" ]]; then
+    mode_args+=(--homebind-runtime-counter "$WOW_BOT_HOMEBIND_RUNTIME_COUNTER")
   fi
 elif ((inventory_swap_requested)); then
   report_path="${WOW_BOT_REPORT:-/tmp/rustycore-bot-inventory-swap-smoke-report.json}"
@@ -193,5 +205,5 @@ echo "log: $log_path"
 echo "report: $report_path"
 
 if command -v jq >/dev/null 2>&1; then
-  jq '{login_only, quest_smoke, stand_state_smoke, bank_smoke, inventory_swap_smoke, results: [.results[] | {account, world_auth, enum_characters, player_login_verified, stand_state_smoke, stand_state_smoke_passed, stand_states_requested, stand_states_confirmed, stand_state_failure, bank_smoke, bank_smoke_passed, bank_banker_entry, bank_banker_spawn_guid, bank_banker_guid_counter, bank_item_guid, bank_item_entry, bank_inventory_slot, bank_bank_slot, bank_open_confirmed, bank_deposit_persisted, bank_relogin_after_deposit, bank_withdraw_persisted, bank_failure, inventory_swap_smoke, inventory_swap_smoke_passed, inventory_swap_item_guid_a, inventory_swap_item_guid_b, inventory_swap_item_entry_a, inventory_swap_item_entry_b, inventory_swap_slot_a, inventory_swap_slot_b, inventory_swap_forward_persisted, inventory_swap_relogin_after_forward, inventory_swap_reverse_persisted, inventory_swap_failure, quest_smoke_passed, quest_target_entry, quest_target_spawn_guid, quest_target_guid_counter, quest_ids_seen, quest_titles_seen, quest_accept_sent, quest_accept_confirm_seen, quest_db_verified, quest_db_status, quest_failure, join_result}]}' "$report_path"
+  jq '{login_only, quest_smoke, stand_state_smoke, bank_smoke, homebind_smoke, inventory_swap_smoke, results: [.results[] | {account, world_auth, enum_characters, player_login_verified, stand_state_smoke, stand_state_smoke_passed, stand_states_requested, stand_states_confirmed, stand_state_failure, bank_smoke, bank_smoke_passed, bank_banker_entry, bank_banker_spawn_guid, bank_banker_guid_counter, bank_item_guid, bank_item_entry, bank_inventory_slot, bank_bank_slot, bank_open_confirmed, bank_deposit_persisted, bank_relogin_after_deposit, bank_withdraw_persisted, bank_failure, homebind_smoke, homebind_smoke_passed, homebind_innkeeper_entry, homebind_innkeeper_spawn_guid, homebind_innkeeper_guid_counter, homebind_spell_go_seen, homebind_bind_point_update_seen, homebind_player_bound_seen, homebind_gossip_complete_seen, homebind_db_persisted, homebind_relogin_verified, homebind_failure, inventory_swap_smoke, inventory_swap_smoke_passed, inventory_swap_item_guid_a, inventory_swap_item_guid_b, inventory_swap_item_entry_a, inventory_swap_item_entry_b, inventory_swap_slot_a, inventory_swap_slot_b, inventory_swap_forward_persisted, inventory_swap_relogin_after_forward, inventory_swap_reverse_persisted, inventory_swap_failure, quest_smoke_passed, quest_target_entry, quest_target_spawn_guid, quest_target_guid_counter, quest_ids_seen, quest_titles_seen, quest_accept_sent, quest_accept_confirm_seen, quest_db_verified, quest_db_status, quest_failure, join_result}]}' "$report_path"
 fi

--- a/tools/wow-test-bot/src/main.rs
+++ b/tools/wow-test-bot/src/main.rs
@@ -406,6 +406,8 @@ struct BankSmokeOptions {
 #[derive(Debug, Clone, Copy)]
 struct CharacterPositionSnapshot {
     map_id: u32,
+    zone_id: u32,
+    instance_id: u32,
     x: f64,
     y: f64,
     z: f64,
@@ -3555,7 +3557,8 @@ async fn run_homebind_smoke_phase(
             match (connection, opcode) {
                 ("instance", SMSG_SPELL_GO) => {
                     let player_high = (2u64 << 58) | ((u64::from(realm_id()) & 0x1FFF) << 42);
-                    result.homebind_spell_go_seen = spell_go_matches_bind(
+                    result.homebind_spell_go_seen = homebind_spell_go_seen_after_packet(
+                        result.homebind_spell_go_seen,
                         &payload,
                         runtime_low,
                         runtime_high,
@@ -4935,14 +4938,14 @@ fn prepare_bank_smoke_fixture(
     let mut characters = mysql::Conn::new(character_opts)
         .map_err(|e| anyhow!("Connect to characters DB failed: {e}"))?;
 
-    let character: Option<(u32, u8, u32, f64, f64, f64, f32)> = characters
+    let character: Option<(u32, u8, u32, u32, u32, f64, f64, f64, f32)> = characters
         .exec_first(
-            "SELECT account, online, map, position_x, position_y, position_z, orientation \
+            "SELECT account, online, map, zone, instance_id, position_x, position_y, position_z, orientation \
              FROM characters WHERE guid = ?",
             (bot.character_guid,),
         )
         .map_err(|e| anyhow!("Load bank bot character: {e}"))?;
-    let (owner, online, map_id, x, y, z, orientation) =
+    let (owner, online, map_id, zone_id, instance_id, x, y, z, orientation) =
         character.ok_or_else(|| anyhow!("No characters row for guid {}", bot.character_guid))?;
     if owner != bot.account_id {
         bail!(
@@ -4960,6 +4963,8 @@ fn prepare_bank_smoke_fixture(
     }
     let original_position = CharacterPositionSnapshot {
         map_id,
+        zone_id,
+        instance_id,
         x,
         y,
         z,
@@ -5141,14 +5146,14 @@ fn prepare_homebind_smoke_fixture(
         .map_err(|e| anyhow!("Bad characters DB URL: {e}"))?;
     let mut characters = mysql::Conn::new(character_opts)
         .map_err(|e| anyhow!("Connect to characters DB failed: {e}"))?;
-    let character: Option<(u32, u8, u8, u32, f64, f64, f64, f32)> = characters
+    let character: Option<(u32, u8, u8, u32, u32, u32, f64, f64, f64, f32)> = characters
         .exec_first(
-            "SELECT account, online, race, map, position_x, position_y, position_z, orientation \
+            "SELECT account, online, race, map, zone, instance_id, position_x, position_y, position_z, orientation \
              FROM characters WHERE guid = ?",
             (bot.character_guid,),
         )
         .map_err(|e| anyhow!("Load homebind bot character: {e}"))?;
-    let (owner, online, race, map_id, x, y, z, orientation) =
+    let (owner, online, race, map_id, zone_id, instance_id, x, y, z, orientation) =
         character.ok_or_else(|| anyhow!("No characters row for guid {}", bot.character_guid))?;
     if owner != bot.account_id {
         bail!(
@@ -5166,6 +5171,8 @@ fn prepare_homebind_smoke_fixture(
     }
     let original_position = CharacterPositionSnapshot {
         map_id,
+        zone_id,
+        instance_id,
         x,
         y,
         z,
@@ -5327,9 +5334,11 @@ fn cleanup_homebind_smoke_fixture(
         .start_transaction(mysql::TxOpts::default())
         .map_err(|e| anyhow!("Start homebind cleanup transaction: {e}"))?;
     tx.exec_drop(
-        "UPDATE characters SET map = ?, position_x = ?, position_y = ?, position_z = ?, orientation = ? WHERE guid = ?",
+        "UPDATE characters SET map = ?, zone = ?, instance_id = ?, position_x = ?, position_y = ?, position_z = ?, orientation = ? WHERE guid = ?",
         (
             fixture.original_position.map_id,
+            fixture.original_position.zone_id,
+            fixture.original_position.instance_id,
             fixture.original_position.x,
             fixture.original_position.y,
             fixture.original_position.z,
@@ -5447,10 +5456,12 @@ fn cleanup_bank_smoke_fixture(bot: &config::BotConfig, fixture: &BankSmokeFixtur
         .map_err(|e| anyhow!("Delete bank fixture item: {e}"))?;
     transaction
         .exec_drop(
-            "UPDATE characters SET map = ?, position_x = ?, position_y = ?, position_z = ?, orientation = ? \
+            "UPDATE characters SET map = ?, zone = ?, instance_id = ?, position_x = ?, position_y = ?, position_z = ?, orientation = ? \
              WHERE guid = ?",
             (
                 fixture.original_position.map_id,
+                fixture.original_position.zone_id,
+                fixture.original_position.instance_id,
                 fixture.original_position.x,
                 fixture.original_position.y,
                 fixture.original_position.z,
@@ -6241,6 +6252,24 @@ fn spell_go_matches_bind(
     target == (expected_player_low, expected_player_high) && hit_target == target && item == (0, 0)
 }
 
+fn homebind_spell_go_seen_after_packet(
+    already_seen: bool,
+    payload: &[u8],
+    expected_caster_low: u64,
+    expected_caster_high: u64,
+    expected_player_low: u64,
+    expected_player_high: u64,
+) -> bool {
+    already_seen
+        || spell_go_matches_bind(
+            payload,
+            expected_caster_low,
+            expected_caster_high,
+            expected_player_low,
+            expected_player_high,
+        )
+}
+
 fn player_bound_matches(
     payload: &[u8],
     expected_low: u64,
@@ -6538,6 +6567,35 @@ mod tests {
         payload[spell_offset..spell_offset + 4].copy_from_slice(&1u32.to_le_bytes());
         assert!(!spell_go_matches_bind(
             &payload,
+            caster_low,
+            caster_high,
+            player_low,
+            player_high,
+        ));
+    }
+
+    #[test]
+    fn homebind_smoke_keeps_match_after_later_unrelated_spell_go() {
+        let (caster_low, caster_high) = create_creature_guid_raw(1, 12_196, 733);
+        let player_low = 99;
+        let player_high = (2u64 << 58) | (1u64 << 42);
+        let matching = bind_spell_go_fixture(caster_low, caster_high, player_low, player_high);
+        let mut unrelated = matching.clone();
+        let spell_offset = 2 * build_packed_guid(caster_low, caster_high).len()
+            + 2 * build_packed_guid(1, 0).len();
+        unrelated[spell_offset..spell_offset + 4].copy_from_slice(&1u32.to_le_bytes());
+
+        let seen = homebind_spell_go_seen_after_packet(
+            false,
+            &matching,
+            caster_low,
+            caster_high,
+            player_low,
+            player_high,
+        );
+        assert!(homebind_spell_go_seen_after_packet(
+            seen,
+            &unrelated,
             caster_low,
             caster_high,
             player_low,

--- a/tools/wow-test-bot/src/main.rs
+++ b/tools/wow-test-bot/src/main.rs
@@ -32,11 +32,16 @@ const SMSG_AURA_UPDATE: u16 = 0x2C1F;
 const SMSG_TIME_SYNC_REQUEST: u16 = 0x2DD2;
 const SMSG_ON_MONSTER_MOVE: u16 = 0x2DD4;
 const CMSG_BANKER_ACTIVATE: u16 = 0x34B3;
+const CMSG_BINDER_ACTIVATE: u16 = 0x34B2;
 const CMSG_AUTOBANK_ITEM: u16 = 0x3997;
 const CMSG_AUTOSTORE_BANK_ITEM: u16 = 0x3996;
 const CMSG_SWAP_INV_ITEM: u16 = 0x399B;
 const SMSG_NPC_INTERACTION_OPEN_RESULT: u16 = 0x288A;
 const SMSG_INVENTORY_CHANGE_FAILURE: u16 = 0x2DA5;
+const SMSG_BIND_POINT_UPDATE: u16 = 0x257D;
+const SMSG_GOSSIP_COMPLETE: u16 = 0x2A97;
+const SMSG_PLAYER_BOUND: u16 = 0x2FF8;
+const SMSG_SPELL_GO: u16 = 0x2C36;
 const CMSG_LOGOUT_REQUEST: u16 = 0x34D6;
 const SMSG_LOGOUT_COMPLETE: u16 = 0x2684;
 const INVENTORY_SLOT_BAG_0: u8 = 255;
@@ -44,6 +49,7 @@ const INVENTORY_SLOT_ITEM_START: u8 = 35;
 const BANK_SLOT_ITEM_START: u8 = 59;
 const BANK_SLOT_ITEM_END: u8 = 87;
 const NPC_FLAG_BANKER: u32 = 0x20000;
+const NPC_FLAG_INNKEEPER: u32 = 0x10000;
 const DEFAULT_BANK_SMOKE_ITEM_ENTRY: u32 = 2589;
 const DEFAULT_INVENTORY_SWAP_ITEM_ENTRY_A: u32 = 2589;
 const DEFAULT_INVENTORY_SWAP_ITEM_ENTRY_B: u32 = 2592;
@@ -142,6 +148,9 @@ struct CliOptions {
     bank_item_entry: u32,
     bank_runtime_counter: Option<u64>,
     bank_timeout_secs: u64,
+    homebind_smoke: bool,
+    homebind_runtime_counter: Option<u64>,
+    homebind_timeout_secs: u64,
     inventory_swap_smoke: bool,
     inventory_swap_item_entry_a: u32,
     inventory_swap_item_entry_b: u32,
@@ -209,6 +218,18 @@ struct BotRunResult {
     bank_relogin_after_deposit: bool,
     bank_withdraw_persisted: bool,
     bank_failure: Option<String>,
+    homebind_smoke: bool,
+    homebind_smoke_passed: Option<bool>,
+    homebind_innkeeper_entry: Option<u32>,
+    homebind_innkeeper_spawn_guid: Option<u64>,
+    homebind_innkeeper_guid_counter: Option<u64>,
+    homebind_spell_go_seen: bool,
+    homebind_bind_point_update_seen: bool,
+    homebind_player_bound_seen: bool,
+    homebind_gossip_complete_seen: bool,
+    homebind_db_persisted: bool,
+    homebind_relogin_verified: bool,
+    homebind_failure: Option<String>,
     inventory_swap_smoke: bool,
     inventory_swap_smoke_passed: Option<bool>,
     inventory_swap_item_guid_a: Option<u64>,
@@ -275,6 +296,12 @@ impl BotRunResult {
                 && self.player_login_verified
                 && self.bank_smoke_passed.unwrap_or(false);
         }
+        if self.homebind_smoke {
+            return self.world_auth
+                && self.enum_characters
+                && self.player_login_verified
+                && self.homebind_smoke_passed.unwrap_or(false);
+        }
         if self.inventory_swap_smoke {
             return self.world_auth
                 && self.enum_characters
@@ -300,6 +327,7 @@ struct RunReport {
     login_only: bool,
     stand_state_smoke: bool,
     bank_smoke: bool,
+    homebind_smoke: bool,
     inventory_swap_smoke: bool,
     quest_smoke: bool,
     results: Vec<BotRunResult>,
@@ -388,6 +416,38 @@ struct CharacterPositionSnapshot {
 struct BankSmokeFixture {
     options: BankSmokeOptions,
     original_position: CharacterPositionSnapshot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HomebindSmokePhase {
+    Bind,
+    VerifyRelog,
+}
+
+#[derive(Debug, Clone)]
+struct HomebindSmokeOptions {
+    phase: HomebindSmokePhase,
+    innkeeper: ResolvedCreatureTarget,
+    discover_runtime_guid: bool,
+    expected_homebind: Option<HomebindRowSnapshot>,
+    timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct HomebindRowSnapshot {
+    map_id: u16,
+    zone_id: u16,
+    x: f32,
+    y: f32,
+    z: f32,
+    orientation: f32,
+}
+
+#[derive(Debug, Clone)]
+struct HomebindSmokeFixture {
+    options: HomebindSmokeOptions,
+    original_position: CharacterPositionSnapshot,
+    original_homebind: Option<HomebindRowSnapshot>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -500,6 +560,19 @@ fn parse_cli() -> Result<CliOptions> {
             .map(|value| value.parse::<u64>())
             .transpose()?,
         bank_timeout_secs: std::env::var("WOW_BOT_BANK_TIMEOUT_SECS")
+            .ok()
+            .map(|value| value.parse::<u64>())
+            .transpose()?
+            .unwrap_or(8),
+        homebind_smoke: std::env::var("WOW_BOT_HOMEBIND_SMOKE")
+            .ok()
+            .map(|v| is_truthy(&v))
+            .unwrap_or(false),
+        homebind_runtime_counter: std::env::var("WOW_BOT_HOMEBIND_RUNTIME_COUNTER")
+            .ok()
+            .map(|value| value.parse::<u64>())
+            .transpose()?,
+        homebind_timeout_secs: std::env::var("WOW_BOT_HOMEBIND_TIMEOUT_SECS")
             .ok()
             .map(|value| value.parse::<u64>())
             .transpose()?
@@ -643,6 +716,14 @@ fn parse_cli() -> Result<CliOptions> {
             }
             "--bank-timeout" => {
                 opts.bank_timeout_secs = next_arg(&mut args, "--bank-timeout")?.parse()?;
+            }
+            "--homebind-smoke" => opts.homebind_smoke = true,
+            "--homebind-runtime-counter" => {
+                opts.homebind_runtime_counter =
+                    Some(next_arg(&mut args, "--homebind-runtime-counter")?.parse()?);
+            }
+            "--homebind-timeout" => {
+                opts.homebind_timeout_secs = next_arg(&mut args, "--homebind-timeout")?.parse()?;
             }
             "--inventory-swap-smoke" => opts.inventory_swap_smoke = true,
             "--inventory-swap-item-entry-a" => {
@@ -802,6 +883,16 @@ fn print_help() {
     println!("  --bank-timeout <secs>    Per bank phase timeout (default: 8)");
     println!(
         "                           Env: WOW_BOT_BANK_SMOKE, WOW_BOT_BANK_ITEM_ENTRY, WOW_BOT_BANK_RUNTIME_COUNTER, WOW_BOT_BANK_TIMEOUT_SECS"
+    );
+    println!(
+        "  --homebind-smoke         Bind at an innkeeper, relog, and verify response packets plus DB persistence"
+    );
+    println!(
+        "  --homebind-runtime-counter <n> Optional ObjectGuid low-counter override for the innkeeper"
+    );
+    println!("  --homebind-timeout <secs> Bind response timeout (default: 8)");
+    println!(
+        "                           Env: WOW_BOT_HOMEBIND_SMOKE, WOW_BOT_HOMEBIND_RUNTIME_COUNTER, WOW_BOT_HOMEBIND_TIMEOUT_SECS"
     );
     println!("  --quest-smoke            After login, right-click/query one questgiver NPC");
     println!("  --quest-creature-entry <id>  Creature entry to resolve from world.creature");
@@ -1101,6 +1192,7 @@ async fn main() -> Result<()> {
     let post_login_mode_count = [
         cli.stand_state_smoke,
         cli.bank_smoke,
+        cli.homebind_smoke,
         cli.inventory_swap_smoke,
         cli.quest_smoke,
     ]
@@ -1108,7 +1200,7 @@ async fn main() -> Result<()> {
     .filter(|enabled| *enabled)
     .count();
     if post_login_mode_count > 1 {
-        bail!("stand-state, bank, inventory-swap, and quest smoke are separate post-login modes");
+        bail!("stand-state, bank, homebind, inventory-swap, and quest smoke are separate post-login modes");
     }
     if cli.bank_smoke && bots.len() != 1 {
         bail!("--bank-smoke requires exactly one bot; select it with --single");
@@ -1120,6 +1212,12 @@ async fn main() -> Result<()> {
         bail!(
             "--bank-smoke requires --bank-runtime-counter or WOW_BOT_BANK_RUNTIME_COUNTER for the live banker ObjectGuid"
         );
+    }
+    if cli.homebind_smoke && bots.len() != 1 {
+        bail!("--homebind-smoke requires exactly one bot; select it with --single");
+    }
+    if cli.homebind_smoke && cli.homebind_timeout_secs == 0 {
+        bail!("--homebind-timeout must be greater than zero");
     }
     if cli.inventory_swap_smoke && bots.len() != 1 {
         bail!("--inventory-swap-smoke requires exactly one bot; select it with --single");
@@ -1172,6 +1270,8 @@ async fn main() -> Result<()> {
             "stand-state-smoke"
         } else if cli.bank_smoke {
             "bank-smoke"
+        } else if cli.homebind_smoke {
+            "homebind-smoke"
         } else if cli.inventory_swap_smoke {
             "inventory-swap-smoke"
         } else if cli.quest_smoke {
@@ -1192,6 +1292,7 @@ async fn main() -> Result<()> {
         && !cli.login_only
         && !cli.stand_state_smoke
         && !cli.bank_smoke
+        && !cli.homebind_smoke
         && !cli.inventory_swap_smoke
     {
         cleanup_bot_group_state(&bots)?;
@@ -1213,6 +1314,16 @@ async fn main() -> Result<()> {
                     cli.bank_timeout_secs,
                 )
                 .await
+            } else if cli.homebind_smoke {
+                run_homebind_smoke_workflow(
+                    bot,
+                    dungeon_id,
+                    timeout_secs,
+                    auto_teleport,
+                    cli.homebind_runtime_counter,
+                    cli.homebind_timeout_secs,
+                )
+                .await
             } else if cli.inventory_swap_smoke {
                 run_inventory_swap_smoke_workflow(
                     bot,
@@ -1232,6 +1343,7 @@ async fn main() -> Result<()> {
                     auto_teleport,
                     cli.login_only,
                     stand_state_options.clone(),
+                    None,
                     None,
                     None,
                     quest_options.clone(),
@@ -1269,6 +1381,7 @@ async fn main() -> Result<()> {
                     stand_state_options_for_bot,
                     None,
                     None,
+                    None,
                     quest_options_for_bot,
                 )
                 .await;
@@ -1299,6 +1412,7 @@ async fn main() -> Result<()> {
         cli.login_only,
         cli.stand_state_smoke,
         cli.bank_smoke,
+        cli.homebind_smoke,
         cli.inventory_swap_smoke,
         cli.quest_smoke,
         &results,
@@ -1422,6 +1536,7 @@ async fn run_bot(
     login_only: bool,
     stand_state_options: Option<StandStateSmokeOptions>,
     bank_options: Option<BankSmokeOptions>,
+    homebind_options: Option<HomebindSmokeOptions>,
     inventory_swap_options: Option<InventorySwapSmokeOptions>,
     quest_options: Option<QuestSmokeOptions>,
 ) -> Result<BotRunResult> {
@@ -1470,6 +1585,24 @@ async fn run_bot(
         bank_relogin_after_deposit: false,
         bank_withdraw_persisted: false,
         bank_failure: None,
+        homebind_smoke: homebind_options.is_some(),
+        homebind_smoke_passed: None,
+        homebind_innkeeper_entry: homebind_options
+            .as_ref()
+            .map(|options| options.innkeeper.entry),
+        homebind_innkeeper_spawn_guid: homebind_options
+            .as_ref()
+            .map(|options| options.innkeeper.spawn_guid),
+        homebind_innkeeper_guid_counter: homebind_options
+            .as_ref()
+            .map(|options| options.innkeeper.guid_counter),
+        homebind_spell_go_seen: false,
+        homebind_bind_point_update_seen: false,
+        homebind_player_bound_seen: false,
+        homebind_gossip_complete_seen: false,
+        homebind_db_persisted: false,
+        homebind_relogin_verified: false,
+        homebind_failure: None,
         inventory_swap_smoke: inventory_swap_options.is_some(),
         inventory_swap_smoke_passed: None,
         inventory_swap_item_guid_a: inventory_swap_options
@@ -1797,6 +1930,7 @@ async fn run_bot(
     info!("[Bot {}] ✅ CMSG_PLAYER_LOGIN sent", bot_index);
 
     let mut login_ok = false;
+    let preserve_realm_connection = stand_state_options.is_some() || homebind_options.is_some();
     for _ in 0..30 {
         match tokio::time::timeout(
             Duration::from_secs(5),
@@ -1813,10 +1947,10 @@ async fn run_bot(
                     // SMSG_LOGIN_VERIFY_WORLD
                     info!("[Bot {}] ✅ SMSG_LOGIN_VERIFY_WORLD received", bot_index);
                     login_ok = true;
-                    if stand_state_options.is_none() || realm_connection.is_some() {
+                    if !preserve_realm_connection || realm_connection.is_some() {
                         break;
                     }
-                    // A stand-state capture validates connection routing, so
+                    // Routing-sensitive captures validate both connections, so
                     // keep reading the realm socket until SMSG_CONNECT_TO has
                     // created and authenticated a distinct instance socket.
                     continue;
@@ -1836,9 +1970,9 @@ async fn run_bot(
                     );
                     let (instance_stream, instance_crypt) =
                         connect_to_instance(bot_index, &connect_to, &derived_session_key).await?;
-                    if stand_state_options.is_some() {
+                    if preserve_realm_connection {
                         if realm_connection.is_some() {
-                            bail!("Stand-state smoke received more than one SMSG_CONNECT_TO");
+                            bail!("Routing smoke received more than one SMSG_CONNECT_TO");
                         }
                         let realm_stream = std::mem::replace(&mut stream, instance_stream);
                         let realm_crypt = std::mem::replace(&mut crypt, instance_crypt);
@@ -1854,7 +1988,7 @@ async fn run_bot(
                         server_inflater = ServerPacketInflater::default();
                     }
                     info!("[Bot {}] ✅ Instance socket authenticated", bot_index);
-                    if login_ok && stand_state_options.is_some() {
+                    if login_ok && preserve_realm_connection {
                         break;
                     }
                 } else if op == 0x304B {
@@ -1934,6 +2068,25 @@ async fn run_bot(
         {
             result.bank_failure = Some(error.to_string());
             result.bank_smoke_passed = Some(false);
+        }
+        return Ok(result);
+    }
+
+    if let Some(homebind_options) = homebind_options {
+        if let Err(error) = run_homebind_smoke_phase(
+            bot_index,
+            &bot,
+            &mut stream,
+            &mut crypt,
+            &mut server_inflater,
+            &mut realm_connection,
+            &homebind_options,
+            &mut result,
+        )
+        .await
+        {
+            result.homebind_failure = Some(error.to_string());
+            result.homebind_smoke_passed = Some(false);
         }
         return Ok(result);
     }
@@ -2182,6 +2335,22 @@ fn log_bot_summary(
             );
             return;
         }
+        if result.homebind_smoke {
+            info!(
+                "✅ Bot {}: SUCCESS homebind_smoke innkeeper={:?}/{:?} spell_go={} bind_update={} player_bound={} gossip_complete={} db_persisted={} relog={} failure={:?}",
+                result.account,
+                result.homebind_innkeeper_entry,
+                result.homebind_innkeeper_spawn_guid,
+                result.homebind_spell_go_seen,
+                result.homebind_bind_point_update_seen,
+                result.homebind_player_bound_seen,
+                result.homebind_gossip_complete_seen,
+                result.homebind_db_persisted,
+                result.homebind_relogin_verified,
+                result.homebind_failure
+            );
+            return;
+        }
         if result.inventory_swap_smoke {
             info!(
                 "✅ Bot {}: SUCCESS inventory_swap_smoke items={:?}/{:?} entries={:?}/{:?} slots={:?}<->{:?} forward={} relog={} reverse={} failure={:?}",
@@ -2259,6 +2428,22 @@ fn log_bot_summary(
             );
             return;
         }
+        if result.homebind_smoke {
+            error!(
+                "❌ Bot {}: FAILED homebind_smoke innkeeper={:?}/{:?} spell_go={} bind_update={} player_bound={} gossip_complete={} db_persisted={} relog={} failure={:?}",
+                result.account,
+                result.homebind_innkeeper_entry,
+                result.homebind_innkeeper_spawn_guid,
+                result.homebind_spell_go_seen,
+                result.homebind_bind_point_update_seen,
+                result.homebind_player_bound_seen,
+                result.homebind_gossip_complete_seen,
+                result.homebind_db_persisted,
+                result.homebind_relogin_verified,
+                result.homebind_failure
+            );
+            return;
+        }
         if result.inventory_swap_smoke {
             error!(
                 "❌ Bot {}: FAILED inventory_swap_smoke items={:?}/{:?} entries={:?}/{:?} slots={:?}<->{:?} forward={} relog={} reverse={} failure={:?}",
@@ -2301,6 +2486,7 @@ fn write_report_if_requested(
     login_only: bool,
     stand_state_smoke: bool,
     bank_smoke: bool,
+    homebind_smoke: bool,
     inventory_swap_smoke: bool,
     quest_smoke: bool,
     results: &[BotRunResult],
@@ -2320,6 +2506,7 @@ fn write_report_if_requested(
         login_only,
         stand_state_smoke,
         bank_smoke,
+        homebind_smoke,
         inventory_swap_smoke,
         quest_smoke,
         results: results.to_vec(),
@@ -3021,6 +3208,7 @@ async fn run_bank_smoke_workflow(
         Some(deposit_options),
         None,
         None,
+        None,
     )
     .await;
 
@@ -3048,6 +3236,7 @@ async fn run_bank_smoke_workflow(
             false,
             None,
             Some(withdraw_options),
+            None,
             None,
             None,
         )
@@ -3089,6 +3278,388 @@ async fn run_bank_smoke_workflow(
     }
 
     Ok(combined)
+}
+
+async fn run_homebind_smoke_workflow(
+    bot: config::BotConfig,
+    dungeon_id: u32,
+    lfg_secs: u64,
+    auto_teleport: bool,
+    runtime_counter: Option<u64>,
+    timeout_secs: u64,
+) -> Result<BotRunResult> {
+    let bot_for_setup = bot.clone();
+    let fixture = tokio::task::spawn_blocking(move || {
+        prepare_homebind_smoke_fixture(&bot_for_setup, runtime_counter, timeout_secs)
+    })
+    .await
+    .map_err(|e| anyhow!("Homebind smoke setup DB worker join failed: {e}"))??;
+
+    let first = run_bot(
+        bot.clone(),
+        dungeon_id,
+        lfg_secs,
+        auto_teleport,
+        false,
+        None,
+        None,
+        Some(fixture.options.clone()),
+        None,
+        None,
+    )
+    .await;
+
+    let mut combined = match first {
+        Ok(result) => result,
+        Err(error) => {
+            let bot_for_cleanup = bot.clone();
+            let fixture_for_cleanup = fixture.clone();
+            let cleanup = tokio::task::spawn_blocking(move || {
+                cleanup_homebind_smoke_fixture(&bot_for_cleanup, &fixture_for_cleanup)
+            })
+            .await
+            .map_err(|join_error| {
+                anyhow!(
+                    "Homebind smoke bind login/phase failed: {error}; cleanup worker failed: {join_error}"
+                )
+            })?;
+            if let Err(cleanup_error) = cleanup {
+                bail!(
+                    "Homebind smoke bind login/phase failed: {error}; fixture cleanup failed: {cleanup_error}"
+                );
+            }
+            return Err(error.context("Homebind smoke bind login/phase failed"));
+        }
+    };
+
+    if combined.homebind_smoke_passed.unwrap_or(false) {
+        let mut relog_options = fixture.options.clone();
+        relog_options.phase = HomebindSmokePhase::VerifyRelog;
+        let bot_for_db = bot.clone();
+        relog_options.expected_homebind =
+            match tokio::task::spawn_blocking(move || load_homebind_row(&bot_for_db)).await {
+                Ok(Ok(Some(row))) => Some(row),
+                Ok(Ok(None)) => {
+                    combined.homebind_failure =
+                        Some("character_homebind disappeared before relog".to_string());
+                    combined.homebind_smoke_passed = Some(false);
+                    None
+                }
+                Ok(Err(error)) => {
+                    combined.homebind_failure =
+                        Some(format!("Homebind expected-row query failed: {error}"));
+                    combined.homebind_smoke_passed = Some(false);
+                    None
+                }
+                Err(error) => {
+                    combined.homebind_failure =
+                        Some(format!("Homebind expected-row worker join failed: {error}"));
+                    combined.homebind_smoke_passed = Some(false);
+                    None
+                }
+            };
+        if relog_options.expected_homebind.is_some() {
+            match run_bot(
+                bot.clone(),
+                dungeon_id,
+                lfg_secs,
+                auto_teleport,
+                false,
+                None,
+                None,
+                Some(relog_options),
+                None,
+                None,
+            )
+            .await
+            {
+                Ok(second) => {
+                    combined.world_auth &= second.world_auth;
+                    combined.enum_characters &= second.enum_characters;
+                    combined.player_login_verified &= second.player_login_verified;
+                    combined.homebind_relogin_verified = second.homebind_relogin_verified;
+                    combined.seen_opcodes.extend(second.seen_opcodes);
+                    combined.homebind_failure = second.homebind_failure;
+                    combined.homebind_smoke_passed = Some(
+                        combined.homebind_spell_go_seen
+                            && combined.homebind_bind_point_update_seen
+                            && combined.homebind_player_bound_seen
+                            && combined.homebind_gossip_complete_seen
+                            && combined.homebind_db_persisted
+                            && combined.homebind_relogin_verified
+                            && second.homebind_smoke_passed.unwrap_or(false),
+                    );
+                }
+                Err(error) => {
+                    combined.homebind_failure = Some(format!("Homebind relog failed: {error}"));
+                    combined.homebind_smoke_passed = Some(false);
+                }
+            }
+        }
+    }
+
+    let bot_for_cleanup = bot.clone();
+    let fixture_for_cleanup = fixture.clone();
+    let cleanup = tokio::task::spawn_blocking(move || {
+        cleanup_homebind_smoke_fixture(&bot_for_cleanup, &fixture_for_cleanup)
+    })
+    .await
+    .map_err(|e| anyhow!("Homebind smoke cleanup DB worker join failed: {e}"))?;
+    if let Err(error) = cleanup {
+        combined.homebind_failure = Some(format!("Homebind fixture cleanup failed: {error}"));
+        combined.homebind_smoke_passed = Some(false);
+    }
+
+    Ok(combined)
+}
+
+async fn run_homebind_smoke_phase(
+    bot_index: usize,
+    bot: &config::BotConfig,
+    stream: &mut TcpStream,
+    crypt: &mut WorldCrypt,
+    server_inflater: &mut ServerPacketInflater,
+    realm_connection: &mut Option<EncryptedWorldConnection>,
+    options: &HomebindSmokeOptions,
+    result: &mut BotRunResult,
+) -> Result<()> {
+    if options.phase == HomebindSmokePhase::Bind {
+        let mut runtime_components = (!options.discover_runtime_guid).then(|| {
+            let (_, low, high) = parse_packed_guid(&options.innkeeper.packed_guid)
+                .expect("fixture packed GUID was built locally");
+            (low, high)
+        });
+        let drain_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while tokio::time::Instant::now() < drain_deadline {
+            match tokio::time::timeout(
+                Duration::from_millis(250),
+                read_encrypted_packet(stream, crypt, server_inflater),
+            )
+            .await
+            {
+                Ok(Ok((opcode, payload))) => {
+                    result.seen_opcodes.push(format!("0x{opcode:04X}"));
+                    if opcode == SMSG_UPDATE_OBJECT {
+                        if let Some((low, high)) = find_creature_guid_in_update_object(
+                            &payload,
+                            options.innkeeper.map_id,
+                            options.innkeeper.entry,
+                        ) {
+                            runtime_components = Some((low, high));
+                            result.homebind_innkeeper_guid_counter = Some(low & 0xFF_FFFF_FFFF);
+                        }
+                    }
+                }
+                Ok(Err(error)) => return Err(error),
+                Err(_) => break,
+            }
+        }
+        let (runtime_low, runtime_high) = runtime_components.ok_or_else(|| {
+            anyhow!(
+                "innkeeper entry {} was not discovered in login SMSG_UPDATE_OBJECT packets",
+                options.innkeeper.entry
+            )
+        })?;
+        let realm = realm_connection.as_mut().context(
+            "homebind smoke requires distinct realm/instance sockets to validate C++ routing",
+        )?;
+        loop {
+            match tokio::time::timeout(
+                Duration::from_millis(250),
+                read_encrypted_packet(&mut realm.stream, &mut realm.crypt, &mut realm.inflater),
+            )
+            .await
+            {
+                Ok(Ok((opcode, payload))) => {
+                    result.seen_opcodes.push(format!("0x{opcode:04X}"));
+                    info!(
+                        "[Bot {}] 📦 realm login drain {}",
+                        bot_index,
+                        parse_packet(opcode, &payload)
+                    );
+                }
+                Ok(Err(error)) => return Err(error),
+                Err(_) => break,
+            }
+        }
+        let runtime_guid = build_packed_guid(runtime_low, runtime_high);
+        send_encrypted_packet(stream, crypt, CMSG_BINDER_ACTIVATE, &runtime_guid).await?;
+        info!(
+            "[Bot {}] ✅ CMSG_BINDER_ACTIVATE sent to entry={} spawn={}",
+            bot_index, options.innkeeper.entry, options.innkeeper.spawn_guid
+        );
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(options.timeout_secs);
+        let mut bind_packet_homebind = None;
+        let mut pending_player_bound = None;
+        while tokio::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            enum HomebindReady {
+                Instance,
+                Realm,
+            }
+            let mut instance_peek = [0u8; 1];
+            let mut realm_peek = [0u8; 1];
+            let ready = tokio::time::timeout(remaining, async {
+                tokio::select! {
+                    result = stream.peek(&mut instance_peek) => {
+                        if result.context("homebind instance peek failed")? == 0 {
+                            bail!("instance connection closed during homebind smoke");
+                        }
+                        Ok(HomebindReady::Instance)
+                    }
+                    result = realm.stream.peek(&mut realm_peek) => {
+                        if result.context("homebind realm peek failed")? == 0 {
+                            bail!("realm connection closed during homebind smoke");
+                        }
+                        Ok(HomebindReady::Realm)
+                    }
+                }
+            })
+            .await;
+            let ready = match ready {
+                Ok(result) => result?,
+                Err(_) => break,
+            };
+            let (connection, opcode, payload) = match ready {
+                HomebindReady::Instance => {
+                    let (opcode, payload) = tokio::time::timeout(
+                        deadline.saturating_duration_since(tokio::time::Instant::now()),
+                        read_encrypted_packet(stream, crypt, server_inflater),
+                    )
+                    .await
+                    .map_err(|_| anyhow!("homebind instance packet read timed out"))??;
+                    ("instance", opcode, payload)
+                }
+                HomebindReady::Realm => {
+                    let (opcode, payload) = tokio::time::timeout(
+                        deadline.saturating_duration_since(tokio::time::Instant::now()),
+                        read_encrypted_packet(
+                            &mut realm.stream,
+                            &mut realm.crypt,
+                            &mut realm.inflater,
+                        ),
+                    )
+                    .await
+                    .map_err(|_| anyhow!("homebind realm packet read timed out"))??;
+                    ("realm", opcode, payload)
+                }
+            };
+            result.seen_opcodes.push(format!("0x{opcode:04X}"));
+            info!(
+                "[Bot {}] 📦 {} {}",
+                bot_index,
+                connection,
+                parse_packet(opcode, &payload)
+            );
+            match (connection, opcode) {
+                ("instance", SMSG_SPELL_GO) => {
+                    let player_high = (2u64 << 58) | ((u64::from(realm_id()) & 0x1FFF) << 42);
+                    result.homebind_spell_go_seen = spell_go_matches_bind(
+                        &payload,
+                        runtime_low,
+                        runtime_high,
+                        bot.character_guid,
+                        player_high,
+                    );
+                }
+                ("instance", SMSG_BIND_POINT_UPDATE) => {
+                    if let Some(homebind) =
+                        parse_bind_point_update(&payload, options.innkeeper.orientation)
+                    {
+                        result.homebind_bind_point_update_seen = true;
+                        if let Some(player_bound) = pending_player_bound.as_deref() {
+                            result.homebind_player_bound_seen = player_bound_matches(
+                                player_bound,
+                                runtime_low,
+                                runtime_high,
+                                u32::from(homebind.zone_id),
+                            );
+                        }
+                        bind_packet_homebind = Some(homebind);
+                    }
+                }
+                ("realm", SMSG_PLAYER_BOUND) => {
+                    if let Some(expected) = bind_packet_homebind.as_ref() {
+                        result.homebind_player_bound_seen = player_bound_matches(
+                            &payload,
+                            runtime_low,
+                            runtime_high,
+                            u32::from(expected.zone_id),
+                        );
+                    }
+                    pending_player_bound = Some(payload);
+                }
+                ("realm", SMSG_GOSSIP_COMPLETE) => result.homebind_gossip_complete_seen = true,
+                ("instance", SMSG_PLAYER_BOUND | SMSG_GOSSIP_COMPLETE) => {
+                    bail!(
+                        "{} arrived on instance; C++ routes it on realm",
+                        parse_packet(opcode, &payload)
+                    );
+                }
+                ("realm", SMSG_SPELL_GO | SMSG_BIND_POINT_UPDATE) => {
+                    bail!(
+                        "{} arrived on realm; C++ routes it on instance",
+                        parse_packet(opcode, &payload)
+                    );
+                }
+                _ => {}
+            }
+            if result.homebind_spell_go_seen
+                && result.homebind_bind_point_update_seen
+                && result.homebind_player_bound_seen
+                && result.homebind_gossip_complete_seen
+            {
+                break;
+            }
+        }
+        if !(result.homebind_spell_go_seen
+            && result.homebind_bind_point_update_seen
+            && result.homebind_player_bound_seen
+            && result.homebind_gossip_complete_seen)
+        {
+            bail!(
+                "missing bind responses: spell_go={} bind_update={} player_bound={} gossip_complete={}",
+                result.homebind_spell_go_seen,
+                result.homebind_bind_point_update_seen,
+                result.homebind_player_bound_seen,
+                result.homebind_gossip_complete_seen
+            );
+        }
+        let expected_homebind = bind_packet_homebind
+            .ok_or_else(|| anyhow!("BindPointUpdate payload could not be decoded"))?;
+        let bot_for_db = bot.clone();
+        result.homebind_db_persisted = tokio::task::spawn_blocking(move || {
+            Ok::<_, anyhow::Error>(
+                load_homebind_row(&bot_for_db)?.as_ref() == Some(&expected_homebind),
+            )
+        })
+        .await
+        .map_err(|e| anyhow!("Homebind DB verification worker join failed: {e}"))??;
+        if !result.homebind_db_persisted {
+            bail!("character_homebind did not persist the live bind location");
+        }
+    } else {
+        let expected_homebind = options
+            .expected_homebind
+            .clone()
+            .ok_or_else(|| anyhow!("Homebind relog phase missing expected complete row"))?;
+        let bot_for_db = bot.clone();
+        result.homebind_relogin_verified = tokio::task::spawn_blocking(move || {
+            Ok::<_, anyhow::Error>(
+                load_homebind_row(&bot_for_db)?.as_ref() == Some(&expected_homebind),
+            )
+        })
+        .await
+        .map_err(|e| anyhow!("Homebind relog DB worker join failed: {e}"))??;
+        if !result.homebind_relogin_verified {
+            bail!("character_homebind changed before the verification relog completed");
+        }
+    }
+
+    logout_and_wait(bot_index, stream, crypt, server_inflater, result).await?;
+    result.homebind_smoke_passed = Some(true);
+    Ok(())
 }
 
 async fn run_bank_smoke_phase(
@@ -3235,6 +3806,7 @@ async fn run_inventory_swap_smoke_workflow(
         false,
         None,
         None,
+        None,
         Some(forward_options),
         None,
     )
@@ -3262,6 +3834,7 @@ async fn run_inventory_swap_smoke_workflow(
             lfg_secs,
             auto_teleport,
             false,
+            None,
             None,
             None,
             Some(reverse_options),
@@ -4549,6 +5122,249 @@ fn prepare_bank_smoke_fixture(
     })
 }
 
+fn prepare_homebind_smoke_fixture(
+    bot: &config::BotConfig,
+    runtime_counter: Option<u64>,
+    timeout_secs: u64,
+) -> Result<HomebindSmokeFixture> {
+    use mysql::prelude::Queryable;
+
+    if !bot.account.to_ascii_uppercase().ends_with("@BOT.LOCAL") {
+        bail!(
+            "refusing destructive homebind fixture setup for non-local account {}",
+            bot.account
+        );
+    }
+
+    let characters_url = characters_db_url()?;
+    let character_opts = mysql::Opts::from_url(&characters_url)
+        .map_err(|e| anyhow!("Bad characters DB URL: {e}"))?;
+    let mut characters = mysql::Conn::new(character_opts)
+        .map_err(|e| anyhow!("Connect to characters DB failed: {e}"))?;
+    let character: Option<(u32, u8, u8, u32, f64, f64, f64, f32)> = characters
+        .exec_first(
+            "SELECT account, online, race, map, position_x, position_y, position_z, orientation \
+             FROM characters WHERE guid = ?",
+            (bot.character_guid,),
+        )
+        .map_err(|e| anyhow!("Load homebind bot character: {e}"))?;
+    let (owner, online, race, map_id, x, y, z, orientation) =
+        character.ok_or_else(|| anyhow!("No characters row for guid {}", bot.character_guid))?;
+    if owner != bot.account_id {
+        bail!(
+            "character {} belongs to account {}, expected {}",
+            bot.character_guid,
+            owner,
+            bot.account_id
+        );
+    }
+    if online != 0 {
+        bail!(
+            "character {} is online; log it out before homebind smoke setup",
+            bot.character_guid
+        );
+    }
+    let original_position = CharacterPositionSnapshot {
+        map_id,
+        x,
+        y,
+        z,
+        orientation,
+    };
+    let original_homebind = characters
+        .exec_first(
+            "SELECT mapId, zoneId, posX, posY, posZ, orientation FROM character_homebind WHERE guid = ?",
+            (bot.character_guid,),
+        )
+        .map_err(|e| anyhow!("Load original character_homebind: {e}"))?
+        .map(|(map_id, zone_id, x, y, z, orientation)| HomebindRowSnapshot {
+            map_id,
+            zone_id,
+            x,
+            y,
+            z,
+            orientation,
+        });
+
+    let world_url = world_db_url()?;
+    let world_opts =
+        mysql::Opts::from_url(&world_url).map_err(|e| anyhow!("Bad world DB URL: {e}"))?;
+    let mut world =
+        mysql::Conn::new(world_opts).map_err(|e| anyhow!("Connect to world DB failed: {e}"))?;
+    let preferred_faction = if matches!(race, 2 | 5 | 6 | 8 | 9 | 10 | 26 | 27 | 28 | 35 | 36) {
+        29u32
+    } else {
+        12u32
+    };
+    let innkeeper_row: (u64, u32, u32, f64, f64, f64, f32) = world
+        .exec_first(
+            "SELECT c.guid, c.id, c.map, c.position_x, c.position_y, c.position_z, c.orientation \
+             FROM creature c JOIN creature_template ct ON ct.entry = c.id \
+             WHERE c.map IN (0, 1) \
+               AND ct.faction = ? \
+               AND ((IF(c.npcflag <> 0, c.npcflag, ct.npcflag) & ?) <> 0) \
+               AND c.phaseid = 0 AND c.phasegroup = 0 \
+               AND FIND_IN_SET('0', c.spawnDifficulties) > 0 \
+               AND ct.VehicleId = 0 \
+               AND NOT EXISTS (SELECT 1 FROM creature duplicate \
+                               WHERE duplicate.map = c.map AND duplicate.id = c.id \
+                                 AND duplicate.guid <> c.guid) \
+             ORDER BY c.guid LIMIT 1",
+            (preferred_faction, NPC_FLAG_INNKEEPER),
+        )
+        .map_err(|e| anyhow!("Resolve unique faction-friendly innkeeper: {e}"))?
+        .ok_or_else(|| anyhow!("No unique faction-friendly continent innkeeper exists"))?;
+    let (spawn_guid, entry, innkeeper_map, innkeeper_x, innkeeper_y, innkeeper_z, innkeeper_o) =
+        innkeeper_row;
+    let innkeeper_map = u16::try_from(innkeeper_map)
+        .map_err(|_| anyhow!("innkeeper map id does not fit protocol: {innkeeper_map}"))?;
+    let discover_runtime_guid = runtime_counter.is_none();
+    // The placeholder is replaced from the login UpdateObject stream. An
+    // explicit override remains useful for narrow packet captures.
+    let guid_counter = runtime_counter.unwrap_or(spawn_guid);
+    let (low, high) = create_creature_guid_raw(innkeeper_map, entry, guid_counter);
+    let innkeeper = ResolvedCreatureTarget {
+        entry,
+        spawn_guid,
+        guid_counter,
+        map_id: innkeeper_map,
+        x: innkeeper_x,
+        y: innkeeper_y,
+        z: innkeeper_z,
+        orientation: innkeeper_o,
+        packed_guid: build_packed_guid(low, high),
+    };
+
+    characters
+        .exec_drop(
+            "UPDATE characters SET map = ?, position_x = ?, position_y = ?, position_z = ?, orientation = ? WHERE guid = ?",
+            (
+                u32::from(innkeeper_map),
+                innkeeper_x + 2.0,
+                innkeeper_y,
+                innkeeper_z,
+                innkeeper_o,
+                bot.character_guid,
+            ),
+        )
+        .map_err(|e| anyhow!("Relocate homebind bot near innkeeper: {e}"))?;
+
+    Ok(HomebindSmokeFixture {
+        options: HomebindSmokeOptions {
+            phase: HomebindSmokePhase::Bind,
+            innkeeper,
+            discover_runtime_guid,
+            expected_homebind: None,
+            timeout_secs,
+        },
+        original_position,
+        original_homebind,
+    })
+}
+
+fn load_homebind_row(bot: &config::BotConfig) -> Result<Option<HomebindRowSnapshot>> {
+    use mysql::prelude::Queryable;
+
+    let characters_url = characters_db_url()?;
+    let opts = mysql::Opts::from_url(&characters_url)
+        .map_err(|e| anyhow!("Bad characters DB URL: {e}"))?;
+    let mut conn =
+        mysql::Conn::new(opts).map_err(|e| anyhow!("Connect to characters DB failed: {e}"))?;
+    let row: Option<(u16, u16, f32, f32, f32, f32)> = conn
+        .exec_first(
+            "SELECT mapId, zoneId, posX, posY, posZ, orientation FROM character_homebind WHERE guid = ?",
+            (bot.character_guid,),
+        )
+        .map_err(|e| anyhow!("Load bound character_homebind: {e}"))?;
+    Ok(row.map(
+        |(map_id, zone_id, x, y, z, orientation)| HomebindRowSnapshot {
+            map_id,
+            zone_id,
+            x,
+            y,
+            z,
+            orientation,
+        },
+    ))
+}
+
+fn cleanup_homebind_smoke_fixture(
+    bot: &config::BotConfig,
+    fixture: &HomebindSmokeFixture,
+) -> Result<()> {
+    use mysql::prelude::Queryable;
+
+    let characters_url = characters_db_url()?;
+    let opts = mysql::Opts::from_url(&characters_url)
+        .map_err(|e| anyhow!("Bad characters DB URL: {e}"))?;
+    let mut conn =
+        mysql::Conn::new(opts).map_err(|e| anyhow!("Connect to characters DB failed: {e}"))?;
+    let offline_deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let online: Option<u8> = conn
+            .exec_first(
+                "SELECT online FROM characters WHERE guid = ?",
+                (bot.character_guid,),
+            )
+            .map_err(|e| anyhow!("Check homebind bot offline state before cleanup: {e}"))?;
+        match online {
+            Some(0) => break,
+            Some(_) if std::time::Instant::now() < offline_deadline => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Some(_) => bail!(
+                "character {} remained online during homebind cleanup",
+                bot.character_guid
+            ),
+            None => bail!(
+                "No characters row for guid {} during homebind cleanup",
+                bot.character_guid
+            ),
+        }
+    }
+
+    let mut tx = conn
+        .start_transaction(mysql::TxOpts::default())
+        .map_err(|e| anyhow!("Start homebind cleanup transaction: {e}"))?;
+    tx.exec_drop(
+        "UPDATE characters SET map = ?, position_x = ?, position_y = ?, position_z = ?, orientation = ? WHERE guid = ?",
+        (
+            fixture.original_position.map_id,
+            fixture.original_position.x,
+            fixture.original_position.y,
+            fixture.original_position.z,
+            fixture.original_position.orientation,
+            bot.character_guid,
+        ),
+    )
+    .map_err(|e| anyhow!("Restore homebind bot position: {e}"))?;
+    if let Some(homebind) = &fixture.original_homebind {
+        tx.exec_drop(
+            "INSERT INTO character_homebind (guid, mapId, zoneId, posX, posY, posZ, orientation) \
+             VALUES (?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE mapId=VALUES(mapId), zoneId=VALUES(zoneId), posX=VALUES(posX), posY=VALUES(posY), posZ=VALUES(posZ), orientation=VALUES(orientation)",
+            (
+                bot.character_guid,
+                homebind.map_id,
+                homebind.zone_id,
+                homebind.x,
+                homebind.y,
+                homebind.z,
+                homebind.orientation,
+            ),
+        )
+        .map_err(|e| anyhow!("Restore original character_homebind: {e}"))?;
+    } else {
+        tx.exec_drop(
+            "DELETE FROM character_homebind WHERE guid = ?",
+            (bot.character_guid,),
+        )
+        .map_err(|e| anyhow!("Delete homebind fixture row: {e}"))?;
+    }
+    tx.commit()
+        .map_err(|e| anyhow!("Commit homebind fixture cleanup: {e}"))?;
+    Ok(())
+}
+
 fn verify_bank_fixture_location(
     bot: &config::BotConfig,
     item_guid: u64,
@@ -5270,6 +6086,180 @@ fn create_creature_guid_raw(map_id: u16, entry: u32, counter: u64) -> (u64, u64)
     (low, high)
 }
 
+fn find_creature_guid_in_update_object(
+    payload: &[u8],
+    map_id: u16,
+    entry: u32,
+) -> Option<(u64, u64)> {
+    // CreateObject blocks start with UpdateType (1/2) followed by a packed
+    // ObjectGuid. Scanning is intentional: blocks are variable-sized, while
+    // the GUID's high fields make a false match for type/map/entry negligible.
+    for offset in 0..payload.len().saturating_sub(2) {
+        if !matches!(payload[offset], 1 | 2) {
+            continue;
+        }
+        let Some((_, low, high)) = parse_packed_guid(&payload[offset + 1..]) else {
+            continue;
+        };
+        if ((high >> 58) & 0x3F) == 8
+            && ((high >> 29) & 0x1FFF) == u64::from(map_id)
+            && ((high >> 6) & 0x7F_FFFF) == u64::from(entry)
+        {
+            return Some((low, high));
+        }
+    }
+    None
+}
+
+fn parse_bind_point_update(
+    payload: &[u8],
+    expected_orientation: f32,
+) -> Option<HomebindRowSnapshot> {
+    if payload.len() != 20 {
+        return None;
+    }
+    let x = f32::from_le_bytes(payload[0..4].try_into().ok()?);
+    let y = f32::from_le_bytes(payload[4..8].try_into().ok()?);
+    let z = f32::from_le_bytes(payload[8..12].try_into().ok()?);
+    let map_id = u16::try_from(i32::from_le_bytes(payload[12..16].try_into().ok()?)).ok()?;
+    let zone_id = u16::try_from(i32::from_le_bytes(payload[16..20].try_into().ok()?)).ok()?;
+    Some(HomebindRowSnapshot {
+        map_id,
+        zone_id,
+        x,
+        y,
+        z,
+        orientation: expected_orientation,
+    })
+}
+
+fn read_msb_bits(data: &[u8], bit_offset: usize, bit_count: usize) -> Option<u32> {
+    if bit_count > 32 || bit_offset.checked_add(bit_count)? > data.len().checked_mul(8)? {
+        return None;
+    }
+    let mut value = 0u32;
+    for bit in bit_offset..bit_offset + bit_count {
+        value = (value << 1) | u32::from((data[bit / 8] >> (7 - bit % 8)) & 1);
+    }
+    Some(value)
+}
+
+fn take_packed_guid(data: &[u8], position: &mut usize) -> Option<(u64, u64)> {
+    let (consumed, low, high) = parse_packed_guid(data.get(*position..)?)?;
+    *position = position.checked_add(consumed)?;
+    Some((low, high))
+}
+
+fn take_u32(data: &[u8], position: &mut usize) -> Option<u32> {
+    let bytes: [u8; 4] = data
+        .get(*position..position.checked_add(4)?)?
+        .try_into()
+        .ok()?;
+    *position = position.checked_add(4)?;
+    Some(u32::from_le_bytes(bytes))
+}
+
+fn spell_go_matches_bind(
+    payload: &[u8],
+    expected_caster_low: u64,
+    expected_caster_high: u64,
+    expected_player_low: u64,
+    expected_player_high: u64,
+) -> bool {
+    let mut position = 0usize;
+    let Some(caster) = take_packed_guid(payload, &mut position) else {
+        return false;
+    };
+    let Some(caster_unit) = take_packed_guid(payload, &mut position) else {
+        return false;
+    };
+    if caster != (expected_caster_low, expected_caster_high) || caster_unit != caster {
+        return false;
+    }
+    if take_packed_guid(payload, &mut position).is_none()
+        || take_packed_guid(payload, &mut position).is_none()
+        || take_u32(payload, &mut position) != Some(3286)
+    {
+        return false;
+    }
+
+    // Visual, CastFlags, CastFlagsEx, CastTime, trajectory, destination index,
+    // immunities, heal prediction and empty prediction beacon GUID.
+    if take_u32(payload, &mut position).is_none()
+        || take_u32(payload, &mut position) != Some(0x0004_0101)
+        || take_u32(payload, &mut position) != Some(0)
+        || take_u32(payload, &mut position).is_none()
+    {
+        return false;
+    }
+    position = match position.checked_add(8 + 1 + 8 + 4 + 1) {
+        Some(end) if end <= payload.len() => end,
+        _ => return false,
+    };
+    let Some(beacon) = take_packed_guid(payload, &mut position) else {
+        return false;
+    };
+    if beacon != (0, 0) {
+        return false;
+    }
+
+    let Some(counts) = payload.get(position..position.saturating_add(10)) else {
+        return false;
+    };
+    if read_msb_bits(counts, 0, 16) != Some(1)
+        || read_msb_bits(counts, 16, 16) != Some(0)
+        || read_msb_bits(counts, 32, 16) != Some(0)
+        || read_msb_bits(counts, 48, 9) != Some(0)
+        || read_msb_bits(counts, 57, 1) != Some(0)
+        || read_msb_bits(counts, 58, 16) != Some(0)
+        || read_msb_bits(counts, 74, 1) != Some(0)
+        || read_msb_bits(counts, 75, 1) != Some(0)
+    {
+        return false;
+    }
+    position += 10;
+
+    let Some(target_header) = payload.get(position..position.saturating_add(5)) else {
+        return false;
+    };
+    if read_msb_bits(target_header, 0, 28) != Some(0x2)
+        || read_msb_bits(target_header, 28, 4) != Some(0)
+        || read_msb_bits(target_header, 32, 7) != Some(0)
+    {
+        return false;
+    }
+    position += 5;
+    let Some(target) = take_packed_guid(payload, &mut position) else {
+        return false;
+    };
+    let Some(item) = take_packed_guid(payload, &mut position) else {
+        return false;
+    };
+    let Some(hit_target) = take_packed_guid(payload, &mut position) else {
+        return false;
+    };
+    target == (expected_player_low, expected_player_high) && hit_target == target && item == (0, 0)
+}
+
+fn player_bound_matches(
+    payload: &[u8],
+    expected_low: u64,
+    expected_high: u64,
+    expected_area_id: u32,
+) -> bool {
+    let Some((consumed, low, high)) = parse_packed_guid(payload) else {
+        return false;
+    };
+    payload
+        .get(consumed..consumed + 4)
+        .and_then(|bytes| bytes.try_into().ok())
+        .map(u32::from_le_bytes)
+        == Some(expected_area_id)
+        && low == expected_low
+        && high == expected_high
+        && payload.len() == consumed + 4
+}
+
 fn build_packed_guid(low: u64, high: u64) -> Vec<u8> {
     let (low_mask, low_bytes) = pack_u64(low);
     let (high_mask, high_bytes) = pack_u64(high);
@@ -5284,6 +6274,69 @@ fn build_packed_guid(low: u64, high: u64) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pack_msb_fields(fields: &[(u32, usize)]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut current = 0u8;
+        let mut used = 0usize;
+        for &(value, width) in fields {
+            for bit in (0..width).rev() {
+                current |= (((value >> bit) & 1) as u8) << (7 - used);
+                used += 1;
+                if used == 8 {
+                    bytes.push(current);
+                    current = 0;
+                    used = 0;
+                }
+            }
+        }
+        if used != 0 {
+            bytes.push(current);
+        }
+        bytes
+    }
+
+    fn bind_spell_go_fixture(
+        caster_low: u64,
+        caster_high: u64,
+        player_low: u64,
+        player_high: u64,
+    ) -> Vec<u8> {
+        let mut payload = Vec::new();
+        payload.extend(build_packed_guid(caster_low, caster_high));
+        payload.extend(build_packed_guid(caster_low, caster_high));
+        payload.extend(build_packed_guid(1, 0));
+        payload.extend(build_packed_guid(1, 0));
+        payload.extend_from_slice(&3286u32.to_le_bytes());
+        payload.extend_from_slice(&0u32.to_le_bytes());
+        payload.extend_from_slice(&0x0004_0101u32.to_le_bytes());
+        payload.extend_from_slice(&0u32.to_le_bytes());
+        payload.extend_from_slice(&1234u32.to_le_bytes());
+        payload.extend_from_slice(&0i32.to_le_bytes());
+        payload.extend_from_slice(&0f32.to_le_bytes());
+        payload.push(0);
+        payload.extend_from_slice(&0u32.to_le_bytes());
+        payload.extend_from_slice(&0u32.to_le_bytes());
+        payload.extend_from_slice(&0u32.to_le_bytes());
+        payload.push(0);
+        payload.extend(build_packed_guid(0, 0));
+        payload.extend(pack_msb_fields(&[
+            (1, 16),
+            (0, 16),
+            (0, 16),
+            (0, 9),
+            (0, 1),
+            (0, 16),
+            (0, 1),
+            (0, 1),
+        ]));
+        payload.extend(pack_msb_fields(&[(0x2, 28), (0, 4), (0, 7)]));
+        payload.extend(build_packed_guid(player_low, player_high));
+        payload.extend(build_packed_guid(0, 0));
+        payload.extend(build_packed_guid(player_low, player_high));
+        payload.push(0);
+        payload
+    }
 
     #[test]
     fn auto_bank_payload_uses_cpp_inv_update_then_source_position() {
@@ -5401,6 +6454,95 @@ mod tests {
         assert_eq!((high >> 42) & 0x1FFF, 0);
         assert_eq!((high >> 29) & 0x1FFF, 571);
         assert_eq!((high >> 6) & 0x7F_FFFF, 15_513);
+    }
+
+    #[test]
+    fn homebind_smoke_discovers_loaded_creature_guid_from_update_object() {
+        let (low, high) = create_creature_guid_raw(1, 12_196, 733);
+        let mut payload = vec![0, 0, 0, 0, 1, 0, 0, 0];
+        payload.push(1);
+        payload.extend(build_packed_guid(low, high));
+        payload.push(5);
+
+        assert_eq!(
+            find_creature_guid_in_update_object(&payload, 1, 12_196),
+            Some((low, high))
+        );
+        assert_eq!(
+            find_creature_guid_in_update_object(&payload, 1, 12_197),
+            None
+        );
+    }
+
+    #[test]
+    fn homebind_smoke_decodes_complete_bind_point_update() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&1.25f32.to_le_bytes());
+        payload.extend_from_slice(&(-2.5f32).to_le_bytes());
+        payload.extend_from_slice(&3.75f32.to_le_bytes());
+        payload.extend_from_slice(&571i32.to_le_bytes());
+        payload.extend_from_slice(&4395i32.to_le_bytes());
+
+        assert_eq!(
+            parse_bind_point_update(&payload, 4.5),
+            Some(HomebindRowSnapshot {
+                map_id: 571,
+                zone_id: 4395,
+                x: 1.25,
+                y: -2.5,
+                z: 3.75,
+                orientation: 4.5,
+            })
+        );
+        assert_eq!(parse_bind_point_update(&payload[..19], 4.5), None);
+    }
+
+    #[test]
+    fn homebind_smoke_validates_exact_player_bound_payload() {
+        let (low, high) = create_creature_guid_raw(1, 12_196, 733);
+        let mut payload = build_packed_guid(low, high);
+        payload.extend_from_slice(&3430u32.to_le_bytes());
+
+        assert!(player_bound_matches(&payload, low, high, 3430));
+        assert!(!player_bound_matches(&payload, low, high, 3431));
+        assert!(!player_bound_matches(&payload, low + 1, high, 3430));
+
+        payload.push(0);
+        assert!(!player_bound_matches(&payload, low, high, 3430));
+    }
+
+    #[test]
+    fn homebind_smoke_requires_exact_bind_spell_go() {
+        let (caster_low, caster_high) = create_creature_guid_raw(1, 12_196, 733);
+        let player_low = 99;
+        let player_high = (2u64 << 58) | (1u64 << 42);
+        let mut payload = bind_spell_go_fixture(caster_low, caster_high, player_low, player_high);
+
+        assert!(spell_go_matches_bind(
+            &payload,
+            caster_low,
+            caster_high,
+            player_low,
+            player_high,
+        ));
+        assert!(!spell_go_matches_bind(
+            &payload,
+            caster_low + 1,
+            caster_high,
+            player_low,
+            player_high,
+        ));
+
+        let spell_offset = 2 * build_packed_guid(caster_low, caster_high).len()
+            + 2 * build_packed_guid(1, 0).len();
+        payload[spell_offset..spell_offset + 4].copy_from_slice(&1u32.to_le_bytes());
+        assert!(!spell_go_matches_bind(
+            &payload,
+            caster_low,
+            caster_high,
+            player_low,
+            player_high,
+        ));
     }
 }
 

--- a/tools/wow-test-bot/src/main.rs
+++ b/tools/wow-test-bot/src/main.rs
@@ -3632,10 +3632,9 @@ async fn run_homebind_smoke_phase(
         let expected_homebind = bind_packet_homebind
             .ok_or_else(|| anyhow!("BindPointUpdate payload could not be decoded"))?;
         let bot_for_db = bot.clone();
+        let persistence_timeout = Duration::from_secs(options.timeout_secs.clamp(1, 10));
         result.homebind_db_persisted = tokio::task::spawn_blocking(move || {
-            Ok::<_, anyhow::Error>(
-                load_homebind_row(&bot_for_db)?.as_ref() == Some(&expected_homebind),
-            )
+            wait_for_homebind_row(&bot_for_db, &expected_homebind, persistence_timeout)
         })
         .await
         .map_err(|e| anyhow!("Homebind DB verification worker join failed: {e}"))??;
@@ -5293,6 +5292,23 @@ fn load_homebind_row(bot: &config::BotConfig) -> Result<Option<HomebindRowSnapsh
             orientation,
         },
     ))
+}
+
+fn wait_for_homebind_row(
+    bot: &config::BotConfig,
+    expected: &HomebindRowSnapshot,
+    timeout: Duration,
+) -> Result<bool> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if load_homebind_row(bot)?.as_ref() == Some(expected) {
+            return Ok(true);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
 }
 
 fn cleanup_homebind_smoke_fixture(


### PR DESCRIPTION
Closes #44

## Summary

- Loads `character_homebind` into the represented player state during login and preserves it across relog.
- Routes innkeeper activation through the triggered creature spell pipeline (`3286`), persists the new bind, and preserves the C++ packet order and socket topology.
- Resolves `TARGET_DEST_HOME` before `SMSG_SPELL_GO`, including per-effect destination snapshots, effective-caster semantics, instance-aware canonical/legacy lookup, and vehicle/transport-relative destinations.
- Adds a reproducible `--homebind-smoke` bot flow with DB and relog verification plus unconditional cleanup.

## Validation

- `./tools/pr-preflight.sh full origin/3.4.3`
  - format and core checks/builds clean
  - `wow-data`: 568 passed
  - `wow-world`: 2778 passed
  - committed capture-diff gate clean
  - local Codex review: CLEAN
- Release runtime QA on the current HEAD with `WOW_BOT_HOMEBIND_SMOKE=1`:
  - innkeeper entry `12196`, spawn `271100`, runtime GUID low `143`
  - instance socket: `SMSG_SPELL_GO` (`0x2C36`) and `SMSG_BIND_POINT_UPDATE` (`0x257D`)
  - realm socket: `SMSG_PLAYER_BOUND` (`0x2FF8`) and `SMSG_GOSSIP_COMPLETE` (`0x2A97`)
  - exact `character_homebind` row persisted and verified again after relog
  - bot cleanup restored the prior character position and homebind

The stable world-server binary was restored after runtime QA and is listening on ports 8085/8086.
