### PR TITLE
[ARCH.PERF.1] Drop gate work that enforces nothing

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -149,7 +149,11 @@ jobs:
 
       - name: Cargo check
         run: |
-          cargo +1.88.0 check --locked -p wow-data -p wow-database -p wow-network -p wow-world -p bnet-server -p world-server
+          # The two builds below already type-check these crates: world-server
+          # depends directly on wow-data, wow-database, wow-network and
+          # wow-world, and bnet-server on wow-database. Checking them first
+          # compiled the same crates twice. wow-test-bot stays: it is outside
+          # the workspace and nothing else builds it.
           cargo +1.88.0 check --locked --manifest-path tools/wow-test-bot/Cargo.toml
           # `-j1` was introduced to stop two large debug binaries from linking
           # concurrently, but it also serialized every dependency compile in the
@@ -158,11 +162,6 @@ jobs:
           cargo +1.88.0 build --locked -j4 -p bnet-server
           cargo +1.88.0 build --locked -j4 -p world-server
 
-      - name: Clippy loot authority boundary
-        run: cargo +1.88.0 clippy --locked --no-deps --message-format short -p wow-loot -p wow-entities -p wow-map -p wow-network --lib
-
-      - name: Clippy world target with inherited debt capped
-        run: cargo +1.88.0 clippy --locked --no-deps --message-format short -p wow-world --lib -- --cap-lints warn
 
   tests:
     name: Focused library tests
@@ -239,3 +238,13 @@ jobs:
         run: |
           cargo +stable check --locked -p bnet-server -p world-server
           cargo +stable build --locked -p bnet-server -p world-server
+
+      # Neither pass can fail: no crate sets `lints.workspace = true`, none
+      # denies a lint in source, there is no `-D warnings`, and the world
+      # target caps lints to warnings outright. They were costing every PR
+      # 1.1 minutes to print advice nobody was gated on. Keep the signal
+      # where it is free, and make it enforcing in its own change.
+      - name: Clippy advisory sweep
+        run: |
+          cargo +1.88.0 clippy --locked --no-deps --message-format short -p wow-loot -p wow-entities -p wow-map -p wow-network --lib
+          cargo +1.88.0 clippy --locked --no-deps --message-format short -p wow-world --lib -- --cap-lints warn

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -205,6 +205,49 @@ jobs:
           cargo +1.88.0 run --locked -p capture-diff -- verify-required loot-single-item-claim
           cargo +1.88.0 run --locked -p capture-diff -- verify-required creature-spell-casting
 
+  clippy:
+    name: Clippy advisory sweep
+    # Neither pass can fail a build: no crate sets `lints.workspace = true`, so
+    # the workspace lint table is inherited by nothing; no crate denies a lint
+    # in source; there is no `-D warnings`; and the world pass caps lints to
+    # warnings outright. That cost every PR 1.1 minutes to print advice which
+    # gated nothing, so the signal lives here instead — visible and free.
+    # Making it enforcing means clearing wow-world's lint debt first.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.88.0
+        with:
+          components: clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: clippy
+
+      - name: Install protoc
+        run: |
+          protoc_version="$(tr -d '[:space:]' < .protoc-version)"
+          curl --fail --show-error --location --retry 3 --retry-all-errors \
+            -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip"
+          python3 -m zipfile -e /tmp/protoc.zip "$HOME/.local"
+          chmod +x "$HOME/.local/bin/protoc"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Clippy loot authority boundary
+        run: cargo +1.88.0 clippy --locked --no-deps --message-format short -p wow-loot -p wow-entities -p wow-map -p wow-network --lib
+
+      - name: Clippy world target with inherited debt capped
+        run: cargo +1.88.0 clippy --locked --no-deps --message-format short -p wow-world --lib -- --cap-lints warn
+
   latest-stable:
     name: Latest stable compatibility
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -238,13 +281,3 @@ jobs:
         run: |
           cargo +stable check --locked -p bnet-server -p world-server
           cargo +stable build --locked -p bnet-server -p world-server
-
-      # Neither pass can fail: no crate sets `lints.workspace = true`, none
-      # denies a lint in source, there is no `-D warnings`, and the world
-      # target caps lints to warnings outright. They were costing every PR
-      # 1.1 minutes to print advice nobody was gated on. Keep the signal
-      # where it is free, and make it enforcing in its own change.
-      - name: Clippy advisory sweep
-        run: |
-          cargo +1.88.0 clippy --locked --no-deps --message-format short -p wow-loot -p wow-entities -p wow-map -p wow-network --lib
-          cargo +1.88.0 clippy --locked --no-deps --message-format short -p wow-world --lib -- --cap-lints warn

--- a/tools/architecture/handler-contract-check/src/session_ownership.rs
+++ b/tools/architecture/handler-contract-check/src/session_ownership.rs
@@ -1813,6 +1813,19 @@ fn collect_workspace_persistence_baseline(
 }
 
 fn collect_repository_baseline(repository_root: &Path) -> Result<SessionSyntaxBaseline, String> {
+    collect_repository_baseline_with_persistence(repository_root, true)
+}
+
+/// Collect the session syntax surface, optionally without the persistence scan.
+///
+/// The persistence inventory costs a full workspace scan — minutes, and the
+/// dominant cost of the whole gate. `print-baseline` renders an envelope whose
+/// persistence field is `#[serde(skip)]`, so paying for that scan there bought
+/// a value that was then discarded unread.
+fn collect_repository_baseline_with_persistence(
+    repository_root: &Path,
+    with_persistence: bool,
+) -> Result<SessionSyntaxBaseline, String> {
     let mut units = repository_units(
         repository_root,
         PackageRole::World,
@@ -1831,7 +1844,11 @@ fn collect_repository_baseline(repository_root: &Path) -> Result<SessionSyntaxBa
         NETWORK_PACKAGE_ROOT,
         NETWORK_CRATE_ROOT,
     )?);
-    let persistence_accesses = collect_workspace_persistence_baseline(repository_root)?;
+    let persistence_accesses = if with_persistence {
+        collect_workspace_persistence_baseline(repository_root)?
+    } else {
+        PersistenceAccessBaseline::default()
+    };
     let baseline = collect_units(units, persistence_accesses)?;
     validate_curated_bridge_anchors(&baseline.bridge_accesses)
         .map_err(|error| format!("invalid curated bridge inventory:\n{error}"))?;
@@ -2096,7 +2113,9 @@ pub fn check_repository(policy_path: Option<&Path>) -> Result<String, String> {
 /// `syntax_baseline` object deliberately into the semantic policy.
 pub fn print_repository_baseline() -> Result<String, String> {
     let repository_root = crate::repository_root()?;
-    let baseline = collect_repository_baseline(&repository_root)?;
+    // Without persistence: the envelope skips that field when serializing, so
+    // scanning for it would discard the result.
+    let baseline = collect_repository_baseline_with_persistence(&repository_root, false)?;
     serde_json::to_string_pretty(&BaselineEnvelope {
         schema_version: 1,
         persistence_access_snapshot: PERSISTENCE_ACCESS_SNAPSHOT_RELATIVE_PATH,

--- a/tools/pr-preflight.sh
+++ b/tools/pr-preflight.sh
@@ -476,27 +476,16 @@ run_architecture() {
 run_check() {
   log "Core checks and linked server builds (same commands as GitHub Actions)"
   resolve_protoc
-  cargo_cmd check --locked \
-    -p wow-data \
-    -p wow-database \
-    -p wow-network \
-    -p wow-world \
-    -p bnet-server \
-    -p world-server
+  # The builds below already type-check the four libraries: world-server
+  # depends on all of them and bnet-server on wow-database. Only wow-test-bot
+  # needs its own check — it lives outside the workspace.
   cargo_cmd check --locked --manifest-path tools/wow-test-bot/Cargo.toml
   cargo_cmd build --locked -j4 -p bnet-server
   cargo_cmd build --locked -j4 -p world-server
-  cargo_cmd clippy --locked --no-deps --message-format short \
-    -p wow-loot \
-    -p wow-entities \
-    -p wow-map \
-    -p wow-network \
-    --lib
-  cargo_cmd clippy --locked --no-deps --message-format short \
-    -p wow-world \
-    --lib \
-    -- \
-    --cap-lints warn
+  # Clippy moved to the scheduled job: neither pass could fail (no crate sets
+  # `lints.workspace = true`, none denies in source, no `-D warnings`, and the
+  # world pass caps lints outright), so it cost PR time to print advice that
+  # gated nothing.
 }
 
 run_test() {
@@ -1017,10 +1006,8 @@ run_self_test() {
   require_exact_occurrences "$ci_dry_run_output" \
     "fmt --manifest-path $HANDLER_CONTRACT_CHECK_MANIFEST -- --check" 1 \
     "local CI handler-contract checker formatting"
-  [[ "$ci_dry_run_output" == *"clippy --locked --no-deps --message-format short -p wow-loot"* ]] || die \
-    "CI profile did not print the loot-authority clippy command"
-  [[ "$ci_dry_run_output" == *"clippy --locked --no-deps --message-format short -p wow-world --lib -- --cap-lints warn"* ]] || die \
-    "CI profile did not print the capped wow-world clippy command"
+  [[ "$ci_dry_run_output" != *"clippy --locked"* ]] || die \
+    "CI profile must not spend PR time on clippy passes that cannot fail"
   require_exact_occurrences "$ci_dry_run_output" \
     "build --locked -j4 -p bnet-server" 1 \
     "local CI bnet-server linked build"

--- a/tools/pr-preflight.sh
+++ b/tools/pr-preflight.sh
@@ -1063,7 +1063,7 @@ run_self_test() {
     "cargo +1.88.0 fmt --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- --check" 1 \
     "GitHub workflow handler-contract checker formatting"
   require_exact_occurrences "$github_workflow_text" \
-    'CARGO_INCREMENTAL: "0"' 2 \
+    'CARGO_INCREMENTAL: "0"' 3 \
     "GitHub workflow non-incremental Rust 1.88 contract"
   require_exact_occurrences "$github_workflow_text" \
     "cargo +1.88.0 build --locked -j4 -p bnet-server" 1 \


### PR DESCRIPTION
Closes #208. Follow-up to #206.

Three cuts to `Check core crates`, **none of which costs a guarantee**.

## 1. The `cargo check` of six crates duplicated the builds beside it

Verified in `crates/world-server/Cargo.toml`: world-server depends directly on `wow-data`,
`wow-database`, `wow-network` and `wow-world`; bnet-server on `wow-database`. The two builds
already type-check everything that line covered. `wow-test-bot` keeps its own check — it is
outside the workspace and nothing else builds it. **~2-3 min.**

## 2. Neither clippy pass could fail

Verified three independent ways:

* `[workspace.lints.clippy]` (`Cargo.toml:185-193`) exists, but **no crate declares
  `lints.workspace = true`**, so nothing inherits it.
* No `#![deny(...)]` / `#![forbid(...)]` in any of the five crates.
* No `-D warnings` anywhere, and the world pass passes `--cap-lints warn`, which degrades an
  explicit `-D` back to a warning.

They cost every PR 1.1 min to print advice that gated nothing. Moved to the scheduled job so
the signal stays visible and free. Making clippy *enforcing* means addressing wow-world's lint
debt first, and deserves its own change.

## 3. `print-baseline` paid ~10 min for a value it discarded

`print_repository_baseline` ran the full workspace persistence collection to render an envelope
whose persistence field is `#[serde(skip)]` (`session_ownership.rs:214-215`). The collector now
takes it as a parameter. **~590 s to 6.3 s.**

Verified the result is only *stored*, never derived from: `persistence_accesses` appears twice
in `collect_units` (parameter, then passed to `finish`), and `finish` places it in the struct
literal at `:1651`. The rendered output is unchanged.

This also makes it cheap to un-skip `repository_surface_can_be_collected` later — currently the
only test cross-checking the collector against an independent `syn::parse_file`.

## Rejected after measuring

**A clippy deny-list on sqlx and the concrete `wow-database` types.** This was the plan, and it
does not work. `wow-loot`, `wow-entities`, `wow-map` and `wow-network` cannot *name* those types
because they cannot declare the dependency: `dependency-policy.json` puts them in the protected
`domain-runtime` category and allows `wow-loot` exactly `rand`. The deny-list would have
enforced nothing that the Cargo-edge check does not already enforce in milliseconds — enforcement
theatre on top of a gate whose problem is precisely that it records rather than prohibits.

**Restricting the hotspot glob** to the 8 audited paths. Measured: the whole Python guard is
14.2 s, so this saves ~10 s and costs the ranking report the refactor programme uses.

**The "duplicate" validator runs** (`pr-preflight.sh:872` self-test vs `rust-ci.yml:92` check)
are different modes in parallel jobs; they cost no wall clock.

## Validation

* Tool suite in release: **304 passed, 0 failed**
* `cargo fmt --all --check`, `git diff --check`: clean
* `./tools/pr-preflight.sh self-test`: passes, and the local profile is mirrored — the new
  invariant `CI profile must not spend PR time on clippy passes that cannot fail` was verified
  adversarially by reintroducing a clippy call and watching it fail.

Expected: `Check core crates` ~22.5 min to ~19-20 min. The remaining dominant cost is the
11.3-min exact scan, which #206's audit addresses in later steps.