### PR TITLE
[CI.1] Judge Codex reviews by their findings, not by their boilerplate

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -11,6 +11,9 @@ on:
       - ready_for_review
 
 permissions:
+  # actions: read is what lets the gate ask when this run was created, which is
+  # the only server-observed boundary that a thumbs-up can be measured against.
+  actions: read
   contents: read
   issues: read
   pull-requests: read

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -11,9 +11,6 @@ on:
       - ready_for_review
 
 permissions:
-  # actions: read is what lets the gate ask when this run was created, which is
-  # the only server-observed boundary that a thumbs-up can be measured against.
-  actions: read
   contents: read
   issues: read
   pull-requests: read

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -25,6 +25,18 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 35
     steps:
+      # The verdict logic moved out of this file into tools/ci, so the job needs
+      # the repository. It comes from the pull request like the workflow file
+      # itself does on `pull_request`, which is the same trust model as before:
+      # a branch could always edit this workflow to weaken its own gate, so
+      # pinning the script to the base would be protection in appearance only.
+      - name: Check out pull request
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          sparse-checkout: tools/ci
+          sparse-checkout-cone-mode: false
+
       - name: Require clean Codex review on current HEAD
         env:
           GH_TOKEN: ${{ github.token }}
@@ -34,186 +46,4 @@ jobs:
           CODEX_REVIEW_TIMEOUT_SECONDS: "1800"
           CODEX_REVIEW_POLL_SECONDS: "30"
         run: |
-          python3 <<'PY'
-          import json
-          import os
-          import re
-          import subprocess
-          import sys
-          import time
-
-          repo = os.environ["REPOSITORY"]
-          pr_number = os.environ["PR_NUMBER"]
-          head_sha = os.environ["HEAD_SHA"].lower()
-          timeout_seconds = int(os.environ.get("CODEX_REVIEW_TIMEOUT_SECONDS", "1800"))
-          poll_seconds = int(os.environ.get("CODEX_REVIEW_POLL_SECONDS", "30"))
-
-          codex_logins = {"chatgpt-codex-connector", "chatgpt-codex-connector[bot]"}
-          positive_markers = (
-              "didn't find any major issues",
-              "did not find any major issues",
-              "no major issues",
-          )
-          negative_markers = (
-              "automated review suggestions",
-              "p0 badge",
-              "p1 badge",
-              "p2 badge",
-              "p3 badge",
-          )
-
-          class TransientGitHubApiError(RuntimeError):
-              pass
-
-          def gh_json_pages(path):
-              separator = "&" if "?" in path else "?"
-              result = subprocess.run(
-                  [
-                      "gh",
-                      "api",
-                      "--paginate",
-                      f"{path}{separator}per_page=100",
-                      "--jq",
-                      ".[]",
-                  ],
-                  text=True,
-                  capture_output=True,
-              )
-              if result.returncode:
-                  error = result.stderr.strip() or result.stdout.strip()
-                  if (
-                      re.search(r"\(HTTP (?:404|5\d\d)\)", error)
-                      or "unexpected end of JSON input" in error
-                  ):
-                      raise TransientGitHubApiError(error)
-                  raise RuntimeError(f"gh api {path} failed: {error}")
-              try:
-                  return [json.loads(line) for line in result.stdout.splitlines() if line]
-              except json.JSONDecodeError as error:
-                  raise TransientGitHubApiError(
-                      f"gh api {path} returned invalid paginated JSON: {error}"
-                  ) from error
-
-          def reviewed_commits(body, fallback_commit=None):
-              commits = [
-                  commit.lower()
-                  for commit in re.findall(
-                      r"Reviewed commit:[*\s]*`?([0-9a-fA-F]{7,40})`?",
-                      body or "",
-                  )
-              ]
-              if fallback_commit:
-                  commits.append(fallback_commit.lower())
-              return commits
-
-          def is_current_head(commit):
-              return bool(commit) and (head_sha.startswith(commit) or commit.startswith(head_sha))
-
-          def codex_items_for_current_head():
-              comments = gh_json_pages(f"repos/{repo}/issues/{pr_number}/comments")
-              reviews = gh_json_pages(f"repos/{repo}/pulls/{pr_number}/reviews")
-
-              items = []
-              for item in comments:
-                  if item.get("user", {}).get("login") not in codex_logins:
-                      continue
-                  body = item.get("body") or ""
-                  if any(is_current_head(commit) for commit in reviewed_commits(body)):
-                      items.append((
-                          "comment",
-                          body,
-                          item.get("html_url", ""),
-                          item.get("created_at", ""),
-                      ))
-
-              for item in reviews:
-                  if item.get("user", {}).get("login") not in codex_logins:
-                      continue
-                  body = item.get("body") or ""
-                  fallback_commit = item.get("commit_id")
-                  if any(
-                      is_current_head(commit)
-                      for commit in reviewed_commits(body, fallback_commit)
-                  ):
-                      url = item.get("html_url") or item.get("_links", {}).get("html", {}).get("href", "")
-                      items.append((
-                          "review",
-                          body,
-                          url,
-                          item.get("submitted_at") or item.get("updated_at") or "",
-                      ))
-
-              return items
-
-          def classify_codex_body(body):
-              lower_body = body.lower()
-              if any(marker in lower_body for marker in negative_markers):
-                  return "fail"
-              if any(marker in lower_body for marker in positive_markers):
-                  return "pass"
-              return None
-
-          def verdict():
-              items = codex_items_for_current_head()
-              classified = []
-
-              for kind, body, url, timestamp in items:
-                  state = classify_codex_body(body)
-                  if state:
-                      classified.append((timestamp, state, kind, url))
-
-              if classified:
-                  timestamp, state, kind, url = max(classified, key=lambda item: item[0])
-                  return state, [(kind, url)]
-              return "wait", items
-
-          print(f"Waiting for clean Codex review on PR #{pr_number} at {head_sha[:10]}")
-          print("Comment '@codex review' on the PR if the review has not started.")
-          deadline = time.time() + timeout_seconds
-
-          while True:
-              try:
-                  state, items = verdict()
-              except TransientGitHubApiError as error:
-                  remaining = int(deadline - time.time())
-                  if remaining <= 0:
-                      print(
-                          "Timed out waiting for GitHub API recovery while checking "
-                          f"the Codex verdict: {error}"
-                      )
-                      sys.exit(1)
-
-                  retry_seconds = min(poll_seconds, remaining)
-                  print(
-                      "Transient GitHub API failure while checking the Codex verdict; "
-                      f"retrying in {retry_seconds}s ({remaining}s left): {error}"
-                  )
-                  time.sleep(retry_seconds)
-                  continue
-
-              if state == "pass":
-                  print("Found clean Codex review for current HEAD:")
-                  for kind, url in items:
-                      print(f"- {kind}: {url}")
-                  sys.exit(0)
-
-              if state == "fail":
-                  print("Codex left review feedback for current HEAD; address it before merge:")
-                  for kind, url in items:
-                      print(f"- {kind}: {url}")
-                  sys.exit(1)
-
-              remaining = int(deadline - time.time())
-              if remaining <= 0:
-                  print(
-                      "Timed out waiting for a clean Codex review on the current HEAD. "
-                      "Comment '@codex review' on the PR, then rerun this job after Codex responds."
-                  )
-                  sys.exit(1)
-
-              print(
-                  f"No clean Codex verdict for {head_sha[:10]} yet; "
-                  f"checking again in {poll_seconds}s ({remaining}s left)."
-              )
-              time.sleep(poll_seconds)
-          PY
+          python3 tools/ci/codex_review_gate.py

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ TOOLS.md
 world-server-rust
 world-server-rust.old
 world-server-bin
+
+# Python bytecode from the tools/ scripts (check_architecture.py, codex_review_gate.py)
+__pycache__/
+*.pyc

--- a/tools/ci/codex_review_gate.py
+++ b/tools/ci/codex_review_gate.py
@@ -79,24 +79,6 @@ def raise_for_gh_failure(result, path):
     raise RuntimeError(f"gh api {path} failed: {error}")
 
 
-def gh_json_object(path):
-    """Fetch one JSON object.
-
-    Not gh_json_pages: that passes `--jq .[]`, which on an object iterates its
-    values instead of yielding the object, so a single-resource endpoint such as
-    a commit would come back shredded into unrelated fragments.
-    """
-    result = subprocess.run(
-        ["gh", "api", path], text=True, capture_output=True
-    )
-    raise_for_gh_failure(result, path)
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError as error:
-        raise TransientGitHubApiError(
-            f"gh api {path} returned invalid JSON: {error}"
-        ) from error
-
 def review_inline_comment_count(review_id):
     return len(
         gh_json_pages(
@@ -179,74 +161,6 @@ def classify_codex_item(kind, body, inline_comments):
         return "pass"
     return None
 
-def head_transition_boundary():
-    """When this pull request took the current HEAD, as an ISO-8601 string.
-
-    Three weaker boundaries were tried and are wrong:
-
-      - the commit's committer date is author-controlled and records when the
-        commit was *written*, so a commit created at 10:00, thumbs-upped at
-        10:30 and pushed at 11:00 looks reviewed, and back-dating a force-push
-        does the same;
-      - the earliest check suite for the SHA is server-observed but belongs to
-        the SHA, not to this pull request, so a SHA already pushed to another
-        ref carries an old suite and force-pushing it here reuses that older
-        boundary;
-      - this process's own start time moves on every re-run, which would reject
-        a reaction that was valid when the run was first created -- and a re-run
-        is exactly how a timed-out gate is retried.
-
-    This run was created by the event that made this SHA the pull request's
-    head, and a re-run keeps the original creation time, so the run's own
-    created_at is both server-observed and scoped to this pull request.
-    """
-    run_id = os.environ.get("GITHUB_RUN_ID", "")
-    if not run_id:
-        return ""
-    run = gh_json_object(f"repos/{repo}/actions/runs/{run_id}")
-    return run.get("created_at") or ""
-
-
-def reaction_is_current(reaction_created_at, head_seen_at):
-    """Whether a thumbs-up can be about the current HEAD rather than an older one.
-
-    A reaction carries no commit reference at all -- unlike a review, whose body
-    states "Reviewed commit: <sha>" -- so the only thing tying it to a revision
-    is that Codex reacts after reviewing. Requiring it to postdate the moment
-    the server first saw this SHA keeps the gate from going green on unreviewed
-    code when someone pushes a fix on top of an approved commit.
-
-    The residual gap is narrow and worth stating: if Codex began reviewing the
-    previous HEAD, a push landed mid-review, and Codex then reacted, the
-    reaction postdates this SHA while describing the previous one. Nothing in
-    the reactions API can distinguish that, and Codex re-reviews on every
-    synchronize, so the next review or reaction settles it. A finding always
-    outranks a reaction, so the failure mode is a delayed pass, never a
-    suppressed finding.
-    """
-    if not reaction_created_at or not head_seen_at:
-        return False
-    return reaction_created_at > head_seen_at
-
-
-def codex_thumbs_up_for_current_head():
-    """Codex's other way of saying it found nothing: a thumbs-up, with no review.
-
-    Its own note reads "If Codex has suggestions, it will comment; otherwise it
-    will react with a thumbs up", so a gate that only reads comments and reviews
-    times out on exactly the clean case it is meant to let through.
-    """
-    head_seen_at = head_transition_boundary()
-    for reaction in gh_json_pages(f"repos/{repo}/issues/{pr_number}/reactions"):
-        if reaction.get("user", {}).get("login") not in codex_logins:
-            continue
-        if reaction.get("content") != "+1":
-            continue
-        if reaction_is_current(reaction.get("created_at", ""), head_seen_at):
-            return reaction.get("created_at", "")
-    return None
-
-
 def verdict():
     items = codex_items_for_current_head()
     classified = []
@@ -259,13 +173,6 @@ def verdict():
     if classified:
         timestamp, state, kind, url = max(classified, key=lambda item: item[0])
         return state, [(kind, url)]
-
-    # Checked only when nothing was written about this HEAD, so a real finding
-    # always outranks a thumbs-up.
-    reacted_at = codex_thumbs_up_for_current_head()
-    if reacted_at:
-        return "pass", [("thumbs-up reaction", f"reacted at {reacted_at}")]
-
     return "wait", items
 
 
@@ -367,39 +274,6 @@ def self_test():
         ),
     ]
 
-    # The boundary is when the server first saw the HEAD, never the commit's own
-    # date: a commit written locally at 10:00, thumbs-upped at 10:30 and pushed
-    # at 11:00 would otherwise look reviewed, and a back-dated force-push would
-    # too, because committer dates are author-controlled.
-    reaction_cases = [
-        (
-            "a thumbs-up after the SHA reached the server is about that SHA",
-            "2026-08-19T11:20:00Z", "2026-08-19T11:00:00Z", True,
-        ),
-        (
-            "a thumbs-up predating the push cannot be about the pushed SHA, so "
-            "pushing a fix on top of an approved commit must not stay green",
-            "2026-08-19T10:30:00Z", "2026-08-19T11:00:00Z", False,
-        ),
-        (
-            "a back-dated commit does not backdate the boundary: written 10:00, "
-            "reacted 10:30, pushed 11:00 is still unreviewed",
-            "2026-08-19T10:30:00Z", "2026-08-19T11:00:00Z", False,
-        ),
-        (
-            "a reaction exactly at the boundary is not after it",
-            "2026-08-19T11:00:00Z", "2026-08-19T11:00:00Z", False,
-        ),
-        (
-            "a missing reaction timestamp is not evidence of anything",
-            "", "2026-08-19T11:00:00Z", False,
-        ),
-        (
-            "an unknown boundary fails closed rather than passing",
-            "2026-08-19T11:20:00Z", "", False,
-        ),
-    ]
-
     failures = 0
     for name, kind, body, inline, expected in cases:
         got = classify_codex_item(kind, body, inline)
@@ -409,15 +283,7 @@ def self_test():
         else:
             print(f"ok   {expected!r:6} {name}")
 
-    for name, reacted_at, committed_at, expected in reaction_cases:
-        got = reaction_is_current(reacted_at, committed_at)
-        if got != expected:
-            failures += 1
-            print(f"FAIL expected={expected!r} got={got!r}: {name}")
-        else:
-            print(f"ok   {expected!r:6} {name}")
-
-    total = len(cases) + len(reaction_cases)
+    total = len(cases)
     if failures:
         print(f"{failures} of {total} self-test cases failed")
         return 1

--- a/tools/ci/codex_review_gate.py
+++ b/tools/ci/codex_review_gate.py
@@ -58,19 +58,43 @@ def gh_json_pages(path):
         text=True,
         capture_output=True,
     )
-    if result.returncode:
-        error = result.stderr.strip() or result.stdout.strip()
-        if (
-            re.search(r"\(HTTP (?:404|5\d\d)\)", error)
-            or "unexpected end of JSON input" in error
-        ):
-            raise TransientGitHubApiError(error)
-        raise RuntimeError(f"gh api {path} failed: {error}")
+    raise_for_gh_failure(result, path)
     try:
         return [json.loads(line) for line in result.stdout.splitlines() if line]
     except json.JSONDecodeError as error:
         raise TransientGitHubApiError(
             f"gh api {path} returned invalid paginated JSON: {error}"
+        ) from error
+
+
+def raise_for_gh_failure(result, path):
+    if not result.returncode:
+        return
+    error = result.stderr.strip() or result.stdout.strip()
+    if (
+        re.search(r"\(HTTP (?:404|5\d\d)\)", error)
+        or "unexpected end of JSON input" in error
+    ):
+        raise TransientGitHubApiError(error)
+    raise RuntimeError(f"gh api {path} failed: {error}")
+
+
+def gh_json_object(path):
+    """Fetch one JSON object.
+
+    Not gh_json_pages: that passes `--jq .[]`, which on an object iterates its
+    values instead of yielding the object, so a single-resource endpoint such as
+    a commit would come back shredded into unrelated fragments.
+    """
+    result = subprocess.run(
+        ["gh", "api", path], text=True, capture_output=True
+    )
+    raise_for_gh_failure(result, path)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise TransientGitHubApiError(
+            f"gh api {path} returned invalid JSON: {error}"
         ) from error
 
 def review_inline_comment_count(review_id):
@@ -155,6 +179,44 @@ def classify_codex_item(kind, body, inline_comments):
         return "pass"
     return None
 
+def head_commit_timestamp():
+    """When the current HEAD commit was committed, as an ISO-8601 string."""
+    commit = gh_json_object(f"repos/{repo}/commits/{head_sha}")
+    return (commit.get("commit") or {}).get("committer", {}).get("date") or ""
+
+
+def reaction_is_current(reaction_created_at, head_committed_at):
+    """Whether a thumbs-up can be about the current HEAD rather than an older one.
+
+    A reaction carries no commit reference, so the only thing tying it to a
+    revision is that Codex reacts *after* reviewing. A thumbs-up older than the
+    HEAD commit therefore cannot be about it and must not pass the gate; without
+    this the check would go green on unreviewed code every time someone pushed a
+    fix on top of an approved commit.
+    """
+    if not reaction_created_at or not head_committed_at:
+        return False
+    return reaction_created_at > head_committed_at
+
+
+def codex_thumbs_up_for_current_head():
+    """Codex's other way of saying it found nothing: a thumbs-up, with no review.
+
+    Its own note reads "If Codex has suggestions, it will comment; otherwise it
+    will react with a thumbs up", so a gate that only reads comments and reviews
+    times out on exactly the clean case it is meant to let through.
+    """
+    head_committed_at = head_commit_timestamp()
+    for reaction in gh_json_pages(f"repos/{repo}/issues/{pr_number}/reactions"):
+        if reaction.get("user", {}).get("login") not in codex_logins:
+            continue
+        if reaction.get("content") != "+1":
+            continue
+        if reaction_is_current(reaction.get("created_at", ""), head_committed_at):
+            return reaction.get("created_at", "")
+    return None
+
+
 def verdict():
     items = codex_items_for_current_head()
     classified = []
@@ -167,6 +229,13 @@ def verdict():
     if classified:
         timestamp, state, kind, url = max(classified, key=lambda item: item[0])
         return state, [(kind, url)]
+
+    # Checked only when nothing was written about this HEAD, so a real finding
+    # always outranks a thumbs-up.
+    reacted_at = codex_thumbs_up_for_current_head()
+    if reacted_at:
+        return "pass", [("thumbs-up reaction", f"reacted at {reacted_at}")]
+
     return "wait", items
 
 
@@ -268,6 +337,26 @@ def self_test():
         ),
     ]
 
+    reaction_cases = [
+        (
+            "a thumbs-up added after the HEAD commit is about that commit",
+            "2026-08-19T11:20:00Z", "2026-08-19T11:00:00Z", True,
+        ),
+        (
+            "a thumbs-up predating the HEAD commit cannot be about it, so pushing "
+            "a fix on top of an approved commit must not stay green",
+            "2026-08-19T10:00:00Z", "2026-08-19T11:00:00Z", False,
+        ),
+        (
+            "a missing reaction timestamp is not evidence of anything",
+            "", "2026-08-19T11:00:00Z", False,
+        ),
+        (
+            "an unknown HEAD commit date fails closed rather than passing",
+            "2026-08-19T11:20:00Z", "", False,
+        ),
+    ]
+
     failures = 0
     for name, kind, body, inline, expected in cases:
         got = classify_codex_item(kind, body, inline)
@@ -276,10 +365,20 @@ def self_test():
             print(f"FAIL expected={expected!r} got={got!r}: {name}")
         else:
             print(f"ok   {expected!r:6} {name}")
+
+    for name, reacted_at, committed_at, expected in reaction_cases:
+        got = reaction_is_current(reacted_at, committed_at)
+        if got != expected:
+            failures += 1
+            print(f"FAIL expected={expected!r} got={got!r}: {name}")
+        else:
+            print(f"ok   {expected!r:6} {name}")
+
+    total = len(cases) + len(reaction_cases)
     if failures:
-        print(f"{failures} of {len(cases)} self-test cases failed")
+        print(f"{failures} of {total} self-test cases failed")
         return 1
-    print(f"codex_review_gate self-test: {len(cases)} cases OK")
+    print(f"codex_review_gate self-test: {total} cases OK")
     return 0
 
 

--- a/tools/ci/codex_review_gate.py
+++ b/tools/ci/codex_review_gate.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Require a clean Codex review on a pull request's current HEAD.
+
+Extracted from `.github/workflows/codex-review-gate.yml` so the verdict logic can
+be exercised directly: run `python3 tools/ci/codex_review_gate.py --self-test`.
+The gate had been failing clean reviews, which is unmergeable-with-nothing-to-fix,
+so the classification rules are now covered by cases rather than only by the live
+run. Mirrors the repo convention of tools carrying their own self-test subcommand.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+repo = os.environ.get("REPOSITORY", "")
+pr_number = os.environ.get("PR_NUMBER", "")
+head_sha = os.environ.get("HEAD_SHA", "").lower()
+timeout_seconds = int(os.environ.get("CODEX_REVIEW_TIMEOUT_SECONDS", "1800"))
+poll_seconds = int(os.environ.get("CODEX_REVIEW_POLL_SECONDS", "30"))
+
+codex_logins = {"chatgpt-codex-connector", "chatgpt-codex-connector[bot]"}
+positive_markers = (
+    "didn't find any major issues",
+    "did not find any major issues",
+    "no major issues",
+)
+# A finding is a P-badge in the text. These are the only reliable
+# in-body evidence that Codex actually reported something.
+finding_markers = (
+    "p0 badge",
+    "p1 badge",
+    "p2 badge",
+    "p3 badge",
+)
+# Codex prints this header whenever it posts a body at all, including
+# on reviews that carry no findings, so it cannot be read as feedback
+# on its own. For issue comments there is nothing else to go on, so it
+# still counts there; for reviews the inline comment count decides.
+comment_only_finding_marker = "automated review suggestions"
+
+class TransientGitHubApiError(RuntimeError):
+    pass
+
+def gh_json_pages(path):
+    separator = "&" if "?" in path else "?"
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            f"{path}{separator}per_page=100",
+            "--jq",
+            ".[]",
+        ],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode:
+        error = result.stderr.strip() or result.stdout.strip()
+        if (
+            re.search(r"\(HTTP (?:404|5\d\d)\)", error)
+            or "unexpected end of JSON input" in error
+        ):
+            raise TransientGitHubApiError(error)
+        raise RuntimeError(f"gh api {path} failed: {error}")
+    try:
+        return [json.loads(line) for line in result.stdout.splitlines() if line]
+    except json.JSONDecodeError as error:
+        raise TransientGitHubApiError(
+            f"gh api {path} returned invalid paginated JSON: {error}"
+        ) from error
+
+def review_inline_comment_count(review_id):
+    return len(
+        gh_json_pages(
+            f"repos/{repo}/pulls/{pr_number}/reviews/{review_id}/comments"
+        )
+    )
+
+def reviewed_commits(body, fallback_commit=None):
+    commits = [
+        commit.lower()
+        for commit in re.findall(
+            r"Reviewed commit:[*\s]*`?([0-9a-fA-F]{7,40})`?",
+            body or "",
+        )
+    ]
+    if fallback_commit:
+        commits.append(fallback_commit.lower())
+    return commits
+
+def is_current_head(commit):
+    return bool(commit) and (head_sha.startswith(commit) or commit.startswith(head_sha))
+
+def codex_items_for_current_head():
+    comments = gh_json_pages(f"repos/{repo}/issues/{pr_number}/comments")
+    reviews = gh_json_pages(f"repos/{repo}/pulls/{pr_number}/reviews")
+
+    items = []
+    for item in comments:
+        if item.get("user", {}).get("login") not in codex_logins:
+            continue
+        body = item.get("body") or ""
+        if any(is_current_head(commit) for commit in reviewed_commits(body)):
+            items.append((
+                "comment",
+                body,
+                item.get("html_url", ""),
+                item.get("created_at", ""),
+                None,
+            ))
+
+    for item in reviews:
+        if item.get("user", {}).get("login") not in codex_logins:
+            continue
+        body = item.get("body") or ""
+        fallback_commit = item.get("commit_id")
+        if any(
+            is_current_head(commit)
+            for commit in reviewed_commits(body, fallback_commit)
+        ):
+            url = item.get("html_url") or item.get("_links", {}).get("html", {}).get("href", "")
+            items.append((
+                "review",
+                body,
+                url,
+                item.get("submitted_at") or item.get("updated_at") or "",
+                review_inline_comment_count(item["id"]),
+            ))
+
+    return items
+
+def classify_codex_item(kind, body, inline_comments):
+    """Decide pass/fail/unknown for one Codex item on the current HEAD.
+
+    A P-badge anywhere in the text is a finding and always fails. Beyond
+    that, a *review* is judged by whether it carries inline comments,
+    because Codex emits its "automated review suggestions" header even
+    when it found nothing: reading that header as feedback fails a clean
+    review and leaves the PR unmergeable with nothing to address. An
+    *issue comment* has no inline comments to count, so there the header
+    remains the only available signal and still counts as feedback.
+    """
+    lower_body = body.lower()
+    if any(marker in lower_body for marker in finding_markers):
+        return "fail"
+    if kind == "review":
+        return "fail" if inline_comments else "pass"
+    if comment_only_finding_marker in lower_body:
+        return "fail"
+    if any(marker in lower_body for marker in positive_markers):
+        return "pass"
+    return None
+
+def verdict():
+    items = codex_items_for_current_head()
+    classified = []
+
+    for kind, body, url, timestamp, inline_comments in items:
+        state = classify_codex_item(kind, body, inline_comments)
+        if state:
+            classified.append((timestamp, state, kind, url))
+
+    if classified:
+        timestamp, state, kind, url = max(classified, key=lambda item: item[0])
+        return state, [(kind, url)]
+    return "wait", items
+
+
+
+def main():
+    if not repo or not pr_number or not head_sha:
+        print("REPOSITORY, PR_NUMBER and HEAD_SHA must be set.")
+        return 1
+
+    print(f"Waiting for clean Codex review on PR #{pr_number} at {head_sha[:10]}")
+    print("Comment '@codex review' on the PR if the review has not started.")
+    deadline = time.time() + timeout_seconds
+
+    while True:
+        try:
+            state, items = verdict()
+        except TransientGitHubApiError as error:
+            remaining = int(deadline - time.time())
+            if remaining <= 0:
+                print(
+                    "Timed out waiting for GitHub API recovery while checking "
+                    f"the Codex verdict: {error}"
+                )
+                sys.exit(1)
+
+            retry_seconds = min(poll_seconds, remaining)
+            print(
+                "Transient GitHub API failure while checking the Codex verdict; "
+                f"retrying in {retry_seconds}s ({remaining}s left): {error}"
+            )
+            time.sleep(retry_seconds)
+            continue
+
+        if state == "pass":
+            print("Found clean Codex review for current HEAD:")
+            for kind, url in items:
+                print(f"- {kind}: {url}")
+            sys.exit(0)
+
+        if state == "fail":
+            print("Codex left review feedback for current HEAD; address it before merge:")
+            for kind, url in items:
+                print(f"- {kind}: {url}")
+            sys.exit(1)
+
+        remaining = int(deadline - time.time())
+        if remaining <= 0:
+            print(
+                "Timed out waiting for a clean Codex review on the current HEAD. "
+                "Comment '@codex review' on the PR, then rerun this job after Codex responds."
+            )
+            sys.exit(1)
+
+        print(
+            f"No clean Codex verdict for {head_sha[:10]} yet; "
+            f"checking again in {poll_seconds}s ({remaining}s left)."
+        )
+        time.sleep(poll_seconds)
+
+def self_test():
+    """Cases the live gate got wrong, plus the ones it must keep getting right."""
+    codex_header = (
+        "### Codex Review\n\nHere are some automated review suggestions for this "
+        "pull request.\n\n**Reviewed commit:** `7e32308df3`\n\n<details>"
+        "<summary>About Codex in GitHub</summary>If Codex has suggestions, it will "
+        "comment; otherwise it will react with a thumbs up.</details>"
+    )
+    cases = [
+        # (name, kind, body, inline_comments, expected)
+        (
+            "review carrying only the boilerplate header and no inline comments "
+            "is clean -- this is the case that wrongly blocked PR #212",
+            "review", codex_header, 0, "pass",
+        ),
+        (
+            "review with the same header but inline comments is feedback",
+            "review", codex_header, 3, "fail",
+        ),
+        (
+            "a P-badge outranks a zero inline count, since the finding is in the body",
+            "review", codex_header + "\n\nP1 Badge: broken rollback path", 0, "fail",
+        ),
+        (
+            "issue comment keeps the header as its only signal: no inline comments exist",
+            "comment", codex_header, None, "fail",
+        ),
+        (
+            "issue comment stating no major issues passes",
+            "comment", "I didn't find any major issues.\n**Reviewed commit:** `abc1234`",
+            None, "pass",
+        ),
+        (
+            "unrelated chatter yields no verdict, so the gate keeps waiting",
+            "comment", "Reviewing now.\n**Reviewed commit:** `abc1234`", None, None,
+        ),
+        (
+            "empty review body with no inline comments is still clean",
+            "review", "", 0, "pass",
+        ),
+    ]
+
+    failures = 0
+    for name, kind, body, inline, expected in cases:
+        got = classify_codex_item(kind, body, inline)
+        if got != expected:
+            failures += 1
+            print(f"FAIL expected={expected!r} got={got!r}: {name}")
+        else:
+            print(f"ok   {expected!r:6} {name}")
+    if failures:
+        print(f"{failures} of {len(cases)} self-test cases failed")
+        return 1
+    print(f"codex_review_gate self-test: {len(cases)} cases OK")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv[1:]:
+        sys.exit(self_test())
+    sys.exit(main())

--- a/tools/ci/codex_review_gate.py
+++ b/tools/ci/codex_review_gate.py
@@ -179,24 +179,32 @@ def classify_codex_item(kind, body, inline_comments):
         return "pass"
     return None
 
-def head_sha_first_seen_at():
-    """When GitHub first saw the current HEAD, as an ISO-8601 string.
+def head_transition_boundary():
+    """When this pull request took the current HEAD, as an ISO-8601 string.
 
-    Deliberately not the commit's committer date: that is metadata the author
-    controls and it records when the commit was *written*, not when it reached
-    the server. A commit created locally before Codex reacted and pushed after
-    it would look newer than the reaction, and force-pushing any back-dated
-    commit does the same. GitHub creates a check suite when a SHA arrives, so
-    the earliest suite for this SHA is a server-observed lower bound on when it
-    became reviewable.
+    Three weaker boundaries were tried and are wrong:
+
+      - the commit's committer date is author-controlled and records when the
+        commit was *written*, so a commit created at 10:00, thumbs-upped at
+        10:30 and pushed at 11:00 looks reviewed, and back-dating a force-push
+        does the same;
+      - the earliest check suite for the SHA is server-observed but belongs to
+        the SHA, not to this pull request, so a SHA already pushed to another
+        ref carries an old suite and force-pushing it here reuses that older
+        boundary;
+      - this process's own start time moves on every re-run, which would reject
+        a reaction that was valid when the run was first created -- and a re-run
+        is exactly how a timed-out gate is retried.
+
+    This run was created by the event that made this SHA the pull request's
+    head, and a re-run keeps the original creation time, so the run's own
+    created_at is both server-observed and scoped to this pull request.
     """
-    suites = gh_json_object(f"repos/{repo}/commits/{head_sha}/check-suites")
-    created = [
-        suite.get("created_at")
-        for suite in suites.get("check_suites", [])
-        if suite.get("created_at")
-    ]
-    return min(created) if created else ""
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    if not run_id:
+        return ""
+    run = gh_json_object(f"repos/{repo}/actions/runs/{run_id}")
+    return run.get("created_at") or ""
 
 
 def reaction_is_current(reaction_created_at, head_seen_at):
@@ -228,7 +236,7 @@ def codex_thumbs_up_for_current_head():
     will react with a thumbs up", so a gate that only reads comments and reviews
     times out on exactly the clean case it is meant to let through.
     """
-    head_seen_at = head_sha_first_seen_at()
+    head_seen_at = head_transition_boundary()
     for reaction in gh_json_pages(f"repos/{repo}/issues/{pr_number}/reactions"):
         if reaction.get("user", {}).get("login") not in codex_logins:
             continue

--- a/tools/ci/codex_review_gate.py
+++ b/tools/ci/codex_review_gate.py
@@ -179,24 +179,46 @@ def classify_codex_item(kind, body, inline_comments):
         return "pass"
     return None
 
-def head_commit_timestamp():
-    """When the current HEAD commit was committed, as an ISO-8601 string."""
-    commit = gh_json_object(f"repos/{repo}/commits/{head_sha}")
-    return (commit.get("commit") or {}).get("committer", {}).get("date") or ""
+def head_sha_first_seen_at():
+    """When GitHub first saw the current HEAD, as an ISO-8601 string.
+
+    Deliberately not the commit's committer date: that is metadata the author
+    controls and it records when the commit was *written*, not when it reached
+    the server. A commit created locally before Codex reacted and pushed after
+    it would look newer than the reaction, and force-pushing any back-dated
+    commit does the same. GitHub creates a check suite when a SHA arrives, so
+    the earliest suite for this SHA is a server-observed lower bound on when it
+    became reviewable.
+    """
+    suites = gh_json_object(f"repos/{repo}/commits/{head_sha}/check-suites")
+    created = [
+        suite.get("created_at")
+        for suite in suites.get("check_suites", [])
+        if suite.get("created_at")
+    ]
+    return min(created) if created else ""
 
 
-def reaction_is_current(reaction_created_at, head_committed_at):
+def reaction_is_current(reaction_created_at, head_seen_at):
     """Whether a thumbs-up can be about the current HEAD rather than an older one.
 
-    A reaction carries no commit reference, so the only thing tying it to a
-    revision is that Codex reacts *after* reviewing. A thumbs-up older than the
-    HEAD commit therefore cannot be about it and must not pass the gate; without
-    this the check would go green on unreviewed code every time someone pushed a
-    fix on top of an approved commit.
+    A reaction carries no commit reference at all -- unlike a review, whose body
+    states "Reviewed commit: <sha>" -- so the only thing tying it to a revision
+    is that Codex reacts after reviewing. Requiring it to postdate the moment
+    the server first saw this SHA keeps the gate from going green on unreviewed
+    code when someone pushes a fix on top of an approved commit.
+
+    The residual gap is narrow and worth stating: if Codex began reviewing the
+    previous HEAD, a push landed mid-review, and Codex then reacted, the
+    reaction postdates this SHA while describing the previous one. Nothing in
+    the reactions API can distinguish that, and Codex re-reviews on every
+    synchronize, so the next review or reaction settles it. A finding always
+    outranks a reaction, so the failure mode is a delayed pass, never a
+    suppressed finding.
     """
-    if not reaction_created_at or not head_committed_at:
+    if not reaction_created_at or not head_seen_at:
         return False
-    return reaction_created_at > head_committed_at
+    return reaction_created_at > head_seen_at
 
 
 def codex_thumbs_up_for_current_head():
@@ -206,13 +228,13 @@ def codex_thumbs_up_for_current_head():
     will react with a thumbs up", so a gate that only reads comments and reviews
     times out on exactly the clean case it is meant to let through.
     """
-    head_committed_at = head_commit_timestamp()
+    head_seen_at = head_sha_first_seen_at()
     for reaction in gh_json_pages(f"repos/{repo}/issues/{pr_number}/reactions"):
         if reaction.get("user", {}).get("login") not in codex_logins:
             continue
         if reaction.get("content") != "+1":
             continue
-        if reaction_is_current(reaction.get("created_at", ""), head_committed_at):
+        if reaction_is_current(reaction.get("created_at", ""), head_seen_at):
             return reaction.get("created_at", "")
     return None
 
@@ -337,22 +359,35 @@ def self_test():
         ),
     ]
 
+    # The boundary is when the server first saw the HEAD, never the commit's own
+    # date: a commit written locally at 10:00, thumbs-upped at 10:30 and pushed
+    # at 11:00 would otherwise look reviewed, and a back-dated force-push would
+    # too, because committer dates are author-controlled.
     reaction_cases = [
         (
-            "a thumbs-up added after the HEAD commit is about that commit",
+            "a thumbs-up after the SHA reached the server is about that SHA",
             "2026-08-19T11:20:00Z", "2026-08-19T11:00:00Z", True,
         ),
         (
-            "a thumbs-up predating the HEAD commit cannot be about it, so pushing "
-            "a fix on top of an approved commit must not stay green",
-            "2026-08-19T10:00:00Z", "2026-08-19T11:00:00Z", False,
+            "a thumbs-up predating the push cannot be about the pushed SHA, so "
+            "pushing a fix on top of an approved commit must not stay green",
+            "2026-08-19T10:30:00Z", "2026-08-19T11:00:00Z", False,
+        ),
+        (
+            "a back-dated commit does not backdate the boundary: written 10:00, "
+            "reacted 10:30, pushed 11:00 is still unreviewed",
+            "2026-08-19T10:30:00Z", "2026-08-19T11:00:00Z", False,
+        ),
+        (
+            "a reaction exactly at the boundary is not after it",
+            "2026-08-19T11:00:00Z", "2026-08-19T11:00:00Z", False,
         ),
         (
             "a missing reaction timestamp is not evidence of anything",
             "", "2026-08-19T11:00:00Z", False,
         ),
         (
-            "an unknown HEAD commit date fails closed rather than passing",
+            "an unknown boundary fails closed rather than passing",
             "2026-08-19T11:20:00Z", "", False,
         ),
     ]


### PR DESCRIPTION
Closes #216

The gate classified a review from its body text, with `"automated review
suggestions"` in the negative-marker list. That phrase is the header Codex prints
whenever it posts a body at all — including on a review that reports nothing.

PR #212's review on `7e32308df3` is a body of nothing but that header and the
About-Codex block, with **zero inline comments**. The gate answered *"Codex left
review feedback for current HEAD; address it before merge"* with nothing to
address, so the PR could not go green and could not be merged. Any PR whose
review lands in that shape is blocked the same way — this is not specific to #212.

### What changes

A review is judged by whether it actually carries findings:

- a P0–P3 badge anywhere in the text is a finding and always fails, since the
  finding is stated in the body;
- otherwise a review is decided by its **inline comment count**;
- an issue comment has no inline comments to count, so there the header stays the
  only available signal and still counts as feedback.

The gate stays strict in the direction that matters. Only the empty-review case
changes verdict — confirmed by running the old classifier and the new one against
the real #212 body: `fail` before, `pass` now.

### Why it moved out of the workflow

A gate that silently blocked a mergeable PR should not be verifiable only by
running CI. The logic is now `tools/ci/codex_review_gate.py --self-test`,
matching how `check_architecture.py` carries its own self-tests. Seven cases
cover both directions:

```
ok   'pass' review carrying only the boilerplate header and no inline comments is clean
ok   'fail' review with the same header but inline comments is feedback
ok   'fail' a P-badge outranks a zero inline count, since the finding is in the body
ok   'fail' issue comment keeps the header as its only signal: no inline comments exist
ok   'pass' issue comment stating no major issues passes
ok   None   unrelated chatter yields no verdict, so the gate keeps waiting
ok   'pass' empty review body with no inline comments is still clean
```

Verified the extraction is faithful: diffing the original heredoc against the new
file, ignoring indentation, shows only the intended edits and nothing else.

The job gains a checkout since the script is no longer inline. It takes the
script from the pull request, as `pull_request` already does for the workflow file
itself — pinning it to the base would be protection in appearance only, because a
branch can edit this workflow either way, and it would also leave the script
missing until this commit is on `3.4.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)