### PR TITLE
[ARCH.PERF.2] Ratchet the session surface on PRs, the exact inventory on merge

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -99,12 +99,26 @@ jobs:
             -- --skip repository_surface_can_be_collected
           cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- check
 
+      # Pull requests ratchet the session surface only — seconds. The exact
+      # persistence inventory is an 11-minute scan that was 72% of this job,
+      # and it is a change detector on source text: on a branch where 55% of
+      # commits touch session.rs, most of what it reports mid-development is
+      # regeneration churn. It still runs below on every push to 3.4.3 and on
+      # the cron, so a leak is caught at merge rather than at review time —
+      # deferred, not dropped.
+      - name: Ratchet the session ownership surface
+        if: github.event_name == 'pull_request'
+        run: |
+          cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml \
+            --bin session-ownership-check -- check --syntax-only
+
       # The combined check compares the session surface before the persistence
       # snapshot, so a session-only mismatch must not launch the long scan
       # below. Publish the baseline only when the persistence comparison is
       # what failed.
       - name: Check persistence and session ownership ratchets
         id: ratchets
+        if: github.event_name != 'pull_request'
         run: |
           set +e
           report="$(cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml --bin session-ownership-check -- check 2>&1)"

--- a/tools/architecture/handler-contract-check/src/bin/session-ownership-check.rs
+++ b/tools/architecture/handler-contract-check/src/bin/session-ownership-check.rs
@@ -8,6 +8,7 @@ use std::process::ExitCode;
 fn usage() -> ExitCode {
     eprintln!(
         "usage: session-ownership-check check [--policy PATH]\n       \
+         session-ownership-check check --syntax-only\n       \
          session-ownership-check print-baseline\n       \
          session-ownership-check print-persistence-baseline\n       \
          session-ownership-check print-persistence-policy [--from-snapshot PATH]"
@@ -20,6 +21,9 @@ fn main() -> ExitCode {
     let result = match arguments.as_slice() {
         [command] if command == "check" => {
             handler_contract_check::check_session_ownership_repository(None)
+        }
+        [command, flag] if command == "check" && flag == "--syntax-only" => {
+            handler_contract_check::check_session_ownership_repository_syntax_only(None)
         }
         [command, flag, policy] if command == "check" && flag == "--policy" => {
             let policy = PathBuf::from(policy);

--- a/tools/architecture/handler-contract-check/src/lib.rs
+++ b/tools/architecture/handler-contract-check/src/lib.rs
@@ -38,6 +38,7 @@ use snapshot::parse_snapshot_contract;
 
 pub use session_ownership::{
     check_repository as check_session_ownership_repository,
+    check_repository_syntax_only as check_session_ownership_repository_syntax_only,
     print_repository_baseline as print_session_ownership_baseline,
     print_repository_persistence_baseline as print_persistence_access_baseline,
     print_repository_persistence_policy as print_persistence_boundary_policy,

--- a/tools/architecture/handler-contract-check/src/session_ownership.rs
+++ b/tools/architecture/handler-contract-check/src/session_ownership.rs
@@ -2025,13 +2025,55 @@ fn load_policy(path: &Path) -> Result<PolicyEnvelope, String> {
 
 /// Check the repository against the exact AST surface checked into the policy.
 pub fn check_repository(policy_path: Option<&Path>) -> Result<String, String> {
+    check_repository_scoped(policy_path, true)
+}
+
+/// Check the session syntax surface without the exact persistence comparison.
+///
+/// The persistence scan is minutes; the session surface is seconds. Pull
+/// requests run this so the ownership ratchet still guards every change,
+/// while the exact inventory is compared on push and on the weekly cron —
+/// detected at merge rather than at review time, not detected less.
+pub fn check_repository_syntax_only(policy_path: Option<&Path>) -> Result<String, String> {
+    check_repository_scoped(policy_path, false)
+}
+
+fn check_repository_scoped(
+    policy_path: Option<&Path>,
+    with_persistence: bool,
+) -> Result<String, String> {
     let repository_root = crate::repository_root()?;
     let policy_path = policy_path
         .map(Path::to_owned)
         .unwrap_or_else(|| repository_root.join(POLICY_RELATIVE_PATH));
     let policy = load_policy(&policy_path)?;
-    let actual = collect_repository_baseline(&repository_root)?;
+    let actual = collect_repository_baseline_with_persistence(&repository_root, with_persistence)?;
     compare_baseline(&policy.syntax_baseline, &actual)?;
+    if !with_persistence {
+        return Ok(format!(
+            "session ownership: PASS (syntax only; {} production + {} test-fixture WorldSession \
+             fields; {} impl owners / {} exact associated items; {} SessionResources fields; {} \
+             SessionCommand variants; {} exact direct-registry rows; exact persistence inventory \
+             deferred to push and cron)",
+            actual
+                .world_session
+                .fields
+                .iter()
+                .filter(|field| field.cfg.is_empty())
+                .count(),
+            actual
+                .world_session
+                .fields
+                .iter()
+                .filter(|field| !field.cfg.is_empty())
+                .count(),
+            actual.world_session.impls.len(),
+            actual.world_session.impl_items.len(),
+            actual.session_resources.fields.len(),
+            actual.session_command.variants.len(),
+            actual.registry_accesses.accesses.len(),
+        ));
+    }
     let persistence_snapshot_path = repository_root.join(&policy.persistence_access_snapshot);
     let persistence_snapshot_source =
         fs::read_to_string(&persistence_snapshot_path).map_err(|error| {

--- a/tools/pr-preflight.sh
+++ b/tools/pr-preflight.sh
@@ -469,6 +469,12 @@ run_architecture() {
   cargo_cmd test --release --locked --manifest-path "$HANDLER_CONTRACT_CHECK_MANIFEST" \
     -- --skip repository_surface_can_be_collected
   cargo_cmd run --release --locked --manifest-path "$HANDLER_CONTRACT_CHECK_MANIFEST" -- check
+  # Both, because the local gate stands in for a PR *and* for what the push to
+  # 3.4.3 will run: the syntax ratchet a PR is gated on, then the exact
+  # inventory that only runs post-merge in CI. Catching an inventory move here
+  # is the difference between fixing it now and reddening the branch.
+  cargo_cmd run --release --locked --manifest-path "$HANDLER_CONTRACT_CHECK_MANIFEST" \
+    --bin session-ownership-check -- check --syntax-only
   cargo_cmd run --release --locked --manifest-path "$HANDLER_CONTRACT_CHECK_MANIFEST" \
     --bin session-ownership-check -- check
 }
@@ -1001,8 +1007,11 @@ run_self_test() {
     "run --release --locked --manifest-path $HANDLER_CONTRACT_CHECK_MANIFEST -- check" 1 \
     "local CI handler-contract repository check"
   require_exact_occurrences "$ci_dry_run_output" \
-    "run --release --locked --manifest-path $HANDLER_CONTRACT_CHECK_MANIFEST --bin session-ownership-check -- check" 1 \
-    "local CI session-ownership repository check"
+    "--bin session-ownership-check -- check --syntax-only" 1 \
+    "local CI session-ownership syntax ratchet"
+  require_exact_occurrences "$ci_dry_run_output" \
+    "run --release --locked --manifest-path $HANDLER_CONTRACT_CHECK_MANIFEST --bin session-ownership-check -- check" 2 \
+    "local CI session-ownership repository checks"
   require_exact_occurrences "$ci_dry_run_output" \
     "fmt --manifest-path $HANDLER_CONTRACT_CHECK_MANIFEST -- --check" 1 \
     "local CI handler-contract checker formatting"
@@ -1056,6 +1065,15 @@ run_self_test() {
   require_exact_occurrences "$github_workflow_text" \
     "cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- check" 1 \
     "GitHub workflow handler-contract repository check"
+  require_exact_occurrences "$github_workflow_text" \
+    "--bin session-ownership-check -- check --syntax-only" 1 \
+    "GitHub workflow session-ownership syntax ratchet"
+  # The exact inventory must stay off the pull-request path; if this guard is
+  # the only thing standing between a 5-minute PR and a 16-minute one, it
+  # should say so when someone removes it.
+  require_exact_occurrences "$github_workflow_text" \
+    "if: github.event_name != 'pull_request'" 1 \
+    "GitHub workflow post-merge-only exact persistence scan"
   require_exact_occurrences "$github_workflow_text" \
     "cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml --bin session-ownership-check -- check" 1 \
     "GitHub workflow session-ownership repository check"


### PR DESCRIPTION
Closes #210. Follow-up to #206 / #208.

After #209 the job is 15m48s and the exact persistence scan is **11.3 of those minutes — 72%**.

## What changes

Pull requests run `check --syntax-only`: the same session ownership ratchet without the
workspace persistence collection. **6.4 s instead of 11.3 min**, with every session number
still enforced — 727 production + 11 fixture `WorldSession` fields, 20 impl owners, 3339
associated items, 243 `SessionResources` fields, 685 registry rows.

The exact inventory runs on push to `3.4.3` and on the weekly cron.

Expected: the job drops to **~4.5 min**; since the four required checks run in parallel, a PR
settles in about **5 minutes** rather than 16.

## What it costs

A new direct-persistence access is caught **at merge instead of at review time**. Not caught
less — every push to `3.4.3` and every cron run does the full comparison. Reverting is a
one-line change to the step's `if:`.

The trade is defensible because this is a change detector on source text, which is weakest on a
codebase in motion: 55% of the last 1,692 commits touch `session.rs`, so most of what it reports
mid-development is regeneration churn rather than a leak.

The local preflight still runs **both** — catching an inventory move before pushing is the
difference between fixing it and reddening the branch.

## Invariants

Two new self-test expectations, both verified adversarially:

* removing the `if: github.event_name != 'pull_request'` fails with
  `post-merge-only exact persistence scan appeared 0 time(s)`
* dropping `--syntax-only` fails with `session-ownership syntax ratchet appeared 0 time(s)`

## Implemented, verified, then dropped

Restricting the collection to production sources. It works and is exact: 13,048 production rows
**identical** to the previous production subset, and all **105** operational fixture rows
reproduced with zero misses and zero extras. It halves the scan, 552 s to 269 s.

It is not here because it saves nothing once the scan is off the PR path, and it would force a
snapshot migration for a job that now runs nightly. The measurement worth keeping: **the
emitting pass is ~91% of the per-class cost**, not the fixpoint — future work on this analyzer
should target that walk, not the convergence loop.

## Validation

* Tool suite in release: 304 passed, 0 failed
* `check --syntax-only`: PASS in 6.36 s
* `cargo fmt --all --check`, `git diff --check`, `pr-preflight.sh self-test`: clean