### PR TITLE
[14] Preserve compression stream across socket split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,6 +3313,7 @@ dependencies = [
  "bytes",
  "dashmap",
  "ed25519-dalek",
+ "flate2",
  "flume",
  "num-traits",
  "rand",

--- a/crates/wow-network/Cargo.toml
+++ b/crates/wow-network/Cargo.toml
@@ -24,3 +24,6 @@ wow-data = { workspace = true }
 wow-database = { workspace = true }
 wow-instances = { workspace = true }
 wow-loot = { workspace = true }
+
+[dev-dependencies]
+flate2 = { workspace = true }

--- a/crates/wow-network/src/world_socket.rs
+++ b/crates/wow-network/src/world_socket.rs
@@ -1143,7 +1143,10 @@ impl WorldSocket {
             send_write_fence_like_cpp: self.send_write_fence_like_cpp,
             addr: self.addr,
             connection_id: self.connection_id,
-            compressor: compression::PacketCompressor::new(),
+            // C++ owns one z_stream for the complete physical WorldSocket
+            // lifetime. Moving the existing stream preserves any direct-send
+            // history accumulated before the async read/write ownership split.
+            compressor: self.compressor,
         };
 
         info!(
@@ -1543,6 +1546,71 @@ fn should_compress_server_packet_like_cpp(data: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn split_for_io_preserves_socket_compressor_history_like_cpp() {
+        use flate2::{Decompress, FlushDecompress};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let listener_addr = listener.local_addr().unwrap();
+        let connect = TcpStream::connect(listener_addr);
+        let (accepted, connected) = tokio::join!(listener.accept(), connect);
+        let (server_stream, client_addr) = accepted.unwrap();
+        let client_stream = connected.unwrap();
+
+        let mut socket = WorldSocket::new(server_stream, client_addr);
+        let first_opcode = 0x25E0_u16.to_le_bytes();
+        let first_payload = vec![0xA5; compression::COMPRESSION_THRESHOLD + 257];
+        let first = socket
+            .compressor
+            .compress_packet(&first_opcode, &first_payload);
+        let second_opcode = 0x2724_u16.to_le_bytes();
+        let second_payload = vec![0xA5; compression::COMPRESSION_THRESHOLD + 513];
+
+        let mut uninterrupted = compression::PacketCompressor::new();
+        let expected_first = uninterrupted.compress_packet(&first_opcode, &first_payload);
+        let expected_second = uninterrupted.compress_packet(&second_opcode, &second_payload);
+        assert_eq!(first, expected_first);
+
+        socket.set_encrypt_key([0x42; 16]);
+        let (_packet_rx, send_tx, _write_fence) = socket.create_session_channels();
+        let (_reader, mut writer) = socket.split_for_io(send_tx);
+
+        let second = writer
+            .compressor
+            .compress_packet(&second_opcode, &second_payload);
+        assert_eq!(
+            second, expected_second,
+            "split_for_io must transfer the socket's existing deflate stream"
+        );
+
+        let mut inflater = Decompress::new(false);
+        for (index, (packet, opcode, payload)) in [
+            (&first, first_opcode, &first_payload),
+            (&second, second_opcode, &second_payload),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let expected_size = i32::from_le_bytes(packet[0..4].try_into().unwrap()) as usize;
+            let mut output = vec![0_u8; expected_size + 256];
+            let base_out = inflater.total_out() as usize;
+            inflater
+                .decompress(&packet[12..], &mut output, FlushDecompress::Sync)
+                .unwrap_or_else(|error| {
+                    panic!("packet {index} failed persistent inflate: {error}")
+                });
+            let produced = inflater.total_out() as usize - base_out;
+            output.truncate(produced);
+
+            assert_eq!(produced, expected_size, "packet {index} decoded size");
+            assert_eq!(&output[..2], &opcode, "packet {index} decoded opcode");
+            assert_eq!(&output[2..], payload, "packet {index} decoded payload");
+        }
+
+        drop(client_stream);
+    }
 
     #[tokio::test]
     async fn write_fence_acknowledges_only_after_prior_fifo_packet_like_cpp() {

--- a/crates/wow-packet/src/compression.rs
+++ b/crates/wow-packet/src/compression.rs
@@ -91,16 +91,6 @@ impl PacketCompressor {
 /// [CompressedData: ...]           — deflated bytes (raw deflate, Z_SYNC_FLUSH)
 /// ```
 ///
-/// Returns the compressed data (to be sent with `ServerOpcodes::CompressedPacket`).
-///
-/// **Note:** This creates a fresh compressor per call. For production use,
-/// prefer [`PacketCompressor`] which maintains state across packets
-/// (required for the WoW client's persistent inflate stream).
-pub fn compress_packet(opcode_bytes: &[u8; 2], payload: &[u8]) -> Vec<u8> {
-    let mut compressor = Compress::new(Compression::fast(), false);
-    compress_packet_impl(&mut compressor, opcode_bytes, payload)
-}
-
 /// Shared implementation: compress using an existing deflate stream.
 fn compress_packet_impl(
     compressor: &mut Compress,
@@ -242,6 +232,10 @@ pub fn decompress_packet(data: &[u8]) -> Result<Vec<u8>, PacketError> {
 mod tests {
     use super::*;
 
+    fn compress_single_packet(opcode: &[u8; 2], payload: &[u8]) -> Vec<u8> {
+        PacketCompressor::new().compress_packet(opcode, payload)
+    }
+
     #[test]
     fn adler32_empty() {
         let result = adler32(&[]);
@@ -274,7 +268,7 @@ mod tests {
         let opcode: [u8; 2] = [0x48, 0x30]; // AuthChallenge opcode LE
         let payload = vec![0xAA; 2048]; // Larger than threshold
 
-        let compressed = compress_packet(&opcode, &payload);
+        let compressed = compress_single_packet(&opcode, &payload);
         let decompressed = decompress_packet(&compressed).unwrap();
 
         // Decompressed = opcode + payload
@@ -287,7 +281,7 @@ mod tests {
         let opcode: [u8; 2] = [0x01, 0x00];
         let payload = b"test";
 
-        let compressed = compress_packet(&opcode, payload);
+        let compressed = compress_single_packet(&opcode, payload);
         let decompressed = decompress_packet(&compressed).unwrap();
 
         assert_eq!(&decompressed[..2], &opcode);
@@ -299,7 +293,7 @@ mod tests {
         let opcode: [u8; 2] = [0x01, 0x00];
         let payload = b"test data here!";
 
-        let mut compressed = compress_packet(&opcode, payload);
+        let mut compressed = compress_single_packet(&opcode, payload);
         // Corrupt the compressed adler32 (bytes 8..12)
         compressed[8] ^= 0xFF;
 
@@ -317,7 +311,7 @@ mod tests {
         let opcode: [u8; 2] = [0x83, 0x25]; // EnumCharactersResult
         let payload = vec![0u8; 2048];
 
-        let compressed = compress_packet(&opcode, &payload);
+        let compressed = compress_single_packet(&opcode, &payload);
         // Skip the 12-byte header to get the raw deflated data
         let deflated = &compressed[12..];
 
@@ -342,7 +336,7 @@ mod tests {
         let opcode: [u8; 2] = [0x83, 0x25];
         let payload = vec![0u8; 3600];
 
-        let compressed = compress_packet(&opcode, &payload);
+        let compressed = compress_single_packet(&opcode, &payload);
         let decompressed = decompress_packet(&compressed).unwrap();
 
         assert_eq!(decompressed.len(), 3602); // opcode(2) + payload(3600)

--- a/crates/wow-packet/src/lib.rs
+++ b/crates/wow-packet/src/lib.rs
@@ -16,7 +16,7 @@ pub mod header;
 pub mod packets;
 pub mod world_packet;
 
-pub use compression::{compress_packet, decompress_packet};
+pub use compression::decompress_packet;
 pub use header::PacketHeader;
 pub use world_packet::{PacketError, WorldPacket};
 

--- a/docs/migration/PORT_PLAN.md
+++ b/docs/migration/PORT_PLAN.md
@@ -84,7 +84,9 @@ intent, no mutation — see STATE.md §0). Almost every item below is "convert r
 - [x] **M1.1** Fix **#7** (CUF profiles → bags don't open): match C++'s post-add
   `InitWorldStates → LoadCufProfiles → AuraUpdate → PhaseShiftChange` order and pin a live,
   non-empty C++/Rust capture pair.
-- [ ] **M1.2** Restore real compression **#8** (one persistent deflate stream per socket; re-enable threshold).
+- [x] **M1.2** Restore real compression **#8**: the `0x400` C++ threshold is active,
+  one deflate stream survives the direct-send → async-writer ownership split, and live login QA
+  decoded four consecutive large packets through one persistent inflater.
 - [ ] **M1.3** Close the 33 login-burst divergences (**#9–#12**, `world-load-audit.md`):
   proficiency set, AccountDataTimes/TutorialFlags resend, ordering, FeatureSystemStatus, MOTD, etc.
 - [ ] **M1.4** Fix the CREATE-block UpdateField VALUE gaps (AuraState, DK DisplayPower,

--- a/docs/migration/STATE.md
+++ b/docs/migration/STATE.md
@@ -1,6 +1,6 @@
 # RustyCore — Honest Current State (single source of truth)
 
-**Date:** 2026-07-23 · **Base:** `3.4.3` @ `d740f638` plus the local issue #7 branch.
+**Date:** 2026-07-23 · **Base:** `3.4.3` @ `a39d4f6c` plus the local issue #8 branch.
 
 This document replaces the drifting status snapshots in `_INDEX.md` (2026-05-01, "5–15%"),
 the `MIGRATION_ROADMAP.md` §3 inherited table (which tells you not to trust it), and the
@@ -167,16 +167,22 @@ refresh · Weather · Warden · Calendar · Petitions · Pet/Totem AI. Empty cra
 
 ---
 
-## 3. Known live bugs blocking "playable" (open after issue #7)
+## 3. Known live bugs blocking "playable" (open after issues #7 and #8)
 
 Issue #7's CUF login crash is fixed on its branch: Rust now matches the exact C++
 post-add order, and a paired live capture with one non-empty profile pins the
 four-packet sequence. The CUF and final phase-shift packets are byte-identical;
 the broader M1 exit and manual-client UI validation remain open.
 
+Issue #8 closes the compression-stream lifetime defect: the active C++ `0x400`
+threshold now has one persistent deflate owner for the complete physical socket,
+including across `WorldSocket::split_for_io`. Installed login QA decoded four
+successive compressed packets through one persistent inflater before completing
+the stand-state round trip. Original-client/manual UI validation remains part of
+the broader M1 exit.
+
 | # | Bug | Effect | Status |
 |---|---|---|---|
-| #8 | persistent-deflate desync vs C++ on large SMSG | spells/UpdateObject empty | worked around (compression off, `fa86e19e`) |
 | #13 | `CMSG_GAME_OBJ_USE` doesn't cast GO use-spell | **portals do nothing** | open |
 | #9–#12 | 33 login-burst divergences (`world-load-audit.md`) | ordering/value parity | mostly open |
 

--- a/docs/migration/current-session-handoff.md
+++ b/docs/migration/current-session-handoff.md
@@ -1,3 +1,20 @@
+- `#NEXT.R8.ENTITIES.1209` — issue #8 closes the remaining persistent-compression lifetime
+  gap against C++ `WorldSocket.cpp:178-188,538-609` and `WorldSocket.h:89,139,172`.
+  The earlier `b1bde801` change had already restored C++'s payload-only `> 0x400` threshold
+  and persistent compressors inside both Rust send phases, but `split_for_io` still discarded
+  the physical socket's existing deflate state and constructed a new writer stream. Rust now
+  moves the same `PacketCompressor` into `SocketWriter`, and the fresh-per-call public
+  compression helper is removed so production callers must own persistent state. The regression
+  first proved the old second block differed from an uninterrupted stream, then pins byte-exact
+  history preservation across the async ownership split and decodes both packets through one
+  inflater. Full `wow-network` (104/0) and `wow-packet` (712/0) suites pass. Installed QA on
+  commit `09cc645a` used a bot with one inflater per physical socket and decoded four consecutive
+  compressed instance packets: action buttons `1443 -> 46`, factions `6127 -> 207`, and
+  `UpdateObject` packets `18156 -> 736` and `52913 -> 5171`; auth, enumeration, verified login,
+  Sit/Stand confirmations, capture finalization, and stable-runtime restoration all passed.
+  This proves the default C++ level-1 stream lifecycle and large-login path, not configurable
+  compression levels 2–9 or original-client/manual UI validation.
+
 - `#NEXT.R8.ENTITIES.1208` — issue #7 fixes the CUF-profile login crash by matching C++
   `Player::SendInitialPacketsAfterAddToMap` exactly:
   `InitWorldStates -> LoadCufProfiles -> AuraUpdate -> OnMapChange PhaseShiftChange`.

--- a/docs/world-entry-implementation.md
+++ b/docs/world-entry-implementation.md
@@ -567,7 +567,7 @@ the original packet data.
 ### Compressed Packet Format
 
 ```
-[u16]  CompressedPacket opcode    -- 0x0446 (part of encrypted data)
+[u16]  CompressedPacket opcode    -- 0x3052 (part of encrypted data)
 [i32]  UncompressedSize           -- original opcode(2) + payload size
 [u32]  UncompressedAdler32        -- custom Adler32 of original data
 [u32]  CompressedAdler32          -- custom Adler32 of compressed data
@@ -576,7 +576,7 @@ the original packet data.
 
 ### Persistent Deflate Stream
 
-C# TrinityCore uses a single `z_stream` per socket, initialized once with
+C++ TrinityCore uses a single `z_stream` per socket, initialized once with
 `deflateInit2(stream, 1, 8, -15, 8, 0)` and reused for all packets. The WoW client has
 a matching persistent inflate stream. Each compressed packet must use the same deflate
 state:
@@ -592,7 +592,9 @@ sync marker `00 00 FF FF` to the compressed data. The client's persistent inflat
 stream processes this marker to know where each packet ends.
 
 **Creating a fresh compressor per packet will NOT work** -- the client's decompressor
-carries state across packets, so the server's compressor must too.
+carries state across packets, so the server's compressor must too. Rust moves the
+physical socket's existing `PacketCompressor` into `SocketWriter` during
+`split_for_io`; the async ownership split does not reset the stream.
 
 ### Custom Adler32
 
@@ -611,6 +613,10 @@ During a typical login, these packets exceed the threshold and get compressed:
 - `SMSG_UPDATE_ACTION_BUTTONS` (~1443 bytes: 2 opcode + 1 bit + flush + 180*8)
 - `SMSG_INITIALIZE_FACTIONS` (~6127 bytes: 1000 factions)
 - `SMSG_UPDATE_OBJECT` (~15624 bytes for self-view ActivePlayer)
+
+Issue-#8 installed QA decoded four consecutive compressed packets through one
+persistent bot inflater on the same instance socket before completing login and a
+Sit/Stand round trip: `1443→46`, `6127→207`, `18156→736`, and `52913→5171`.
 
 ---
 


### PR DESCRIPTION
Closes #8

## Summary
- preserve the physical socket's existing `PacketCompressor` when ownership moves into `SocketWriter`
- remove the public fresh-per-call compression helper so production callers keep persistent deflate state
- add a regression that pins byte-exact stream history across `split_for_io`
- record live multi-packet compression QA and correct the documented compressed opcode/C++ source

## C++ parity
C++ owns one `_compressionStream` per physical `WorldSocket`, initializes it once, and reuses it for the socket lifetime (`WorldSocket.cpp:178-188,538-609`). Rust already had the C++ `0x400` payload threshold, but `split_for_io` silently replaced the compressor and reset its history.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-network --lib` — 104 passed
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-packet --lib` — 712 passed
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-world --lib` — 3061 passed
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p world-server`
- installed runtime QA decoded four consecutive compressed packets through one persistent inflater (`1443→46`, `6127→207`, `18156→736`, `52913→5171`) and completed login plus Sit/Stand round trip

## Remaining boundary
Configurable compression levels 2–9 and original-client/manual UI validation remain part of the broader M1 exit.
