### PR TITLE
ci: use local validation for trusted PRs

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -22,6 +22,9 @@ concurrency:
 jobs:
   codex-review-verdict:
     name: Codex reviewer verdict
+    # First-party work uses local review when it is useful; it must not wait on
+    # a serial remote reviewer loop. External PRs retain the existing gate.
+    if: github.event.pull_request.user.login != 'alseif0x'
     runs-on: ubuntu-24.04
     timeout-minutes: 35
     steps:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   label:
     name: Label changed areas
+    if: github.event.pull_request.user.login != 'alseif0x'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/.github/workflows/qa-world-server-artifact.yml
+++ b/.github/workflows/qa-world-server-artifact.yml
@@ -20,7 +20,9 @@ concurrency:
 jobs:
   build:
     name: Build replica ${{ matrix.replica }}
-    if: contains(github.event.pull_request.labels.*.name, 'qa-artifact')
+    if: >-
+      github.event.pull_request.user.login != 'alseif0x' &&
+      contains(github.event.pull_request.labels.*.name, 'qa-artifact')
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     strategy:
@@ -113,7 +115,9 @@ jobs:
 
   verify:
     name: Verify replica hashes
-    if: contains(github.event.pull_request.labels.*.name, 'qa-artifact')
+    if: >-
+      github.event.pull_request.user.login != 'alseif0x' &&
+      contains(github.event.pull_request.labels.*.name, 'qa-artifact')
     needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - "3.4.3"
-  push:
-    branches:
-      - "3.4.3"
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:
@@ -25,6 +22,9 @@ env:
 jobs:
   fmt:
     name: Format
+    # Trusted first-party PRs are validated by tools/local-harness.sh. Keep the
+    # required check visible as skipped without allocating a hosted runner.
+    if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'alseif0x'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -53,6 +53,7 @@ jobs:
 
   check:
     name: Check core crates
+    if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'alseif0x'
     runs-on: ubuntu-24.04
     # The exact persistence inventory is intentionally scanned both by its
     # repository test and by the boundary command before the core build. A
@@ -179,6 +180,7 @@ jobs:
 
   tests:
     name: Focused library tests
+    if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'alseif0x'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:

--- a/.github/workflows/wow-database-live.yml
+++ b/.github/workflows/wow-database-live.yml
@@ -10,15 +10,6 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "crates/wow-database/**"
-  push:
-    branches:
-      - "3.4.3"
-    paths:
-      - ".github/workflows/wow-database-live.yml"
-      - "rust-toolchain.toml"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/wow-database/**"
   workflow_dispatch:
 
 permissions:
@@ -31,6 +22,7 @@ concurrency:
 jobs:
   live-db-updater:
     name: DbUpdater populate/update against MariaDB 10.6
+    if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'alseif0x'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
 

--- a/README.md
+++ b/README.md
@@ -218,17 +218,23 @@ PROTOC=/path/to/protoc cargo check -p world-server
 git diff --check
 ```
 
-The local preflight mirrors GitHub's required Rust commands and is the recommended gate before
-pushing. Use `quick` while iterating and `full` after committing to a clean HEAD:
+First-party development uses the path-scoped local harness. Use `quick` while iterating and
+`final` once before publishing the completed commit:
 
 ```bash
-./tools/pr-preflight.sh quick
-./tools/pr-preflight.sh full origin/3.4.3
+./tools/local-harness.sh quick
+./tools/local-harness.sh final origin/3.4.3
 ```
 
-`full` reproduces the required Rust CI commands, runs the committed capture-diff gate, and invokes
-a read-only local Codex review. It does not replace the required GitHub reviewer verdict. See
-[`docs/operations/pr-preflight.md`](docs/operations/pr-preflight.md) for profiles and safety bounds.
+The harness is non-interactive and agent-agnostic: humans, Kimi, Codex, Grok, Claude, and other
+agents use the same commands. The remote trust decision depends only on the PR author's exact
+GitHub login.
+
+Pull requests authored by `alseif0x` allocate no remote validation runners; external PRs retain
+the full hosted checks. The exhaustive preflight remains available for explicit audits and live
+QA, not daily iteration. See
+[`docs/operations/local-first-development.md`](docs/operations/local-first-development.md) and
+[`docs/operations/pr-preflight.md`](docs/operations/pr-preflight.md).
 
 Inventory TSV files are part of the migration state. Keep their column counts valid:
 
@@ -250,8 +256,9 @@ Every meaningful gameplay change should follow this shape:
 6. Update migration docs and inventories.
 7. Run checks.
 8. Commit the slice on its issue-linked feature branch.
-9. Run `./tools/pr-preflight.sh full origin/3.4.3` on the clean committed HEAD.
-10. Push and open a PR into `3.4.3`; merge only after every required remote check passes.
+9. Run `./tools/local-harness.sh final origin/3.4.3`.
+10. Push and open a PR into `3.4.3`. First-party remote jobs are intentionally skipped; external
+    contributions must pass every required hosted check.
 
 Do not bulk-close rows. Do not mark a runtime feature complete just because a packet parser exists. Do not trust existing Rust code just because it compiles.
 

--- a/docs/operations/local-first-development.md
+++ b/docs/operations/local-first-development.md
@@ -1,0 +1,87 @@
+# Local-first development
+
+RustyCore uses a trusted-author split so first-party development is not serialized by hosted CI.
+The policy is intentionally narrow:
+
+- a pull request authored by exactly `alseif0x` allocates no GitHub-hosted validation runner;
+- every other author, including bots and collaborators, keeps the existing remote checks;
+- scheduled and manually dispatched workflows remain available for broad audits;
+- first-party validation is local and proportional to the changed paths.
+
+The harness is agent-agnostic. Kimi, Codex, Grok, Claude, any other AI agent, and a human
+maintainer all invoke the same non-interactive command and receive the same process exit status.
+Trust is derived only from the GitHub PR author's exact login; it is never derived from the tool
+that wrote the code.
+
+GitHub still creates the required check names for a trusted pull request, but their jobs are
+evaluated as `skipped` before a runner is assigned. This preserves the existing protection for
+external contributions without spending hosted compute or waiting for a remote review on normal
+maintainer work.
+
+## Daily harness
+
+Use the lightweight harness instead of `tools/pr-preflight.sh` during normal development:
+
+```bash
+./tools/local-harness.sh quick
+```
+
+`quick` collects committed, staged, unstaged, and untracked paths relative to `origin/3.4.3`, then
+runs only applicable checks:
+
+- whitespace checks for the current diff;
+- `bash -n` for changed shell scripts;
+- `jq empty` for changed JSON;
+- Rust formatting only when Rust inputs changed;
+- `cargo check --locked` only for directly affected workspace packages;
+- fast standalone checker tests only when that checker changed;
+- the QA bot's own format/check only when the bot changed.
+
+It never runs the workspace-wide persistence inventory, capture QA, a live database, the full
+workspace suite, or Codex review.
+
+Before publishing the final commit, run:
+
+```bash
+./tools/local-harness.sh final origin/3.4.3
+```
+
+`final` adds library tests only for directly affected workspace packages. Binary-only packages
+retain their successful `cargo check` as the local gate. This is evidence for the maintainer, not
+a status published back to GitHub.
+
+The harness supports a routing-only dry run:
+
+```bash
+LOCAL_HARNESS_DRY_RUN=1 ./tools/local-harness.sh quick origin/3.4.3
+```
+
+It does not require an agent SDK, a model-specific CLI, prompts, or interactive input. Agents can
+inspect the stable command interface with `./tools/local-harness.sh --help` and must treat a
+non-zero exit status as a failed local gate.
+
+## What remains exhaustive
+
+`tools/pr-preflight.sh` remains available for an explicitly requested audit, release preparation,
+capture QA, or investigation of an architecture boundary. It is not the daily pre-push gate and
+its local Codex review is optional.
+
+Broad remote validation runs only in these cases:
+
+- a pull request whose author is not `alseif0x`;
+- the scheduled Rust CI audit;
+- an explicit `workflow_dispatch` run.
+
+A failure in a scheduled audit should produce a focused issue. It does not retroactively turn
+every intermediate first-party commit into a review cycle.
+
+## Trust boundary
+
+Do not broaden the trusted condition to `COLLABORATOR`, `MEMBER`, or an author-association class.
+The exact login allowlist is deliberate. External code continues to run under the existing
+read-only pull-request workflows and required checks. Switching from one local AI agent to another
+does not change either side of this boundary.
+
+If another first-party identity is added later, update every trusted-author condition and this
+document in one reviewed change. The local harness must remain the same command for humans and
+agents so the fast path does not fork into undocumented personal procedures.

--- a/docs/operations/pr-preflight.md
+++ b/docs/operations/pr-preflight.md
@@ -1,9 +1,13 @@
-# Local PR preflight and Codex review
+# Exhaustive local PR preflight and Codex review
 
-The local preflight catches deterministic CI failures and review findings before a branch is
-pushed. Its profiles mirror the required Rust CI jobs. GitHub keeps the enforcing Cargo commands
-inline in the workflow so changing a pull request's local wrapper cannot silently weaken a
-required check.
+This is the explicit exhaustive/audit harness. Normal first-party development uses the smaller,
+path-scoped `tools/local-harness.sh`; see
+[`local-first-development.md`](local-first-development.md). Do not run `quick` or `full` from this
+script on every ordinary change.
+
+The exhaustive preflight remains useful for release preparation, architecture investigations,
+capture QA, and deliberately requested full reviews. Its profiles mirror the hosted commands that
+remain mandatory for untrusted pull requests.
 
 The entry point is:
 
@@ -229,29 +233,23 @@ calls suppress `bash -x` so credentials and `MYSQL_PWD` cannot enter logs.
 
 ## Recommended maintainer flow
 
-During implementation, run focused tests and optionally review the uncommitted patch:
+During normal first-party implementation, use the path-scoped harness:
 
 ```bash
-./tools/pr-preflight.sh quick
-./tools/pr-preflight.sh review-uncommitted
+./tools/local-harness.sh quick
 ```
 
-Commit locally before the final pre-push pass. The clean tree matters because it makes the local
-review target the same committed diff that GitHub will see:
+Run its final mode once before publishing the completed commit:
 
 ```bash
 git fetch origin
 git commit
-./tools/pr-preflight.sh full origin/3.4.3
+./tools/local-harness.sh final origin/3.4.3
 ```
 
-If Codex reports findings, fix them, amend or add the appropriate behavior-complete commit, and
-rerun `full`. Push only after it passes. Then open the PR into `3.4.3`; GitHub still runs the same
-deterministic command lists and requires its independent Codex review on the exact remote HEAD.
-
-Local review does **not** satisfy branch protection and can differ from the GitHub reviewer because
-the model run and context are independent. Its purpose is to remove avoidable push/review/fix
-cycles, not to create a maintainer bypass.
+Use this exhaustive script only when the issue or maintainer explicitly requires one of its
+specialized profiles. Remote validation and Codex review remain mandatory for PR authors other
+than `alseif0x`; trusted first-party jobs are skipped before runner allocation.
 
 ## Codex review behavior
 
@@ -278,7 +276,7 @@ Exit status:
 Review artifacts are deleted after a clean result. They are retained and printed when review fails.
 Set `CODEX_REVIEW_KEEP_ARTIFACTS=1` to retain them after a clean review as well.
 
-## CI source of truth
+## External CI source of truth
 
 `.github/workflows/rust-ci.yml` executes the required Cargo commands directly. These local
 profiles mirror the workflow-owned command lists:
@@ -291,8 +289,7 @@ Focused library tests <-> ./tools/pr-preflight.sh test
 Latest stable         <-> ./tools/pr-preflight.sh stable
 ```
 
-When a required command changes, update the workflow and its matching local profile together. The
-workflow is authoritative for branch protection; `Check core crates` executes the architecture
-checker directly and `Format` also runs the harness self-test, but no required job trusts the pull
-request's wrapper as its sole enforcement path. The `quick`, `ci`, and `full` aggregate profiles
-include `architecture`.
+When an externally required command changes, update the workflow and its matching exhaustive
+profile together. These jobs are authoritative for untrusted PRs. Trusted first-party work uses
+`tools/local-harness.sh` instead; `quick`, `ci`, and `full` here continue to include architecture
+only for explicit exhaustive runs.

--- a/tools/local-harness.sh
+++ b/tools/local-harness.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEFAULT_BASE="origin/3.4.3"
+MODE="${1:-}"
+BASE="${2:-$DEFAULT_BASE}"
+DRY_RUN="${LOCAL_HARNESS_DRY_RUN:-0}"
+
+usage() {
+  cat <<'EOF'
+RustyCore lightweight local development harness
+
+Non-interactive and agent-agnostic: humans, Kimi, Codex, Grok, Claude, and other
+agents use the same commands and receive the same exit status.
+
+Usage:
+  ./tools/local-harness.sh quick [BASE]
+  ./tools/local-harness.sh final [BASE]
+  ./tools/local-harness.sh self-test
+  ./tools/local-harness.sh --help
+
+quick
+  Whitespace, changed JSON/shell files, Rust formatting, and cargo check only
+  for directly affected workspace crates.
+
+final
+  Everything in quick plus library tests for directly affected crates. Slow
+  workspace-wide inventories, live databases, capture QA, and Codex review are
+  intentionally excluded from the daily development path.
+
+BASE defaults to origin/3.4.3.
+Set LOCAL_HARNESS_DRY_RUN=1 to print routed commands without executing them.
+EOF
+}
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 64
+}
+
+print_command() {
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+}
+
+run() {
+  print_command "$@"
+  if [[ "$DRY_RUN" != "1" ]]; then
+    "$@"
+  fi
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local label="$3"
+  [[ "$actual" == "$expected" ]] || die \
+    "self-test failed for $label: expected '$expected', got '$actual'"
+}
+
+path_kind() {
+  local path="$1"
+  case "$path" in
+    crates/*) printf 'workspace-rust' ;;
+    tools/architecture/handler-contract-check/*) printf 'architecture-checker' ;;
+    tools/wow-test-bot/*) printf 'wow-test-bot' ;;
+    *.rs|Cargo.toml|Cargo.lock|rust-toolchain.toml|.protoc-version|proto/*|*/build.rs)
+      printf 'workspace-rust'
+      ;;
+    *.sh) printf 'shell' ;;
+    *.json) printf 'json' ;;
+    .github/workflows/*.yml|.github/workflows/*.yaml) printf 'workflow' ;;
+    *) printf 'other' ;;
+  esac
+}
+
+self_test() {
+  assert_eq "$(path_kind docs/migration/STATE.md)" other "documentation routing"
+  assert_eq "$(path_kind crates/wow-world/src/session.rs)" workspace-rust \
+    "workspace crate routing"
+  assert_eq "$(path_kind tools/architecture/handler-contract-check/src/lib.rs)" \
+    architecture-checker "standalone architecture checker routing"
+  assert_eq "$(path_kind tools/wow-test-bot/src/main.rs)" wow-test-bot \
+    "standalone bot routing"
+  assert_eq "$(path_kind tools/pr-preflight.sh)" shell "shell routing"
+  assert_eq "$(path_kind tools/architecture/session-ownership-policy.json)" json \
+    "JSON routing"
+  assert_eq "$(path_kind .github/workflows/rust-ci.yml)" workflow \
+    "workflow routing"
+  log "Local harness self-test passed"
+}
+
+if [[ "$MODE" == "--help" || "$MODE" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "$MODE" == "self-test" ]]; then
+  (($# == 1)) || die "self-test does not accept a base"
+  self_test
+  exit 0
+fi
+
+[[ "$MODE" == "quick" || "$MODE" == "final" ]] || {
+  usage >&2
+  exit 64
+}
+(($# <= 2)) || die "too many arguments"
+
+cd "$REPO_ROOT"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git worktree"
+git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1 || die \
+  "base '$BASE' is unavailable; fetch it or pass another base"
+
+merge_base="$(git merge-base "$BASE" HEAD)"
+mapfile -t changed_files < <(
+  {
+    git diff --name-only "$merge_base"..HEAD
+    git diff --name-only --cached
+    git diff --name-only
+    git ls-files --others --exclude-standard
+  } | awk 'NF' | sort -u
+)
+
+if ((${#changed_files[@]} == 0)); then
+  log "No changes relative to $BASE"
+  exit 0
+fi
+
+log "Changed paths (${#changed_files[@]})"
+printf '  %s\n' "${changed_files[@]}"
+
+log "Whitespace checks"
+run git diff --check "$merge_base"..HEAD
+run git diff --check --cached
+run git diff --check
+
+declare -A crate_dirs=()
+declare -a shell_files=()
+declare -a json_files=()
+workspace_rust=0
+root_rust_scope=0
+architecture_checker=0
+wow_test_bot=0
+workflow_changed=0
+local_harness_changed=0
+
+for path in "${changed_files[@]}"; do
+  [[ "$path" == "tools/local-harness.sh" ]] && local_harness_changed=1
+  case "$(path_kind "$path")" in
+    workspace-rust)
+      workspace_rust=1
+      if [[ "$path" == crates/*/* ]]; then
+        remainder="${path#crates/}"
+        crate_dirs["${remainder%%/*}"]=1
+      else
+        root_rust_scope=1
+      fi
+      ;;
+    architecture-checker) architecture_checker=1 ;;
+    wow-test-bot) wow_test_bot=1 ;;
+    shell)
+      [[ -f "$path" ]] && shell_files+=("$path")
+      ;;
+    json)
+      [[ -f "$path" ]] && json_files+=("$path")
+      ;;
+    workflow) workflow_changed=1 ;;
+  esac
+done
+
+if ((local_harness_changed == 1)); then
+  self_test
+fi
+
+if ((${#shell_files[@]} > 0)); then
+  log "Changed shell syntax"
+  for path in "${shell_files[@]}"; do
+    run bash -n "$path"
+  done
+fi
+
+if ((${#json_files[@]} > 0)); then
+  command -v jq >/dev/null 2>&1 || die "jq is required to validate changed JSON"
+  log "Changed JSON syntax"
+  for path in "${json_files[@]}"; do
+    run jq empty "$path"
+  done
+fi
+
+if ((workflow_changed == 1)); then
+  log "Changed workflow syntax"
+  if command -v actionlint >/dev/null 2>&1; then
+    run actionlint
+  else
+    printf 'warning: actionlint is not installed; workflow execution remains disabled for trusted PRs\n' >&2
+  fi
+fi
+
+if ((workspace_rust == 1 || architecture_checker == 1 || wow_test_bot == 1)); then
+  if [[ -x /home/cdmonio/.local/protoc/bin/protoc ]]; then
+    export PROTOC=/home/cdmonio/.local/protoc/bin/protoc
+  elif command -v protoc >/dev/null 2>&1; then
+    export PROTOC="$(command -v protoc)"
+  fi
+fi
+
+if ((workspace_rust == 1)); then
+  log "Workspace Rust formatting"
+  run cargo +1.88.0 fmt --all --check
+fi
+
+if ((architecture_checker == 1)); then
+  log "Architecture checker formatting and fast tests"
+  run cargo +1.88.0 fmt \
+    --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- --check
+  run cargo +1.88.0 test --locked \
+    --manifest-path tools/architecture/handler-contract-check/Cargo.toml --lib -- \
+    --skip repository_surface_can_be_collected
+fi
+
+if ((wow_test_bot == 1)); then
+  log "QA bot formatting and check"
+  run cargo +1.88.0 fmt --manifest-path tools/wow-test-bot/Cargo.toml -- --check
+  run cargo +1.88.0 check --locked --manifest-path tools/wow-test-bot/Cargo.toml
+fi
+
+declare -A packages=()
+metadata=''
+if ((workspace_rust == 1)); then
+  metadata="$(cargo metadata --no-deps --format-version 1)"
+  for crate_dir in "${!crate_dirs[@]}"; do
+    manifest="$REPO_ROOT/crates/$crate_dir/Cargo.toml"
+    [[ -f "$manifest" ]] || continue
+    package="$(jq -r --arg manifest "$manifest" \
+      '.packages[] | select(.manifest_path == $manifest) | .name' <<<"$metadata")"
+    [[ -n "$package" ]] || die "cannot map crates/$crate_dir to a Cargo package"
+    packages["$package"]=1
+  done
+  if ((root_rust_scope == 1)); then
+    packages[bnet-server]=1
+    packages[world-server]=1
+  fi
+fi
+
+if ((${#packages[@]} > 0)); then
+  mapfile -t package_names < <(printf '%s\n' "${!packages[@]}" | sort)
+  cargo_package_args=()
+  for package in "${package_names[@]}"; do
+    cargo_package_args+=(--package "$package")
+  done
+  log "Cargo check for affected packages: ${package_names[*]}"
+  run cargo +1.88.0 check --locked "${cargo_package_args[@]}"
+
+  if [[ "$MODE" == "final" ]]; then
+    for package in "${package_names[@]}"; do
+      has_lib="$(jq -r --arg package "$package" '
+        [.packages[] | select(.name == $package) | .targets[].kind[]]
+        | any(. == "lib" or . == "proc-macro")
+      ' <<<"$metadata")"
+      if [[ "$has_lib" == "true" ]]; then
+        log "Library tests for affected package: $package"
+        run cargo +1.88.0 test --locked --package "$package" --lib
+      else
+        log "No library target for $package; cargo check is the final local gate"
+      fi
+    done
+  fi
+fi
+
+if [[ "$MODE" == "final" ]]; then
+  log "Final local harness passed"
+else
+  log "Quick local harness passed"
+fi

--- a/tools/pr-preflight.sh
+++ b/tools/pr-preflight.sh
@@ -27,7 +27,7 @@ QA_LOOT_RACE_PRE_READY_MARGIN_SECONDS=120
 
 usage() {
   cat <<'EOF'
-RustyCore local PR preflight
+RustyCore exhaustive local PR preflight
 
 Usage:
   ./tools/pr-preflight.sh [OPTIONS] <COMMAND> [BASE]
@@ -55,7 +55,8 @@ Commands:
   qa-login            Run the existing live login bot; requires --allow-runtime-qa.
   qa-loot-race        Run destructive live two-session loot QA; requires both QA flags.
 
-BASE defaults to origin/3.4.3. The GitHub Codex reviewer verdict remains required.
+BASE defaults to origin/3.4.3. Normal first-party development should use
+./tools/local-harness.sh; remote Codex review remains required only for external PR authors.
 EOF
 }
 


### PR DESCRIPTION
## Summary

- skip hosted CI, labeling, artifact builds, live DB checks, and the Codex gate for PRs authored by exact login `alseif0x`
- preserve the existing hosted validation for every external or bot-authored PR
- add a non-interactive, path-scoped local harness shared by Kimi, Codex, Grok, Claude, other agents, and humans
- retain scheduled/manual exhaustive audits outside the normal first-party development loop

## Local validation

- `./tools/local-harness.sh self-test`
- `./tools/local-harness.sh quick origin/3.4.3`
- `./tools/local-harness.sh final origin/3.4.3`
- `bash -n tools/local-harness.sh tools/pr-preflight.sh`
- `actionlint` on all five changed workflows
- `git diff --check`

Closes #221