### PR TITLE
[BUILD] Pin Rust MSRV to 1.88 and harden CI

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -15,10 +15,15 @@ permissions:
   issues: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codex-review-verdict:
     name: Codex reviewer verdict
     runs-on: ubuntu-24.04
+    timeout-minutes: 35
     steps:
       - name: Require clean Codex review on current HEAD
         env:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -8,10 +8,15 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   label:
     name: Label changed areas
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - name: Label PR
         uses: actions/labeler@v5

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -7,7 +7,16 @@ on:
   push:
     branches:
       - "3.4.3"
+  schedule:
+    - cron: "0 6 * * 1"
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -17,6 +26,7 @@ jobs:
   fmt:
     name: Format
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,11 +37,14 @@ jobs:
           components: rustfmt
 
       - name: Check formatting
-        run: cargo fmt --all --check
+        run: |
+          cargo fmt --all --check
+          cargo fmt --manifest-path tools/wow-test-bot/Cargo.toml -- --check
 
   check:
     name: Check core crates
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,19 +57,23 @@ jobs:
 
       - name: Install protoc
         run: |
-          curl -sSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+          curl --fail --show-error --location --retry 3 --retry-all-errors \
+            -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
           python3 -m zipfile -e /tmp/protoc.zip "$HOME/.local"
           chmod +x "$HOME/.local/bin/protoc"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Cargo check
         run: |
-          cargo check --locked -p wow-data -p wow-database -p wow-network -p wow-world -p world-server
+          cargo check --locked -p wow-data -p wow-database -p wow-network -p wow-world -p bnet-server -p world-server
           cargo check --locked --manifest-path tools/wow-test-bot/Cargo.toml
+          cargo build --locked -p bnet-server -p world-server
 
   tests:
     name: Focused library tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,7 +86,9 @@ jobs:
 
       - name: Install protoc
         run: |
-          curl -sSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+          curl --fail --show-error --location --retry 3 --retry-all-errors \
+            -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
           python3 -m zipfile -e /tmp/protoc.zip "$HOME/.local"
           chmod +x "$HOME/.local/bin/protoc"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -78,4 +97,38 @@ jobs:
         run: |
           cargo test --locked -p wow-data --lib
           cargo test --locked -p wow-packet --lib
+          cargo test --locked -p wow-map --lib
           cargo test --locked -p wow-world --lib
+
+  latest-stable:
+    name: Latest stable compatibility
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install latest stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: latest-stable
+
+      - name: Install protoc
+        run: |
+          curl --fail --show-error --location --retry 3 --retry-all-errors \
+            -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+          python3 -m zipfile -e /tmp/protoc.zip "$HOME/.local"
+          chmod +x "$HOME/.local/bin/protoc"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Check and link server binaries on latest stable
+        run: |
+          cargo +stable check --locked -p bnet-server -p world-server
+          cargo +stable build --locked -p bnet-server -p world-server

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
         with:
           components: rustfmt
 
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -50,7 +50,9 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Cargo check
-        run: cargo check -p wow-data -p wow-database -p wow-network -p wow-world -p world-server
+        run: |
+          cargo check --locked -p wow-data -p wow-database -p wow-network -p wow-world -p world-server
+          cargo check --locked --manifest-path tools/wow-test-bot/Cargo.toml
 
   tests:
     name: Focused library tests
@@ -60,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -74,6 +76,6 @@ jobs:
 
       - name: Run packet/data/world tests
         run: |
-          cargo test -p wow-data --lib
-          cargo test -p wow-packet --lib
-          cargo test -p wow-world --lib
+          cargo test --locked -p wow-data --lib
+          cargo test --locked -p wow-packet --lib
+          cargo test --locked -p wow-world --lib

--- a/.github/workflows/wow-database-live.yml
+++ b/.github/workflows/wow-database-live.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/wow-database-live.yml"
+      - "rust-toolchain.toml"
       - "Cargo.toml"
       - "Cargo.lock"
       - "crates/wow-database/**"
@@ -12,6 +13,7 @@ on:
       - "3.4.3"
     paths:
       - ".github/workflows/wow-database-live.yml"
+      - "rust-toolchain.toml"
       - "Cargo.toml"
       - "Cargo.lock"
       - "crates/wow-database/**"
@@ -40,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
 
       - name: Install MySQL-compatible client
         run: |
@@ -64,4 +66,4 @@ jobs:
           RUSTYCORE_DB_IT_USER: root
           RUSTYCORE_DB_IT_PASS: root
         run: |
-          cargo test -p wow-database live_mariadb_populate_and_update_records_updates_like_cpp -- --ignored --nocapture
+          cargo test --locked -p wow-database live_mariadb_populate_and_update_records_updates_like_cpp -- --ignored --nocapture

--- a/.github/workflows/wow-database-live.yml
+++ b/.github/workflows/wow-database-live.yml
@@ -2,6 +2,8 @@ name: wow-database live MariaDB
 
 on:
   pull_request:
+    branches:
+      - "3.4.3"
     paths:
       - ".github/workflows/wow-database-live.yml"
       - "rust-toolchain.toml"
@@ -19,10 +21,18 @@ on:
       - "crates/wow-database/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   live-db-updater:
     name: DbUpdater populate/update against MariaDB 10.6
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     services:
       mariadb:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ RustyCore is a Rust port of a TrinityCore-derived World of Warcraft Wrath/Cata-c
   is feature branches → PR into `3.4.3`; releases are tags on `3.4.3`.
 - `main` is retained as an optional stable pointer (ff-advanced at release checkpoints); it is no
   longer the default and not used for day-to-day work. A pre-rebrand backup is `backup/pre-3.4.3-rebrand`.
-- Rust toolchain: Rust 1.85, edition 2024.
+- Rust toolchain: Rust 1.88, edition 2024.
 - `protoc`: `/home/cdmonio/.local/protoc/bin/protoc`
 
 Do not trust existing Rust, old AI summaries, or migration docs as correctness proof. Always contrast behavior against the C++ source before implementing or approving a change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ exclude = [
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/user/rustycore"
 

--- a/MIGRATION_STATUS.md
+++ b/MIGRATION_STATUS.md
@@ -4,7 +4,7 @@
 
 **Proyecto**: rustycore — Migración de RustyCore (WoW 3.4.3.54261) de C# a Rust
 **Dominio**: wowchad.work.gd
-**Rust Version**: 1.85 (edition 2024)
+**Rust Version**: 1.88 (edition 2024)
 **Ubicación**: `/home/server/woltk-server-core/rustycore/`
 **Referencia C#**: `/home/server/woltk-server-core/Source/`
 **Estado General**: ~35% — infraestructura lista, jugador en mundo, combat/movement/loot funcional

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **WoW Wrath of the Lich King Classic (3.4.3.54261) server emulator written in Rust.**
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Rust](https://img.shields.io/badge/Rust-1.85%2B-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/Rust-1.88%2B-orange.svg)](https://www.rust-lang.org)
 [![Target](https://img.shields.io/badge/WotLK%20Classic-3.4.3.54261-blueviolet.svg)](#)
 [![Discord](https://img.shields.io/badge/Discord-Join%20the%20community-5865F2.svg)](https://discord.gg/mH6ACpGPb2)
 
@@ -72,7 +72,7 @@ That split is a migration bridge, not the final design.
 
 ## Tech Stack
 
-- **Rust 1.85+** — edition 2024
+- **Rust 1.88+** — edition 2024
 - **Tokio** — async runtime and networking
 - **Axum** — Battle.net REST API
 - **SQLx + MariaDB** — login/auth, characters, world, and hotfix databases
@@ -117,7 +117,7 @@ MIGRATION_STATUS.md  Older high-level migration status
 
 ## Requirements
 
-- Rust `1.85+`
+- Rust `1.88+`
 - MariaDB `10.6+`
 - `protoc` for protobuf-dependent crates; set `PROTOC` if it is not available on `PATH`
 - A WotLK Classic `3.4.3.54261` client for manual testing

--- a/docs/migration/migration-test-strategy.md
+++ b/docs/migration/migration-test-strategy.md
@@ -194,7 +194,7 @@ Complexity: **L** (<1h), **M** (1-4h), **H** (4-12h), **XL** (>12h, split).
 - [ ] **#TEST.12** Add an `insta`-based snapshot test for chat-message formatting and for log output formatting (covered in `logging.md` too). (M)
 - [ ] **#TEST.13** Backfill regression tests for every commit matching `^fix:` in `git log`. Initial sweep produces a count; one named `regression_<short-sha>` test per. (H)
 - [ ] **#TEST.14** Document a "vector capture playbook" — how to produce a new golden vector from C++: which logger to enable, which file to read, how to convert. Lives at `docs/migration/vector-capture-playbook.md`. (M)
-- [ ] **#TEST.15** Add CI matrix (`stable`, `1.85.0` as MSRV per workspace `rust-version`) running `cargo test --workspace` plus an opt-in `--features slow-tests` job. (M)
+- [ ] **#TEST.15** Add CI matrix (`stable`, `1.88.0` as MSRV per workspace `rust-version`) running `cargo test --workspace` plus an opt-in `--features slow-tests` job. (M)
 - [ ] **#TEST.16** Add a "test-debt watch" job: on each PR, fail if `cargo test --workspace --no-run` count drops below the committed baseline (catches accidentally-deleted tests). (L)
 
 ---

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.88.0"
+profile = "minimal"
+components = ["rustfmt", "clippy"]

--- a/tools/wow-test-bot/Cargo.toml
+++ b/tools/wow-test-bot/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wow-test-bot"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.88"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/tools/wow-test-bot/src/main.rs
+++ b/tools/wow-test-bot/src/main.rs
@@ -3076,9 +3076,7 @@ fn resolve_quest_runtime_counter(
 }
 
 fn create_creature_guid_raw(map_id: u16, entry: u32, counter: u64) -> (u64, u64) {
-    let high = (8u64 << 58)
-        | ((map_id as u64 & 0x1FFF) << 29)
-        | ((entry as u64 & 0x7F_FFFF) << 6);
+    let high = (8u64 << 58) | ((map_id as u64 & 0x1FFF) << 29) | ((entry as u64 & 0x7F_FFFF) << 6);
     let low = counter & 0xFF_FFFF_FFFF;
     (low, high)
 }


### PR DESCRIPTION
Closes #97

## Why

The workspace declared Rust 1.85 while the current Rust 2024 codebase uses let-chains (`&& let`) across multiple crates. Rust 1.85 fails before tests with `E0658`; let-chains are stable starting in Rust 1.88.

The CI audit also found that map tests were omitted, server binaries were never linked, stale workflow runs were not cancelled, and only the pinned MSRV was exercised.

## What changed

- Raise the workspace and integrated `wow-test-bot` MSRV to Rust 1.88.
- Add `rust-toolchain.toml` pinned to 1.88.0 with rustfmt and clippy.
- Pin required Rust CI jobs to 1.88.0 and run Cargo with `--locked`.
- Compile-check and format-check the integrated `wow-test-bot`.
- Add `wow-map` library tests and link both `bnet-server` and `world-server` in the required core check.
- Add explicit read-only workflow permissions, per-PR concurrency cancellation, and job timeouts.
- Make protoc downloads fail fast and retry transient errors.
- Add a weekly/manual latest-stable compatibility check without changing protected check names.
- Pin runner versions consistently and update maintained toolchain documentation.

No gameplay or protocol behavior changes.

## Validation

- `cargo fmt --all --check`
- `cargo fmt --manifest-path tools/wow-test-bot/Cargo.toml -- --check`
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test --locked -p wow-world --lib` — 2684 passed
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test --locked -p wow-map --lib` — 679 passed, 1 ignored (real DataDir)
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check --locked -p wow-data -p wow-database -p wow-network -p wow-world -p bnet-server -p world-server`
- `cargo check --locked --manifest-path tools/wow-test-bot/Cargo.toml`
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo build --locked -p bnet-server -p world-server`
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo build --locked -p world-server --release`
- YAML parse and `git diff --check`