### PR TITLE
[ARCH.1] Add repository-scoped RustyCore architecture skills

### DIFF
--- a/.agents/skills/design-rustycore-architecture/SKILL.md
+++ b/.agents/skills/design-rustycore-architecture/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: design-rustycore-architecture
+description: Design and audit RustyCore architecture using evidence from the current Rust workspace and the legacy C++ server. Use when deciding crate or module boundaries, assigning canonical state ownership, untangling dependencies, decomposing project-wide hotspots such as session, handlers, map, player, world-server, data, packets, or QA tooling, planning runtime convergence, or creating an incremental architecture/refactor campaign. Do not use for a small behavior fix that has no structural decision; use refactor-rustycore-safely when implementing an already approved behavior-preserving restructuring.
+---
+
+# Design RustyCore Architecture
+
+Produce an evidence-backed target architecture and an incremental migration path. Optimize for
+one canonical owner per mutable state, C++-faithful behavior, narrow public APIs, directional
+dependencies, and PR-sized delivery.
+
+## Load the required context
+
+1. Read the repository `AGENTS.md` completely and follow its session kickoff.
+2. Read `docs/migration/STATE.md` and the relevant `docs/migration/PORT_PLAN.md` sections. For
+   `docs/migration/adr-runtime-tick-ownership.md`, read its context, decision, risks, and the
+   current slice sections relevant to the task; do not load its entire historical progress log
+   for a bounded decision.
+3. Read [references/decision-rules.md](references/decision-rules.md) for every architecture
+   decision.
+4. Read [references/current-architecture.md](references/current-architecture.md) for workspace-wide
+   audits or changes involving session, network, runtime, map, player, data, handlers, binaries, or
+   large-file decomposition.
+5. Locate the exact C++ owner and call path under `/home/server/woltk-trinity-legacy` before
+   assigning gameplay responsibility. Treat C++ as the behavioral oracle, not as a required Rust
+   file layout.
+
+Do not trust old migration percentages, crate names, comments, or previous summaries as proof of
+current ownership.
+
+## Architecture workflow
+
+### 1. Establish the current baseline
+
+Inspect the current branch, latest commits, workspace manifest, target crate manifests, module
+trees, public re-exports, largest production files, and internal dependency edges. Recalculate
+metrics on HEAD; never copy stale counts into a decision.
+
+Use `rg`, `rg --files`, `cargo metadata --format-version 1 --no-deps`, `cargo tree`, and focused
+source inspection. Distinguish production logic from inline tests and generated or declarative
+code.
+
+### 2. Map ownership before proposing folders
+
+For every important mutable state, record:
+
+- semantic owner in C++;
+- current Rust owner or owners;
+- all writers and readers;
+- mirrors, clones, caches, registries, and sync directions;
+- lock/task/tick owner;
+- persistence owner;
+- client-visible publication path;
+- intended canonical owner;
+- exact retirement condition for every temporary mirror.
+
+Do not propose concurrency, actors, worker pools, or new abstractions until the state owner is
+unambiguous.
+
+### 3. Diagnose the architectural defect
+
+Classify each finding as one or more of:
+
+- mixed responsibilities inside one owner;
+- duplicated authority or transitional mirror;
+- dependency inversion;
+- infrastructure leaking into domain/application logic;
+- application orchestration leaking into network or binaries;
+- overly broad public API;
+- registration or dispatch with multiple sources of truth;
+- file-size or test-layout symptom without an ownership defect;
+- intentional aggregate that is large but cohesive.
+
+Prioritize duplicated authority and incorrect dependency direction over cosmetic file splitting.
+
+### 4. Select modules, crates, ports, and tasks deliberately
+
+Apply the decision rules from the reference:
+
+- start with a private module when ownership or API is still changing;
+- promote to a crate only with a stable owner, narrow contract, downward dependencies, and useful
+  independent tests/build;
+- introduce a trait only at a real adapter boundary or when a deterministic fake provides value;
+- introduce a task/channel only when one owner must serialize state or I/O and backpressure is
+  explicit;
+- keep Tokio, sockets, SQL, DB2 loading, filesystem, and packet presentation at the edges;
+- keep simulation and rules synchronous and deterministic where practical.
+
+### 5. Define the target and dependency direction
+
+Describe:
+
+- the canonical owner of each state;
+- the allowed dependency direction;
+- the small public commands, queries, outcomes, and events at each boundary;
+- where persistence and packet conversion occur;
+- how C++ phase order and observable behavior remain preserved;
+- which legacy bridge remains temporarily and how it will disappear.
+
+Prefer a modular monolith. Do not propose microservices merely to obtain code organization.
+
+### 6. Produce an incremental migration campaign
+
+Split the work so every PR has one dominant change class:
+
+- mechanical relocation with unchanged ownership and behavior;
+- dependency-boundary change;
+- ownership migration with one source of truth;
+- intentional behavior change or proven legacy defect repair.
+
+Never combine all four. Preserve compatibility paths with temporary re-exports where useful, but
+attach a deletion condition. Require focused positive/negative tests and capture-diff for
+client-visible behavior.
+
+## Hard invariants
+
+- Preserve the accepted single tick-owner invariant and C++ `Map::Update` phase order.
+- Never add a second canonical `Player`, `Creature`, `Map`, combat relation, loot authority, or
+  persistence owner.
+- Never retain a lock across `.await` or send packets while holding a map lock.
+- Build plans or outcomes under the owner; persist and publish in the documented order outside
+  incompatible locks.
+- Keep packet handlers thin: decode, session gate, construct command, invoke use case, present
+  result.
+- Keep gameplay rules out of `wow-network`, SQL adapters, packet DTOs, and composition roots.
+- Keep public visibility narrow. Do not make internals `pub` merely to move files or test them.
+- Do not populate an empty domain crate by moving unstable code solely to satisfy the workspace
+  diagram.
+- Follow `docs/migration/STATE.md` fidelity policy for proven C++ defects. Separate a deliberate
+  correction from a behavior-preserving refactor.
+
+## Required output
+
+Lead with a verdict. Then provide:
+
+1. evidence with exact Rust and C++ anchors;
+2. current owners, mirrors, and dependency defects;
+3. target ownership and dependency direction;
+4. module-versus-crate decisions with reasons;
+5. a risk-ranked sequence of PR-sized slices;
+6. invariants and verification for each slice;
+7. explicit deferrals and bridge-retirement conditions.
+
+If implementation is requested after approval, hand the selected slice to
+`$refactor-rustycore-safely`.

--- a/.agents/skills/design-rustycore-architecture/agents/openai.yaml
+++ b/.agents/skills/design-rustycore-architecture/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Design RustyCore Architecture"
+  short_description: "Design ownership and crate boundaries safely"
+  default_prompt: "Use $design-rustycore-architecture to audit this RustyCore subsystem and propose an incremental architecture plan."

--- a/.agents/skills/design-rustycore-architecture/references/current-architecture.md
+++ b/.agents/skills/design-rustycore-architecture/references/current-architecture.md
@@ -1,0 +1,99 @@
+# Current RustyCore architecture audit guide
+
+Recalculate all metrics on the active HEAD. Use this file to find likely boundaries, not to claim
+that old counts remain exact.
+
+## Current structural reality
+
+- `wow-world` is the central application/god crate and directly knows most internal crates.
+- `WorldSession` contains session state, shared stores, represented player state, gameplay helpers,
+  runtime bridges, persistence coordination, dispatch, and extensive inline tests.
+- `wow-network::accept::SessionResources` currently carries application, database, catalog, loot,
+  instance, runtime, and configuration resources across the network boundary.
+- `wow-network::player_registry::SessionCommand` contains gameplay commands and packet payloads;
+  network therefore depends upward on game data, database, instances, and loot.
+- Legacy `wow_world::MapManager`, canonical `wow_map::MapManager`, and the global world loop coexist.
+  The accepted runtime ADR requires one tick owner and method-by-method convergence.
+- Player and creature state still have represented/session, legacy map, canonical entity/map, and
+  registry mirrors in several paths.
+- Several domain crates are nominal placeholders while their logic remains in `wow-world`,
+  handlers, map, entities, or binaries.
+
+Read `docs/migration/adr-runtime-tick-ownership.md` for the authoritative runtime sequence and
+`docs/migration/STATE.md` for the current represented-versus-live boundary.
+
+## Recalculate the workspace
+
+Use commands like:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -8
+find crates -path '*/src/*.rs' -type f -print0 | xargs -0 wc -l | sort -nr | head -40
+for d in crates/*; do
+  total=$(find "$d/src" -type f -name '*.rs' -print0 | xargs -0 cat | wc -l)
+  printf '%8d %s\n' "$total" "$d"
+done | sort -nr
+cargo metadata --format-version 1 --no-deps
+cargo tree --duplicates
+cargo tree -e features
+rg -n '^(pub )?mod |^pub use ' crates/*/src/lib.rs
+rg -n 'impl WorldSession|impl Map|impl Player' crates
+rg -n 'sqlx|PreparedStatement|Transaction|execute_or_warn' crates/wow-world/src/handlers
+```
+
+Adjust commands when generated files or test modules would distort the question.
+
+## High-priority audit surfaces
+
+Inspect these as project-wide symptoms:
+
+- `crates/wow-network/src/accept.rs`: network/application resource boundary.
+- `crates/wow-network/src/player_registry.rs` and `group_registry.rs`: application commands and
+  social state inside network.
+- `crates/wow-world/src/session.rs`: state ownership, dispatch, stores, runtime mirrors.
+- `crates/wow-world/src/handlers/misc.rs`: unrelated feature families and opcode registrations.
+- `crates/wow-world/src/handlers/character.rs`: character lifecycle mixed with inventory, bank,
+  vendor, equipment, and persistence.
+- `crates/wow-world/src/handlers/loot.rs`: packet handling, generation, authority, transactions,
+  runtime application, and tests.
+- `crates/world-server/src/main.rs`: composition root mixed with loaders, event logic, runtime
+  routing, session factory, DB writers, and shutdown.
+- `crates/world-server/src/spawn_store_loader.rs`: loading mixed with world-state and game-event
+  ownership.
+- `crates/wow-map/src/map.rs`: one legitimate aggregate with too many capabilities in one module.
+- `crates/wow-entities/src/player.rs`: one legitimate aggregate whose substates and impls need
+  private modularization.
+- `crates/wow-data/src/spell.rs`: catalog model, derivation, corrections, and loaders mixed.
+- `crates/wow-packet/src/packets/misc.rs`: unrelated protocol families.
+- `tools/wow-test-bot/src/main.rs`: CLI, protocol, fixtures, scenarios, runtime preparation, and
+  reporting mixed.
+
+Large declarative packet/update-field files or statement tables may be acceptable. Prioritize
+mixed state, I/O, rules, and ownership over raw line count.
+
+## Known dependency debts to ratchet
+
+Inspect rather than blindly preserve:
+
+- `wow-network -> wow-data, wow-database, wow-instances, wow-loot`;
+- `wow-data -> wow-database, wow-entities, wow-movement`;
+- `wow-packet -> wow-loot, wow-movement`;
+- broad `wow-world` and `world-server` dependency sets.
+
+Do not add new upward edges. Remove them one seam at a time with compatibility tests.
+
+## Recommended campaign order
+
+1. Document owners, allowed edges, mirrors, and no-growth guardrails.
+2. Decouple socket acceptance from application `SessionResources`.
+3. Introduce typed catalogs, repositories, and runtime handles; replace setter groups
+   incrementally.
+4. Split obvious feature dumping grounds mechanically without changing behavior.
+5. Extract one complete vertical use case at a time from handler to application/domain.
+6. Modularize `Map`, `Player`, binaries, packet families, and QA scenarios while retaining one
+   aggregate owner.
+7. Retire legacy/canonical mirrors method by method according to the runtime ADR.
+8. Promote stable private modules into domain crates only after dependency direction is clean.
+
+Never begin with a wholesale split of `session.rs` or a worker pool over duplicated runtime state.

--- a/.agents/skills/design-rustycore-architecture/references/current-architecture.md
+++ b/.agents/skills/design-rustycore-architecture/references/current-architecture.md
@@ -29,9 +29,9 @@ Use commands like:
 ```bash
 git status --short --branch
 git log --oneline --decorate -8
-find crates -path '*/src/*.rs' -type f -print0 | xargs -0 wc -l | sort -nr | head -40
+rg --files -0 crates -g '**/src/**/*.rs' | xargs -0r wc -l | sort -nr | head -40
 for d in crates/*; do
-  total=$(find "$d/src" -type f -name '*.rs' -print0 | xargs -0 cat | wc -l)
+  total=$(rg --files -0 "$d/src" -g '*.rs' | xargs -0r cat | wc -l)
   printf '%8d %s\n' "$total" "$d"
 done | sort -nr
 cargo metadata --format-version 1 --no-deps

--- a/.agents/skills/design-rustycore-architecture/references/decision-rules.md
+++ b/.agents/skills/design-rustycore-architecture/references/decision-rules.md
@@ -1,0 +1,152 @@
+# RustyCore architecture decision rules
+
+Use these rules as constraints, not as a substitute for inspecting the current HEAD and exact C++
+behavior.
+
+## Target dependency direction
+
+Dependencies should point inward:
+
+```text
+composition roots
+    world-server, bnet-server
+        |
+adapters
+    network, SQL/DB2 loaders, packet presentation, scripts, recast
+        |
+application
+    session lifecycle, commands, use cases, transactions, event orchestration
+        |
+runtime and domain
+    map, entities, movement, combat, spell, AI, loot, social, PvP
+        |
+foundation
+    core, constants, math, collections
+```
+
+The composition root may know concrete adapters. Domain/runtime must not know sockets, SQL rows,
+configuration files, or client packet publication.
+
+Current crates may mix these roles. Treat the diagram as a migration direction, not permission for
+a big-bang rewrite.
+
+## Canonical ownership map
+
+| Responsibility | Target owner |
+|---|---|
+| TCP/TLS, crypto, framing, socket queues | `wow-network` |
+| Packet wire DTOs and serialization | `wow-packet` |
+| Opcode adaptation and session lifecycle | `wow-world::session` / packet handlers |
+| Cross-domain use cases and transaction orchestration | `wow-world::application` |
+| Active object storage, grids, tick, respawn, visibility phases | canonical `wow-map` runtime |
+| Player, Creature, Item state and local invariants | `wow-entities` |
+| Mutable Unit combat/threat relations, timers, attackers, and current victim | `wow-entities::Unit` / `CombatSubsystem` |
+| Pure combat/threat calculations over explicit inputs | `wow-combat` after its API stabilizes |
+| Pure spell validation/effect resolution | `wow-spell` after its API stabilizes |
+| Loot generation and authority rules | `wow-loot` |
+| Immutable game catalogs | typed catalog modules in `wow-data` |
+| SQL/DB2 loading and repository implementations | adapters over `wow-database` |
+| Startup, configuration, task supervision, shutdown | `world-server` / `bnet-server` |
+| QA scenarios and reporting | `tools/wow-test-bot` scenario modules |
+
+Use C++ ownership as a semantic cross-check:
+
+- `WorldSession`: account/session, sockets, queues, time sync, login/logout, opcode adaptation.
+- `Player`: character-owned inventory, quests, skills, reputation, collections, and persistent
+  gameplay state.
+- `Unit`: mutable combat references, auras, threat lists, attackers, timers, control, and unit
+  state.
+- `Spell`: one cast's validation and effect execution.
+- `Map`: objects, grid, respawn, global tick, visibility, and update phase order.
+- `ObjectMgr` and stores: global immutable/shared data, not copies per session.
+
+Do not reproduce C++ header/source layout mechanically.
+
+Keep mutable combat/threat state in the canonical `Unit`. Let a future `wow-combat` crate compute
+deterministic policies or outcomes over explicit snapshots; do not let it become a second runtime
+owner.
+
+## Module or crate
+
+Create or retain a private module when:
+
+- ownership or API is still changing;
+- code changes with its caller;
+- extraction would introduce cyclic concepts or broad re-exports;
+- the only benefit is a smaller file.
+
+Promote a module to a crate only when all are true:
+
+- it has one stable semantic owner;
+- it exposes a small command/query/model API;
+- dependencies point only toward foundation or lower domain contracts;
+- it has meaningful focused tests or build isolation;
+- at least one consumer benefits from the boundary;
+- moving it does not require infrastructure dependencies in the domain.
+
+Do not populate `wow-combat`, `wow-spell`, `wow-pvp`, `wow-social`, `wow-achievement`, or
+`wow-ecs` merely because the directories exist.
+
+## Port or trait
+
+Introduce a trait when:
+
+- multiple real adapters exist; or
+- a deterministic fake is needed to test an application use case; or
+- dependency inversion cannot be achieved with a concrete value or function.
+
+Typical useful ports include repositories, clock, RNG, packet/event sink, navigation, and world
+runtime handle. Avoid one-method traits that only wrap an internal call.
+
+## Task, lock, or channel
+
+Use an owner task/channel when one task must serialize state or I/O. Make capacity, overload
+behavior, ordering, shutdown, and durable-versus-best-effort semantics explicit.
+
+Use a synchronous lock only for short sections with no `.await`. Never send packets or perform SQL
+while holding a map lock. Avoid adding `Arc<Mutex<_>>` to escape an unclear owner.
+
+Do not parallelize map simulation until each mutable state has one owner. Preserve the C++
+session → respawn → object update → publication phase order.
+
+## Mirror ledger
+
+For every transitional mirror, record:
+
+```text
+State:
+Canonical owner:
+Temporary mirror:
+Writers:
+Readers:
+Sync direction:
+Conflict rule:
+Why the mirror still exists:
+Test that guards it:
+Deletion condition:
+Owning issue:
+```
+
+Reject a new mirror without all fields.
+
+## Public API budget
+
+- Keep modules private by default.
+- Re-export only stable inter-crate contracts.
+- Prefer command, query, outcome, and event types over exposing internal maps or locks.
+- Do not widen visibility to move tests; keep unit tests beside private code or add a narrow
+  behavior-level seam.
+- Treat every `pub` item as a compatibility and coupling cost.
+
+## Architecture slice rules
+
+1. Assign the owner.
+2. Freeze observable behavior with tests/captures.
+3. Move code without changing ownership.
+4. Introduce the target boundary.
+5. Redirect one writer and all related readers.
+6. Delete the superseded mirror or document its precise remaining boundary.
+7. Only then change behavior or concurrency.
+
+Keep mechanical relocation, ownership migration, and behavior correction in separate commits or
+PRs.

--- a/.agents/skills/refactor-rustycore-safely/SKILL.md
+++ b/.agents/skills/refactor-rustycore-safely/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: refactor-rustycore-safely
+description: Implement or review behavior-preserving RustyCore restructuring with C++ fidelity and capture-clean validation. Use for module or file splits, moving methods or types, extracting application services, catalogs, repositories, runtime handles, or private substates, shrinking session/handlers/map/player/world-server/data/packet/QA hotspots, changing dependency edges, or promoting a stable module into a crate without intending gameplay or protocol changes. Do not use to hide a behavior change or legacy bug fix inside a refactor; design unclear ownership first with design-rustycore-architecture.
+---
+
+# Refactor RustyCore Safely
+
+Execute one small structural slice while preserving runtime ownership, database atomicity, packet
+bytes/routing, C++ phase order, and public behavior.
+
+## Load the required context
+
+1. Read the repository `AGENTS.md` completely and run its session kickoff.
+2. Read `docs/migration/STATE.md` and the decision, risks, and task-relevant sections of any owning
+   ADR. For `docs/migration/adr-runtime-tick-ownership.md`, do not load the entire historical
+   progress log for a bounded refactor.
+3. Read [references/refactor-playbook.md](references/refactor-playbook.md).
+4. Inspect the exact C++ source for the moved responsibility and the complete current Rust call
+   path before editing.
+5. Inspect the issue, branch, worktree, related review history, and existing tests.
+
+If the canonical owner or desired dependency direction is not explicit, stop implementation and
+use `$design-rustycore-architecture`.
+
+## Classify the change before editing
+
+Choose exactly one dominant class:
+
+1. **Mechanical relocation:** move code/tests, preserve owner, signatures, ordering, visibility,
+   registration, and behavior.
+2. **Boundary extraction:** introduce a module/service/port and redirect dependencies without
+   changing the canonical state.
+3. **Ownership migration:** redirect all writers/readers to one target owner and delete or ledger
+   the old mirror.
+4. **Behavior correction:** change observable or persistence behavior because C++ parity or a
+   proven legacy defect requires it.
+
+Do not combine class 4 with classes 1–3. Prefer separate PRs for relocation, boundary change, and
+ownership migration when the diff would otherwise obscure review.
+
+## Refactor workflow
+
+### 1. Freeze the contract
+
+List the behavior that must not change:
+
+- opcode, `SessionStatus`, and `PacketProcessing`;
+- packet bytes, connection, recipient gates, ordering, and timing boundary;
+- C++ validation and phase order;
+- SQL statements, transaction boundary, rollback/commit classification, and retry behavior;
+- canonical owner, mutation count, lock order, and tick owner;
+- public paths and downstream callers;
+- positive, negative, concurrency, and failure-path tests.
+
+Add or identify regression tests before moving fragile code.
+
+### 2. Map the complete dependency surface
+
+Use `rg` to find definitions, impl blocks, re-exports, call sites, registrations, tests, feature
+gates, SQL statements, locks, channels, and docs. Inspect macros and `inventory::submit!` rather
+than assuming a handler is registered because a match arm exists.
+
+### 3. Make the smallest coherent edit
+
+Move one feature family, state group, use case, or adapter seam at a time. Keep implementation
+private. Use temporary re-exports only when they reduce unrelated churn, and record their removal
+condition.
+
+Do not:
+
+- invent traits merely to split files;
+- add `Arc<Mutex<_>>`, `RefCell`, global state, clones, or mirrors to satisfy the borrow checker;
+- broaden `pub` visibility for convenience;
+- alter serialization or SQL order during a move;
+- leave two opcode registration sources;
+- introduce unbounded channels or wait while holding a runtime lock.
+
+### 4. Preserve application and persistence ordering
+
+For atomic operations, preserve the established shape:
+
+```text
+validate and plan
+    → execute transaction
+    → classify commit outcome
+    → apply canonical runtime state once
+    → publish packets/events outside incompatible locks
+```
+
+Do not publish success before a durable commit or mutate runtime twice during reconciliation.
+
+### 5. Validate continuously
+
+Run format, diff checks, focused tests, and targeted checks during the edit. Use `PROTOC`
+explicitly for protobuf-dependent crates. Run:
+
+```bash
+cargo fmt --all -- --check
+git diff --check
+PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p <affected-crate>
+PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p <affected-crate> <focused-test> --lib
+./tools/pr-preflight.sh quick origin/3.4.3
+```
+
+After committing to a clean HEAD and before an authorized push, run:
+
+```bash
+./tools/pr-preflight.sh full origin/3.4.3
+```
+
+Treat the capture-diff harness inside `full` preflight as mandatory for every PR. Run a fresh
+action-specific capture or live bot QA when the owning issue requires it. A file move is not
+evidence that observable behavior stayed equal.
+
+### 6. Audit the finished diff
+
+Verify:
+
+- no code, test, registration, cfg branch, or documentation was accidentally dropped;
+- opcode registration tests assert the exact expected set and metadata, not only counts or
+  duplicate absence;
+- moved tests still exercise the same private behavior or a deliberately narrower contract;
+- no new upward crate dependency or public API leak appeared;
+- no new state mirror, clone-sync path, task owner, or lock order appeared;
+- no unrelated user/worktree changes entered the diff;
+- source paths and C++ anchors in docs remain accurate;
+- every compatibility re-export or bridge has a deletion condition.
+
+### 7. Publish only through the repository workflow
+
+Use one issue, one linked branch, and one PR into `3.4.3`. Do not push unless the user asks. After
+push, open the PR immediately with `Closes #<issue>` and wait for CI plus a clean Codex reviewer
+verdict on the current HEAD. Address or explicitly defer every actionable review and resolve its
+thread before merge.
+
+## Stop conditions
+
+Stop and separate the work when:
+
+- the move reveals an undocumented behavior difference;
+- C++ and Rust ownership disagree and the target is not already decided;
+- preserving behavior requires a new mirror or cross-layer dependency;
+- a test fails for a reason that has not been contrasted with C++;
+- the diff combines structural movement with a gameplay/protocol change;
+- the target overlaps unrelated dirty work that cannot be isolated safely.
+
+Report the evidence and propose the smallest next slice instead of forcing the refactor through.

--- a/.agents/skills/refactor-rustycore-safely/SKILL.md
+++ b/.agents/skills/refactor-rustycore-safely/SKILL.md
@@ -8,6 +8,20 @@ description: Implement or review behavior-preserving RustyCore restructuring wit
 Execute one small structural slice while preserving runtime ownership, database atomicity, packet
 bytes/routing, C++ phase order, and public behavior.
 
+## Select review or execution mode
+
+Choose the mode from the user's requested outcome before any mutation:
+
+- **Review mode:** inspect and report only. Do not edit, stage, commit, push, publish, reply to
+  reviews, or resolve threads. Report prioritized findings with a narrow file/line range, the
+  frozen contract that would be violated, supporting Rust/C++ or capture evidence, and the smallest
+  safe correction. Separate patch-caused defects from pre-existing debt. Stop after the findings
+  unless the user explicitly asks to implement them.
+- **Execution mode:** the user asked to change or refactor code. Follow the implementation workflow
+  below and remain within the authorized issue and worktree scope.
+
+If the request is ambiguous between inspection and mutation, use review mode.
+
 ## Load the required context
 
 1. Read the repository `AGENTS.md` completely and run its session kickoff.
@@ -38,7 +52,7 @@ Choose exactly one dominant class:
 Do not combine class 4 with classes 1–3. Prefer separate PRs for relocation, boundary change, and
 ownership migration when the diff would otherwise obscure review.
 
-## Refactor workflow
+## Refactor workflow (execution mode)
 
 ### 1. Freeze the contract
 
@@ -98,8 +112,19 @@ explicitly for protobuf-dependent crates. Run:
 cargo fmt --all -- --check
 git diff --check
 PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p <affected-crate>
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p <affected-crate> <focused-test> --lib
 ./tools/pr-preflight.sh quick origin/3.4.3
+```
+
+Choose the focused test target from `cargo metadata` instead of assuming every package has a
+library:
+
+```bash
+# Library target:
+PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p <package> <focused-test> --lib
+# Binary target such as world-server or bnet-server:
+PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p <package> <focused-test> --bin <binary>
+# Integration-test target:
+PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p <package> <focused-test> --test <target>
 ```
 
 After committing to a clean HEAD and before an authorized push, run:

--- a/.agents/skills/refactor-rustycore-safely/agents/openai.yaml
+++ b/.agents/skills/refactor-rustycore-safely/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Refactor RustyCore Safely"
+  short_description: "Execute capture-clean Rust refactors safely"
+  default_prompt: "Use $refactor-rustycore-safely to implement this behavior-preserving RustyCore refactor and validate it."

--- a/.agents/skills/refactor-rustycore-safely/references/refactor-playbook.md
+++ b/.agents/skills/refactor-rustycore-safely/references/refactor-playbook.md
@@ -1,0 +1,160 @@
+# RustyCore safe-refactor playbook
+
+Use this playbook after ownership and dependency direction are decided.
+
+## Slice template
+
+Record before editing:
+
+```text
+Issue:
+Dominant change class:
+C++ semantic owner and anchors:
+Current Rust owner:
+Target Rust owner:
+Observable contract frozen by:
+Persistence contract:
+Concurrency/lock contract:
+Opcode registrations affected:
+Public paths affected:
+Focused tests:
+Capture/live QA requirement:
+Explicit non-goals:
+Bridge or re-export deletion condition:
+```
+
+Reject a slice whose target owner, frozen contract, or non-goals are unclear.
+
+## Mechanical feature split
+
+Use for `handlers/misc.rs`, packet families, QA scenarios, or a cohesive impl block.
+
+1. Identify one complete feature family and all registrations/tests.
+2. Create a private module in the same crate.
+3. Move definitions and tests without renaming or reordering logic.
+4. Keep imports explicit; do not replace compile errors with broad `pub`.
+5. Confirm every `(opcode, SessionStatus, PacketProcessing)` tuple is unchanged.
+6. Add or update a table-driven test for the exact expected opcode set, metadata, handler names,
+   and uniqueness. Counts alone cannot detect replacement by the wrong opcode.
+7. Run focused tests, crate tests, quick preflight, then full preflight after commit.
+
+Keep `impl WorldSession` across modules when that preserves C++ handler naming. Do not add
+`CharacterHandlers`-style traits solely for organization.
+
+## Composition-root split
+
+Use for `world-server/main.rs` or `bnet-server`.
+
+Extract in this order when seams permit:
+
+1. configuration and CLI parsing;
+2. immutable catalog/bootstrap loading;
+3. concrete repository/DB writer adapters;
+4. session factory;
+5. runtime task supervision and routing;
+6. realm lifecycle and shutdown.
+
+Keep `main` responsible for construction and supervision. Do not move gameplay ownership into a
+binary module merely because it is convenient to wire there.
+
+## Shared-service boundary
+
+Use when replacing `SessionResources` or setter forests.
+
+1. Group immutable catalogs by domain.
+2. Group repositories by transaction boundary, not table count.
+3. Group runtime handles by owner.
+4. Validate mandatory production resources once in bootstrap.
+5. Provide an explicit test builder instead of making every production dependency optional.
+6. Migrate one resource group and its consumers per slice.
+7. Remove the old setters/fields in the same slice when possible.
+
+Do not turn `WorldServices` into an untyped map or allow every use case to depend on the entire
+aggregate. Give each use case the smallest typed dependency set.
+
+## Aggregate modularization
+
+Use for `Map`, `Player`, `Unit`, or another legitimate aggregate.
+
+- Keep one aggregate identity and one canonical state.
+- Split private substates and impl capabilities by responsibility.
+- Preserve invariant enforcement at the aggregate boundary.
+- Do not create submanagers that own copies of aggregate state.
+- Keep C++ update phase ordering explicit in the top-level method.
+
+Candidate private modules:
+
+```text
+map/{objects,grid,respawn,visibility,relocation,transport,scripts,weather}
+player/{inventory,progression,quests,skills,social,pvp,update_fields}
+session/{identity,transport,lifecycle,time_sync,visibility,dispatch,legacy_bridge}
+```
+
+These names are guides, not permission for a bulk move.
+
+## Handler-to-use-case extraction
+
+Extract one complete vertical operation:
+
+```text
+decode packet
+    → session/status gate
+    → command input
+    → application use case
+    → domain plan/outcome
+    → repository transaction
+    → canonical mutation
+    → packet/event presenter
+```
+
+Keep protocol DTOs at the adapter boundary. Keep SQL rows and prepared statements in repository
+implementations. Keep pure gameplay decisions out of both.
+
+Add tests at three levels as applicable:
+
+- unit tests for pure rules and negative branches;
+- application tests for transaction and canonical mutation ordering;
+- packet/capture tests for bytes, connection, routing, and visibility.
+
+## Ownership migration
+
+1. Name the source and target owners.
+2. Freeze both single-session and multi-session behavior.
+3. Redirect one writer and every dependent reader.
+4. Preserve C++ phase order.
+5. Delete the old state and sync path immediately, or update the mirror ledger with a precise
+   remaining boundary.
+6. Prove the mutation happens exactly once.
+
+For runtime work, follow `docs/migration/adr-runtime-tick-ownership.md`. Never enable a global tick
+in addition to a session tick for the same responsibility.
+
+## Promote a module to a crate
+
+Promote only after the API is stable:
+
+1. list intended public types/functions;
+2. prove dependencies point downward;
+3. ensure domain code does not import network, SQL, packet presentation, or binary configuration;
+4. move focused tests with the module;
+5. add the minimum workspace dependencies and inherit workspace lints;
+6. keep adapter conversion in the caller/application layer;
+7. inspect `cargo tree -p <new-crate>` and public re-exports.
+
+Do not use a new crate to conceal cyclic domain concepts.
+
+## Verification matrix
+
+| Change surface | Minimum checks |
+|---|---|
+| Pure private move | format, diff check, focused tests, crate tests |
+| Opcode handler move | exact-set registration test, handler tests, packet tests |
+| Persistence orchestration | positive/negative/deadlock/commit-unknown tests, DB statement order |
+| Map/runtime ownership | one-owner/multi-session tests, lock audit, tick-order tests |
+| Packet/presenter move | byte, connection, recipient, order, visibility, capture-diff |
+| Public API or crate edge | downstream check/tests, `cargo tree`, visibility/re-export audit |
+| QA bot split | scenario JSON fields, CLI compatibility, representative smoke dry run |
+
+Use the repository preflight as the final aggregate gate; its capture-diff harness is mandatory for
+every PR. Require fresh scenario capture or live bot QA only when the issue calls for it. Do not
+replace focused reasoning with a green build.

--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,15 @@ skills/
 wiki/
 skills-lock.json
 
-# Repository-scoped agent skills shared by the RustyCore team.
+# Repository-scoped agent skills shared by the RustyCore team. Keep this as an
+# allowlist: future scripts/assets need an intentional exception so local
+# credentials, certificates, logs, and generated files stay ignored.
 !.agents/skills/
-!.agents/skills/**
+.agents/skills/**
+!.agents/skills/**/
+!.agents/skills/*/SKILL.md
+!.agents/skills/*/agents/openai.yaml
+!.agents/skills/*/references/**/*.md
 
 # OpenClaw workspace files (private)
 SOUL.md

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ Thumbs.db
 
 # OpenClaw agent internal dirs (not for public repo)
 .agent/
-.agents/
+.agents/*
 .claude/
 .openclaw/
 .trae/
@@ -44,6 +44,10 @@ memory/
 skills/
 wiki/
 skills-lock.json
+
+# Repository-scoped agent skills shared by the RustyCore team.
+!.agents/skills/
+!.agents/skills/**
 
 # OpenClaw workspace files (private)
 SOUL.md


### PR DESCRIPTION
## Summary

- add `design-rustycore-architecture` under `.agents/skills` to guide ownership, dependency direction, crate/module boundaries, C++ fidelity, and incremental architecture campaigns
- add `refactor-rustycore-safely` to guide behavior-preserving Rust refactors, exact handler registration checks, ownership migrations, and capture-clean validation
- include focused architecture references, refactor playbooks, and Codex UI metadata for both skills
- track only `.agents/skills/**` while keeping other repository-local agent state ignored

## Why

RustyCore has project-wide maintainability pressure beyond any single large file. Repository-scoped skills give every agent the same architecture and safe-refactor constraints while preserving the current incremental port strategy and C++ behavioral source of truth.

## Impact

No production behavior changes. The skills are automatically discoverable by Codex from the repository and provide shared guidance for future architecture analysis and refactoring work.

## Validation

- both skills pass the official skill creator validator
- representative forward tests exercised architecture-design and safe-refactor prompts
- `./tools/pr-preflight.sh full origin/3.4.3` passed with a fresh target directory
- format, core checks/builds, Clippy, focused library tests, bot tests, and capture-diff passed
- local Codex review: clean, no findings (confidence 0.96)

Closes #131