### PR TITLE
[BUILD] Upgrade Rust toolchain to 1.98.0

### DIFF
--- a/.github/workflows/qa-world-server-artifact.yml
+++ b/.github/workflows/qa-world-server-artifact.yml
@@ -40,10 +40,12 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        # This is dtolnay/rust-toolchain's generated 1.88.0 commit: its
-        # action.yml embeds `env.toolchain: 1.88.0` and exposes no toolchain
-        # input. The immutable SHA therefore retains the former @1.88.0 pin.
-        uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0 # 1.88.0
+        # With no toolchain input this action installs the exact repository
+        # pin from rust-toolchain.toml.
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+          rustflags: ""
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -78,14 +80,12 @@ jobs:
       - name: Build no-LTO release artifacts
         env:
           CARGO_BUILD_JOBS: "1"
-          CARGO_INCREMENTAL: "0"
-          RUST_MIN_STACK: "268435456"
           CARGO_PROFILE_RELEASE_INCREMENTAL: "false"
           CARGO_PROFILE_RELEASE_LTO: "false"
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
         run: |
-          cargo +1.88.0 build --locked --release -p world-server --bin world-server
-          cargo +1.88.0 build --locked --release \
+          cargo build --locked --release -p world-server --bin world-server
+          cargo build --locked --release \
             --manifest-path tools/wow-test-bot/Cargo.toml \
             --bin wow-test-bot
 
@@ -100,7 +100,7 @@ jobs:
           install -D -m 0755 tools/wow-test-bot/target/release/wow-test-bot qa-artifact/wow-test-bot
           sha256sum qa-artifact/world-server | awk '{print $1}' > qa-artifact/world-server.sha256
           sha256sum qa-artifact/wow-test-bot | awk '{print $1}' > qa-artifact/wow-test-bot.sha256
-          rustc +1.88.0 --version --verbose > qa-artifact/rustc-version.txt
+          rustc --version --verbose > qa-artifact/rustc-version.txt
           printf '%s\n' "$actual_head" > qa-artifact/git-head.txt
           printf '%s\n' "$REPLICA" > qa-artifact/replica.txt
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -17,14 +17,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  # 1 GiB, kept as headroom rather than as a diagnosis. The exact-inventory
-  # analyzer was crashing locally and a single run at this budget succeeded,
-  # which looked like a stack overflow; it was not. The same crash reproduces
-  # with an unlimited stack and with the triggering changes reverted, so the
-  # cause was the authoring machine's memory fault and that one success was
-  # luck. The budget is harmless and this note exists so the next reader does
-  # not inherit the wrong conclusion.
-  RUST_MIN_STACK: "1073741824"
 
 jobs:
   fmt:
@@ -42,9 +34,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
-          components: rustfmt
+          cache: false
+          rustflags: ""
 
       - name: Install preflight dependencies
         run: sudo apt-get update && sudo apt-get install --yes ripgrep
@@ -54,9 +47,9 @@ jobs:
 
       - name: Check formatting
         run: |
-          cargo +1.88.0 fmt --all --check
-          cargo +1.88.0 fmt --manifest-path tools/wow-test-bot/Cargo.toml -- --check
-          cargo +1.88.0 fmt --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- --check
+          cargo fmt --all --check
+          cargo fmt --manifest-path tools/wow-test-bot/Cargo.toml -- --check
+          cargo fmt --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- --check
 
   check:
     name: Check core crates
@@ -68,8 +61,6 @@ jobs:
     # core build and clippy steps exhausted a 60-minute budget exactly; keep
     # every intentional validation and give the job room instead.
     timeout-minutes: 120
-    env:
-      CARGO_INCREMENTAL: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -78,9 +69,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
-          components: clippy
+          cache: false
+          rustflags: ""
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -103,9 +95,9 @@ jobs:
           # ratchet step below already performs. Skip it here: the ratchet
           # validates the collected surface against the checked snapshot, so
           # running it twice bought no coverage and doubled the wait.
-          cargo +1.88.0 test --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml \
+          cargo test --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml \
             -- --skip repository_surface_can_be_collected
-          cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- check
+          cargo run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- check
 
       # Pull requests ratchet the session surface only — seconds. The exact
       # persistence inventory is an 11-minute scan that was 72% of this job,
@@ -117,7 +109,7 @@ jobs:
       - name: Ratchet the session ownership surface
         if: github.event_name == 'pull_request'
         run: |
-          cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml \
+          cargo run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml \
             --bin session-ownership-check -- check --syntax-only
 
       # The combined check compares the session surface before the persistence
@@ -129,7 +121,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           set +e
-          report="$(cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml --bin session-ownership-check -- check 2>&1)"
+          report="$(cargo run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml --bin session-ownership-check -- check 2>&1)"
           status=$?
           printf '%s\n' "$report"
           if [ "$status" -ne 0 ] && printf '%s' "$report" | grep -q "direct persistence"; then
@@ -145,7 +137,7 @@ jobs:
       - name: Publish recomputed persistence baseline
         if: failure() && steps.ratchets.outputs.persistence_mismatch == 'true'
         run: |
-          cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml \
+          cargo run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml \
             --bin session-ownership-check -- print-persistence-baseline \
             > "${RUNNER_TEMP}/persistence-access-snapshot.json"
           # The semantic policy is a pure function of the reviewed annotations
@@ -154,7 +146,7 @@ jobs:
           # author a policy that the next run rejects as stale — and a stale
           # policy never reaches this step, because only a persistence
           # mismatch does.
-          cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml \
+          cargo run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml \
             --bin session-ownership-check -- print-persistence-policy \
             --from-snapshot "${RUNNER_TEMP}/persistence-access-snapshot.json" \
             > "${RUNNER_TEMP}/persistence-boundary-policy.json"
@@ -176,13 +168,13 @@ jobs:
           # wow-world, and bnet-server on wow-database. Checking them first
           # compiled the same crates twice. wow-test-bot stays: it is outside
           # the workspace and nothing else builds it.
-          cargo +1.88.0 check --locked --manifest-path tools/wow-test-bot/Cargo.toml
+          cargo check --locked --manifest-path tools/wow-test-bot/Cargo.toml
           # `-j1` was introduced to stop two large debug binaries from linking
           # concurrently, but it also serialized every dependency compile in the
           # job. Link one server at a time instead and keep bounded parallelism
           # inside each: same peak-memory protection, without the serial build.
-          cargo +1.88.0 build --locked -j4 -p bnet-server
-          cargo +1.88.0 build --locked -j4 -p world-server
+          cargo build --locked -j4 -p bnet-server
+          cargo build --locked -j4 -p world-server
 
 
   tests:
@@ -190,14 +182,15 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'alseif0x'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    env:
-      CARGO_INCREMENTAL: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
+        with:
+          cache: false
+          rustflags: ""
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -214,19 +207,19 @@ jobs:
 
       - name: Run focused library and loot-race harness tests
         run: |
-          cargo +1.88.0 test --locked -p wow-data --lib
-          cargo +1.88.0 test --locked -p wow-handler --test inventory_registry
-          cargo +1.88.0 test --locked -p wow-packet --lib
-          cargo +1.88.0 test --locked -p wow-loot --lib
-          cargo +1.88.0 test --locked -p wow-entities --lib
-          cargo +1.88.0 test --locked -p wow-map --lib
-          cargo +1.88.0 test --locked -p wow-network --lib
-          cargo +1.88.0 test --locked -p wow-world --lib
-          cargo +1.88.0 test --locked -p wow-world --test production_handler_registry_contract
-          cargo +1.88.0 test --locked --manifest-path tools/wow-test-bot/Cargo.toml loot_race::tests
-          cargo +1.88.0 test --locked -p capture-diff
-          cargo +1.88.0 run --locked -p capture-diff -- verify-required loot-single-item-claim
-          cargo +1.88.0 run --locked -p capture-diff -- verify-required creature-spell-casting
+          cargo test --locked -p wow-data --lib
+          cargo test --locked -p wow-handler --test inventory_registry
+          cargo test --locked -p wow-packet --lib
+          cargo test --locked -p wow-loot --lib
+          cargo test --locked -p wow-entities --lib
+          cargo test --locked -p wow-map --lib
+          cargo test --locked -p wow-network --lib
+          cargo test --locked -p wow-world --lib
+          cargo test --locked -p wow-world --test production_handler_registry_contract
+          cargo test --locked --manifest-path tools/wow-test-bot/Cargo.toml loot_race::tests
+          cargo test --locked -p capture-diff
+          cargo run --locked -p capture-diff -- verify-required loot-single-item-claim
+          cargo run --locked -p capture-diff -- verify-required creature-spell-casting
 
   clippy:
     name: Clippy advisory sweep
@@ -239,16 +232,15 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    env:
-      CARGO_INCREMENTAL: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
-          components: clippy
+          cache: false
+          rustflags: ""
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -266,10 +258,10 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Clippy loot authority boundary
-        run: cargo +1.88.0 clippy --locked --no-deps --message-format short -p wow-loot -p wow-entities -p wow-map -p wow-network --lib
+        run: cargo clippy --locked --no-deps --message-format short -p wow-loot -p wow-entities -p wow-map -p wow-network --lib
 
       - name: Clippy world target with inherited debt capped
-        run: cargo +1.88.0 clippy --locked --no-deps --message-format short -p wow-world --lib -- --cap-lints warn
+        run: cargo clippy --locked --no-deps --message-format short -p wow-world --lib -- --cap-lints warn
 
   latest-stable:
     name: Latest stable compatibility

--- a/.github/workflows/wow-database-live.yml
+++ b/.github/workflows/wow-database-live.yml
@@ -44,7 +44,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
+        with:
+          cache: false
+          rustflags: ""
 
       - name: Install MySQL-compatible client
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ RustyCore is a Rust port of a TrinityCore-derived World of Warcraft Wrath/Cata-c
   is feature branches → PR into `3.4.3`; releases are tags on `3.4.3`.
 - `main` is retained as an optional stable pointer (ff-advanced at release checkpoints); it is no
   longer the default and not used for day-to-day work. A pre-rebrand backup is `backup/pre-3.4.3-rebrand`.
-- Rust toolchain: Rust 1.88, edition 2024.
+- Rust toolchain: Rust 1.98.0, edition 2024.
 - `protoc`: `/home/cdmonio/.local/protoc/bin/protoc`
 
 Do not trust existing Rust, old AI summaries, or migration docs as correctness proof. Always contrast behavior against the C++ source before implementing or approving a change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ exclude = [
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.98"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/user/rustycore"
 
@@ -197,28 +197,6 @@ missing_panics_doc = "allow"
 # This workspace's combined type DWARF exceeds GNU ld's 32-bit debug
 # relocations. Line tables keep useful backtraces without that linker input.
 debug = 1
-
-[profile.test]
-# Keep line tables for useful backtraces without emitting the complete type
-# DWARF that triggers LLVM 20 codegen failures on the large test crates.
-debug = 1
-
-[profile.test.package.wow-world]
-# The monolithic wow-world lib-test still crashes Rust 1.88/LLVM 20 while
-# finalizing even line-table-only debug data. Keep the rest of the workspace
-# at line tables, but compile this one test package without DWARF.
-debug = 0
-
-[profile.dev.package.wow-world]
-# Full dev DWARF for this crate exceeds the linker's 32-bit debug relocation
-# range once linked into world-server. Keep debuginfo for smaller packages.
-debug = 0
-
-[profile.dev.package.world-server]
-# The monolithic server binary crashes Rust 1.88/LLVM 20 during the
-# CI-equivalent linked debug build even with line-table-only DWARF. Keep
-# debuginfo for smaller dependencies, but omit it here until the binary is split.
-debug = 0
 
 [profile.release]
 lto = "thin"

--- a/MIGRATION_STATUS.md
+++ b/MIGRATION_STATUS.md
@@ -4,7 +4,7 @@
 
 **Proyecto**: rustycore — Migración de RustyCore (WoW 3.4.3.54261) de C# a Rust
 **Dominio**: wowchad.work.gd
-**Rust Version**: 1.88 (edition 2024)
+**Rust Version**: 1.98.0 (edition 2024)
 **Ubicación**: `/home/server/woltk-server-core/rustycore/`
 **Referencia C#**: `/home/server/woltk-server-core/Source/`
 **Estado General**: ~35% — infraestructura lista, jugador en mundo, combat/movement/loot funcional

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **WoW Wrath of the Lich King Classic (3.4.3.54261) server emulator written in Rust.**
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Rust](https://img.shields.io/badge/Rust-1.88%2B-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/Rust-1.98%2B-orange.svg)](https://www.rust-lang.org)
 [![Target](https://img.shields.io/badge/WotLK%20Classic-3.4.3.54261-blueviolet.svg)](#)
 [![Discord](https://img.shields.io/badge/Discord-Join%20the%20community-5865F2.svg)](https://discord.gg/mH6ACpGPb2)
 
@@ -72,7 +72,7 @@ That split is a migration bridge, not the final design.
 
 ## Tech Stack
 
-- **Rust 1.88+** — edition 2024
+- **Rust 1.98+** — edition 2024
 - **Tokio** — async runtime and networking
 - **Axum** — Battle.net REST API
 - **SQLx + MariaDB** — login/auth, characters, world, and hotfix databases
@@ -117,7 +117,7 @@ MIGRATION_STATUS.md  Older high-level migration status
 
 ## Requirements
 
-- Rust `1.88+`
+- Rust `1.98+`
 - MariaDB `10.6+`
 - `protoc` for protobuf-dependent crates; set `PROTOC` if it is not available on `PATH`
 - A WotLK Classic `3.4.3.54261` client for manual testing

--- a/crates/capture-diff/README.md
+++ b/crates/capture-diff/README.md
@@ -113,7 +113,7 @@ The rested-XP gate isolates the first kill reward packet from the complete bot
 round-trip:
 
 ```bash
-cargo +1.88.0 run -q -p capture-diff -- import rested-xp-kill \
+cargo run -q -p capture-diff -- import rested-xp-kill \
   --cpp target/captures/rested-xp-kill/cpp.pkt \
   --rust target/captures/rested-xp-kill/rust \
   --from-opcode s2c:0x26E5 \

--- a/crates/capture-diff/flows/equipment-set-save/README.md
+++ b/crates/capture-diff/flows/equipment-set-save/README.md
@@ -22,7 +22,7 @@ and `_LoadEquipmentSets`/`_LoadTransmogOutfits` source paths.
 The strict import selection is:
 
 ```bash
-cargo +1.88.0 run -q -p capture-diff -- import equipment-set-save \
+cargo run -q -p capture-diff -- import equipment-set-save \
   --cpp target/captures/equipment-set-save/cpp.pkt \
   --rust target/captures/equipment-set-save/rust \
   --from-opcode s2c:0x26B2 \

--- a/crates/capture-diff/flows/loot-single-item-claim/README.md
+++ b/crates/capture-diff/flows/loot-single-item-claim/README.md
@@ -147,8 +147,8 @@ REPO_ROOT=/absolute/path/to/your/rustycore-worktree
 cd "$REPO_ROOT"
 test -z "$(git status --porcelain=v1 --untracked-files=normal)"
 PROTOC=/home/cdmonio/.local/protoc/bin/protoc \
-  cargo +1.88.0 build --locked -p world-server
-cargo +1.88.0 build --locked \
+  cargo build --locked -p world-server
+cargo build --locked \
   --manifest-path tools/wow-test-bot/Cargo.toml
 
 RUST_EXEC="$(realpath target/debug/world-server)"
@@ -331,7 +331,7 @@ Finally, without either capture script running:
 ```bash
 REPO_ROOT=/absolute/path/to/your/rustycore-worktree
 cd "$REPO_ROOT"
-cargo +1.88.0 run -p capture-diff -- import loot-single-item-claim \
+cargo run -p capture-diff -- import loot-single-item-claim \
   --cpp target/captures/loot-single-item-claim/cpp.pkt \
   --rust target/captures/loot-single-item-claim/rust \
   --cpp-manifest target/captures/loot-single-item-claim/cpp.capture-manifest.json \
@@ -352,7 +352,7 @@ After that import reports `CLEAN`, maintainers must:
    provenance and all repository/executable/PM2/config identities;
 2. set `requirement.json` to `"status": "ready"` with no stale
    `blocked_reason`;
-3. run `cargo +1.88.0 run -p capture-diff -- verify-required
+3. run `cargo run -p capture-diff -- verify-required
    loot-single-item-claim` and the local `capture` preflight.
 
 The pre-lineage issue-#106 import on 2026-07-18 did not produce the RAW

--- a/crates/capture-diff/flows/vendor-extended-cost-purchase/README.md
+++ b/crates/capture-diff/flows/vendor-extended-cost-purchase/README.md
@@ -49,6 +49,6 @@ the complete currency, inventory, persistence and restoration behavior.
 Recheck the committed evidence with:
 
 ```bash
-cargo +1.88.0 run -q -p capture-diff -- \
+cargo run -q -p capture-diff -- \
   diff vendor-extended-cost-purchase --strict
 ```

--- a/docs/architecture/ownership-and-boundaries.md
+++ b/docs/architecture/ownership-and-boundaries.md
@@ -152,7 +152,7 @@ The refactor campaign must preserve:
 python3 tools/architecture/check_architecture.py self-test
 python3 tools/architecture/check_architecture.py check
 python3 tools/architecture/check_architecture.py hotspots --limit 20
-cargo +1.88.0 run --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml --bin session-ownership-check -- check
+cargo run --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml --bin session-ownership-check -- check
 ./tools/pr-preflight.sh architecture
 ```
 

--- a/docs/migration/migration-test-strategy.md
+++ b/docs/migration/migration-test-strategy.md
@@ -194,7 +194,7 @@ Complexity: **L** (<1h), **M** (1-4h), **H** (4-12h), **XL** (>12h, split).
 - [ ] **#TEST.12** Add an `insta`-based snapshot test for chat-message formatting and for log output formatting (covered in `logging.md` too). (M)
 - [ ] **#TEST.13** Backfill regression tests for every commit matching `^fix:` in `git log`. Initial sweep produces a count; one named `regression_<short-sha>` test per. (H)
 - [ ] **#TEST.14** Document a "vector capture playbook" — how to produce a new golden vector from C++: which logger to enable, which file to read, how to convert. Lives at `docs/migration/vector-capture-playbook.md`. (M)
-- [ ] **#TEST.15** Add CI matrix (`stable`, `1.88.0` as MSRV per workspace `rust-version`) running `cargo test --workspace` plus an opt-in `--features slow-tests` job. (M)
+- [ ] **#TEST.15** Add CI coverage for the exact `rust-toolchain.toml` / workspace `rust-version` contract running `cargo test --workspace` plus an opt-in `--features slow-tests` job. (M)
 - [ ] **#TEST.16** Add a "test-debt watch" job: on each PR, fail if `cargo test --workspace --no-run` count drops below the committed baseline (catches accidentally-deleted tests). (L)
 
 ---

--- a/docs/operations/local-first-development.md
+++ b/docs/operations/local-first-development.md
@@ -53,7 +53,7 @@ explicitly when behavior changes, for example:
 
 ```bash
 PROTOC=/home/cdmonio/.local/protoc/bin/protoc \
-  cargo +1.88.0 test --locked -p wow-world exact_test_name --lib
+  cargo test --locked -p wow-world exact_test_name --lib
 ```
 
 Broad test execution remains available through `tools/pr-preflight.sh` for explicit audits and
@@ -68,9 +68,9 @@ LOCAL_HARNESS_DRY_RUN=1 ./tools/local-harness.sh quick origin/3.4.3
 
 It does not require an agent SDK, a model-specific CLI, prompts, or interactive input. Agents can
 inspect the stable command interface with `./tools/local-harness.sh --help` and must treat a
-non-zero exit status as a failed local gate. The harness also exports the repository's required
-minimum `RUST_MIN_STACK` and disables Rust incremental compilation so the giant test target does
-not reuse a stale on-disk query cache between agents or branches.
+non-zero exit status as a failed local gate. The harness invokes plain `cargo`, so rustup selects
+the exact compiler from `rust-toolchain.toml`; it imposes no compiler stack or incremental-cache
+workaround.
 
 ## What remains exhaustive
 

--- a/docs/operations/pr-preflight.md
+++ b/docs/operations/pr-preflight.md
@@ -15,7 +15,7 @@ The entry point is:
 ./tools/pr-preflight.sh --help
 ```
 
-It reads `rust-toolchain.toml` and runs the required jobs with Rust `1.88.0`. Protobuf-dependent
+It reads `rust-toolchain.toml` and runs the required jobs with its exact pinned Rust. Protobuf-dependent
 commands require the version pinned in `.protoc-version` (`28.3`); the script uses `PROTOC` when
 set (resolving bare command names through `PATH`), then checks the project's usual local install
 and `PATH`. GitHub downloads the version from the same file. Review commands require an

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.98.0"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/tools/architecture/check_architecture.py
+++ b/tools/architecture/check_architecture.py
@@ -1412,7 +1412,7 @@ def cargo_metadata() -> dict[str, Any]:
 
 
 def package_id_url_basename(package_id_base: str, prefix: str) -> str | None:
-    # Cargo 1.88 PackageIdSpec::fmt omits the name only when the URL's final
+    # Cargo PackageIdSpec::fmt omits the name only when the URL's final
     # path segment equals it exactly. Do not decode, trim, or strip suffixes.
     if not package_id_base.startswith(prefix):
         return None

--- a/tools/architecture/handler-contract-check/Cargo.toml
+++ b/tools/architecture/handler-contract-check/Cargo.toml
@@ -2,7 +2,7 @@
 name = "handler-contract-check"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.98"
 license = "GPL-3.0-or-later"
 publish = false
 default-run = "handler-contract-check"

--- a/tools/codex-review-policy.md
+++ b/tools/codex-review-policy.md
@@ -29,7 +29,7 @@ Check every relevant change for:
   automation entering the patch.
 
 For build and workflow changes, also verify exact command equivalence between local and GitHub
-execution, Rust 1.88.0 and locked dependency use, protoc 28.3 handling, shell quoting and exit-code
+execution, the `rust-toolchain.toml` compiler and locked dependency use, protoc 28.3 handling, shell quoting and exit-code
 propagation, shallow-checkout behavior, and that safe default modes never start services or mutate
 databases. Local review must not bypass the required GitHub `Codex reviewer verdict` for the PR's
 current HEAD.

--- a/tools/local-harness.sh
+++ b/tools/local-harness.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEFAULT_BASE="origin/3.4.3"
-DEFAULT_RUST_MIN_STACK=1073741824
+TOOLCHAIN_FILE="$REPO_ROOT/rust-toolchain.toml"
 MODE="${1:-}"
 BASE="${2:-$DEFAULT_BASE}"
 DRY_RUN="${LOCAL_HARNESS_DRY_RUN:-0}"
@@ -65,6 +65,14 @@ assert_eq() {
     "self-test failed for $label: expected '$expected', got '$actual'"
 }
 
+toolchain_channel() {
+  local channel
+  channel="$(sed -n 's/^channel = "\([^"]*\)"/\1/p' "$TOOLCHAIN_FILE" | head -n 1)"
+  [[ "$channel" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die \
+    "cannot read an exact toolchain channel from $TOOLCHAIN_FILE"
+  printf '%s' "$channel"
+}
+
 path_kind() {
   local path="$1"
   case "$path" in
@@ -82,6 +90,11 @@ path_kind() {
 }
 
 self_test() {
+  local active_toolchain pinned_toolchain
+  pinned_toolchain="$(toolchain_channel)"
+  active_toolchain="$(cd "$REPO_ROOT" && rustc --version | awk '{print $2}')"
+  assert_eq "$active_toolchain" "$pinned_toolchain" \
+    "rust-toolchain.toml active compiler"
   assert_eq "$(path_kind docs/migration/STATE.md)" other "documentation routing"
   assert_eq "$(path_kind crates/wow-world/src/session.rs)" workspace-rust \
     "workspace crate routing"
@@ -113,18 +126,6 @@ fi
   exit 64
 }
 (($# <= 2)) || die "too many arguments"
-
-RUST_MIN_STACK="${RUST_MIN_STACK:-$DEFAULT_RUST_MIN_STACK}"
-[[ "$RUST_MIN_STACK" =~ ^[1-9][0-9]*$ ]] || die \
-  "RUST_MIN_STACK must be a positive integer"
-((RUST_MIN_STACK >= DEFAULT_RUST_MIN_STACK)) || die \
-  "RUST_MIN_STACK must be at least $DEFAULT_RUST_MIN_STACK bytes for Rust 1.88"
-export RUST_MIN_STACK
-# Rust 1.88 has produced stale on-disk query-cache assertions for the giant
-# wow-world test target in this repository. Compile checks value repeatability
-# over incremental reuse, so keep the lightweight harness out of that cache.
-CARGO_INCREMENTAL=0
-export CARGO_INCREMENTAL
 
 cd "$REPO_ROOT"
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git worktree"
@@ -226,22 +227,22 @@ fi
 
 if ((workspace_rust == 1)); then
   log "Workspace Rust formatting"
-  run cargo +1.88.0 fmt --all --check
+  run cargo fmt --all --check
 fi
 
 if ((architecture_checker == 1)); then
   log "Architecture checker formatting and fast tests"
-  run cargo +1.88.0 fmt \
+  run cargo fmt \
     --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- --check
-  run cargo +1.88.0 test --locked \
+  run cargo test --locked \
     --manifest-path tools/architecture/handler-contract-check/Cargo.toml --lib -- \
     --skip repository_surface_can_be_collected
 fi
 
 if ((wow_test_bot == 1)); then
   log "QA bot formatting and check"
-  run cargo +1.88.0 fmt --manifest-path tools/wow-test-bot/Cargo.toml -- --check
-  run cargo +1.88.0 check --locked --manifest-path tools/wow-test-bot/Cargo.toml
+  run cargo fmt --manifest-path tools/wow-test-bot/Cargo.toml -- --check
+  run cargo check --locked --manifest-path tools/wow-test-bot/Cargo.toml
 fi
 
 declare -A packages=()
@@ -269,7 +270,7 @@ if ((${#packages[@]} > 0)); then
     cargo_package_args+=(--package "$package")
   done
   log "Compile code and tests for affected packages: ${package_names[*]}"
-  run cargo +1.88.0 check --locked --tests "${cargo_package_args[@]}"
+  run cargo check --locked --tests "${cargo_package_args[@]}"
 fi
 
 if [[ "$MODE" == "final" ]]; then

--- a/tools/pr-preflight.sh
+++ b/tools/pr-preflight.sh
@@ -8,15 +8,10 @@ ARCHITECTURE_CHECKER="$REPO_ROOT/tools/architecture/check_architecture.py"
 HANDLER_CONTRACT_CHECK_MANIFEST="$REPO_ROOT/tools/architecture/handler-contract-check/Cargo.toml"
 PROTOC_VERSION_FILE="$REPO_ROOT/.protoc-version"
 DEFAULT_BASE="origin/3.4.3"
-# Matches the workflow. Headroom, not a fix: the crash it was raised for
-# reproduces with an unlimited stack, so its cause was elsewhere.
-DEFAULT_RUST_MIN_STACK=1073741824
 CODEX_REVIEW_TIMEOUT_SECONDS="${CODEX_REVIEW_TIMEOUT_SECONDS:-1800}"
 DRY_RUN=0
 ALLOW_RUNTIME_QA=0
 ACK_DISPOSABLE_OVERWORLD_LOOT_RACE=0
-RUST_MIN_STACK="${RUST_MIN_STACK:-$DEFAULT_RUST_MIN_STACK}"
-export RUST_MIN_STACK
 QA_LOOT_RACE_CAPTURE_SCRIPT="$REPO_ROOT/crates/capture-diff/scripts/capture-rust.sh"
 QA_LOOT_RACE_CAPTURE_PID=""
 QA_LOOT_RACE_CAPTURE_FD=""
@@ -73,13 +68,6 @@ warn() {
 die() {
   printf 'error: %s\n' "$*" >&2
   exit 64
-}
-
-validate_rust_min_stack() {
-  [[ "$RUST_MIN_STACK" =~ ^[1-9][0-9]*$ ]] || die \
-    "RUST_MIN_STACK must be a positive integer"
-  ((RUST_MIN_STACK >= DEFAULT_RUST_MIN_STACK)) || die \
-    "RUST_MIN_STACK must be at least $DEFAULT_RUST_MIN_STACK bytes for Rust 1.88"
 }
 
 print_command() {
@@ -345,17 +333,14 @@ valid_tcp_port() {
 toolchain_channel() {
   local channel
   channel="$(sed -n 's/^channel = "\([^"]*\)"/\1/p' "$REPO_ROOT/rust-toolchain.toml" | head -n 1)"
-  [[ -n "$channel" ]] || die "cannot read toolchain channel from rust-toolchain.toml"
+  [[ "$channel" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die \
+    "cannot read an exact toolchain channel from rust-toolchain.toml"
   printf '%s' "$channel"
 }
 
 cargo_cmd() {
-  local channel
   ((DRY_RUN)) || require_command cargo
-  channel="$(toolchain_channel)"
-  # Rust 1.88 can ICE while reloading a stale incremental dep graph. Keep the
-  # compile/test gate deterministic without leaking this setting into live QA.
-  run_cmd env CARGO_INCREMENTAL=0 cargo "+$channel" "$@"
+  run_cmd cargo "$@"
 }
 
 project_protoc_version() {
@@ -773,6 +758,8 @@ PY
 }
 
 run_self_test() {
+  local active_toolchain
+  local active_workflow_text
   local artifacts
   local capture_output
   local clean_result
@@ -783,6 +770,7 @@ run_self_test() {
   local committed_inspection_result
   local dependency
   local expected_protoc_version
+  local pinned_toolchain
   local echo_inspection_result
   local findings_result
   local full_dry_run_output
@@ -964,8 +952,11 @@ run_self_test() {
   for dependency in awk dirname env git head realpath sed sha256sum tr; do
     ln -s "$(command -v "$dependency")" "$artifacts/bin/$dependency"
   done
-  printf '#!/bin/sh\n[ "${RUST_MIN_STACK:-0}" -ge %s ] || exit 70\n[ "${CARGO_INCREMENTAL:-}" = 0 ] || exit 71\nexit 0\n' \
-    "$DEFAULT_RUST_MIN_STACK" >"$artifacts/bin/cargo"
+  pinned_toolchain="$(toolchain_channel)"
+  active_toolchain="$(rustc --version | awk '{print $2}')"
+  [[ "$active_toolchain" == "$pinned_toolchain" ]] || die \
+    "active Rust $active_toolchain does not match rust-toolchain.toml $pinned_toolchain"
+  printf '#!/bin/sh\nexit 0\n' >"$artifacts/bin/cargo"
   expected_protoc_version="$(project_protoc_version)"
   printf '#!/bin/sh\nprintf "libprotoc %s\\n"\n' \
     "$expected_protoc_version" >"$artifacts/bin/protoc"
@@ -1041,8 +1032,8 @@ run_self_test() {
     "CI profile did not print the production-linked handler registry contract"
   [[ "$ci_dry_run_output" == *"--manifest-path tools/wow-test-bot/Cargo.toml loot_race::tests"* ]] || die \
     "CI profile did not print the focused loot-race harness tests"
-  [[ "$ci_dry_run_output" == *"+ env CARGO_INCREMENTAL=0 cargo +1.88.0 test --locked -p wow-world --lib"* ]] || die \
-    "local CI profile did not disable Rust 1.88 incremental compilation"
+  [[ "$ci_dry_run_output" == *"+ cargo test --locked -p wow-world --lib"* ]] || die \
+    "local CI profile did not use the repository toolchain"
   require_exact_occurrences "$ci_dry_run_output" \
     "test --locked -p capture-diff" 1 \
     "local CI capture-diff test command"
@@ -1056,17 +1047,25 @@ run_self_test() {
     "normal CI profile must never activate destructive live loot-race QA"
 
   github_workflow_text="$(<"$REPO_ROOT/.github/workflows/rust-ci.yml")"
+  active_workflow_text="$github_workflow_text
+$(<"$REPO_ROOT/.github/workflows/qa-world-server-artifact.yml")
+$(<"$REPO_ROOT/.github/workflows/wow-database-live.yml")"
+  require_exact_occurrences "$active_workflow_text" \
+    "uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659" 6 \
+    "GitHub workflows reading rust-toolchain.toml"
+  [[ "$active_workflow_text" != *"1.88"* ]] || die \
+    "an active GitHub workflow retained the obsolete Rust 1.88 pin"
   require_exact_occurrences "$github_workflow_text" \
     "python3 tools/architecture/check_architecture.py check" 1 \
     "GitHub workflow architecture check"
   require_exact_occurrences "$github_workflow_text" \
-    "cargo +1.88.0 test --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml" 1 \
+    "cargo test --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml" 1 \
     "GitHub workflow handler-contract checker tests"
   require_exact_occurrences "$github_workflow_text" \
     "-- --skip repository_surface_can_be_collected" 1 \
     "GitHub workflow single-collection skip"
   require_exact_occurrences "$github_workflow_text" \
-    "cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- check" 1 \
+    "cargo run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- check" 1 \
     "GitHub workflow handler-contract repository check"
   require_exact_occurrences "$github_workflow_text" \
     "--bin session-ownership-check -- check --syntax-only" 1 \
@@ -1075,37 +1074,36 @@ run_self_test() {
   # the only thing standing between a 5-minute PR and a 16-minute one, it
   # should say so when someone removes it.
   require_exact_occurrences "$github_workflow_text" \
-    "if: github.event_name != 'pull_request'" 1 \
+    "        if: github.event_name != 'pull_request'" 1 \
     "GitHub workflow post-merge-only exact persistence scan"
   require_exact_occurrences "$github_workflow_text" \
-    "cargo +1.88.0 run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml --bin session-ownership-check -- check" 1 \
+    "cargo run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml --bin session-ownership-check -- check" 1 \
     "GitHub workflow session-ownership repository check"
   require_exact_occurrences "$github_workflow_text" \
-    "cargo +1.88.0 fmt --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- --check" 1 \
+    "cargo fmt --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- --check" 1 \
     "GitHub workflow handler-contract checker formatting"
+  [[ "$github_workflow_text" != *'CARGO_INCREMENTAL: "0"'* ]] || die \
+    "GitHub workflow retained the obsolete non-incremental compiler workaround"
   require_exact_occurrences "$github_workflow_text" \
-    'CARGO_INCREMENTAL: "0"' 3 \
-    "GitHub workflow non-incremental Rust 1.88 contract"
-  require_exact_occurrences "$github_workflow_text" \
-    "cargo +1.88.0 build --locked -j4 -p bnet-server" 1 \
+    "cargo build --locked -j4 -p bnet-server" 1 \
     "GitHub workflow bnet-server linked build"
   require_exact_occurrences "$github_workflow_text" \
-    "cargo +1.88.0 build --locked -j4 -p world-server" 1 \
+    "cargo build --locked -j4 -p world-server" 1 \
     "GitHub workflow world-server linked build"
   require_exact_occurrences "$github_workflow_text" \
-    "cargo +1.88.0 test --locked -p capture-diff" 1 \
+    "cargo test --locked -p capture-diff" 1 \
     "GitHub workflow capture-diff test command"
   require_exact_occurrences "$github_workflow_text" \
-    "cargo +1.88.0 test --locked -p wow-world --test production_handler_registry_contract" 1 \
+    "cargo test --locked -p wow-world --test production_handler_registry_contract" 1 \
     "GitHub workflow production-linked handler registry contract"
   require_exact_occurrences "$github_workflow_text" \
-    "cargo +1.88.0 test --locked -p wow-handler --test inventory_registry" 1 \
+    "cargo test --locked -p wow-handler --test inventory_registry" 1 \
     "GitHub workflow wow-handler inventory registry integration tests"
   require_exact_occurrences "$github_workflow_text" \
-    "cargo +1.88.0 run --locked -p capture-diff -- verify-required loot-single-item-claim" 1 \
+    "cargo run --locked -p capture-diff -- verify-required loot-single-item-claim" 1 \
     "GitHub workflow required loot-flow command"
   require_exact_occurrences "$github_workflow_text" \
-    "cargo +1.88.0 run --locked -p capture-diff -- verify-required creature-spell-casting" 1 \
+    "cargo run --locked -p capture-diff -- verify-required creature-spell-casting" 1 \
     "GitHub workflow required creature-spell-flow command"
 
   if qa_loot_race_missing_ack_output="$(PATH="$artifacts/bin" \
@@ -2595,7 +2593,6 @@ run_self_test() {
   qa_common_env=(
     "PATH=$qa_fake_bin"
     "TMPDIR=$artifacts"
-    "RUST_MIN_STACK=$DEFAULT_RUST_MIN_STACK"
     "PM2_RUST_WORLD=self-test-world"
     "WOW_BOT_WORLD_EXEC=$qa_fake_world_other"
     "WOW_BOT_WORLD_EXEC_SHA256=$qa_target_sha"
@@ -3301,7 +3298,6 @@ fi
 
 cd "$REPO_ROOT"
 require_command git
-validate_rust_min_stack
 
 case "$COMMAND" in
   self-test)

--- a/tools/wow-test-bot/Cargo.toml
+++ b/tools/wow-test-bot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wow-test-bot"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.98"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/tools/wow-test-bot/README.md
+++ b/tools/wow-test-bot/README.md
@@ -368,8 +368,8 @@ Explicit caller environment values always win over `.env.local`, including
 mode/acknowledgement, endpoint, executable/hash, and credential variables; the
 wrapper suppresses xtrace while it loads and restores those values.
 
-Build and test this bot with Rust 1.88.0 (`cargo +1.88.0 ...`), matching the
-RustyCore toolchain.
+Build and test this bot with `cargo ...`; `rust-toolchain.toml` selects the
+same exact compiler as the RustyCore workspace.
 
 For QA on a host that must not compile locally, the wrapper accepts an exact
 prebuilt executable only when both `WOW_BOT_EXEC` (an absolute, canonical,
@@ -377,4 +377,4 @@ non-symlink path) and its `WOW_BOT_EXEC_SHA256` are supplied. The optional
 `qa-artifact` PR workflow builds both `world-server` and `wow-test-bot` twice on
 separate GitHub runners, requires byte-identical replicas, and publishes their
 verified hashes. Without `WOW_BOT_EXEC`, the wrapper keeps the normal local
-Rust 1.88.0 build behavior.
+build behavior.

--- a/tools/wow-test-bot/RUSTYCORE_SMOKE.md
+++ b/tools/wow-test-bot/RUSTYCORE_SMOKE.md
@@ -58,7 +58,7 @@ the corresponding Rust server port is ready.
   `quest_smoke_passed`, target entry/spawn/map, `quest_ids_seen`,
   `quest_titles_seen`, and `quest_failure`.
 
-The bot crate follows RustyCore's Rust 1.88.0 toolchain. Use `cargo +1.88.0` for
+The bot crate follows RustyCore's pinned `rust-toolchain.toml`. Use `cargo` for
 standalone builds/tests of `tools/wow-test-bot`.
 
 The wrapper normally builds the bot locally. To run a reproducible PR artifact

--- a/tools/wow-test-bot/run_rustycore_login_smoke.sh
+++ b/tools/wow-test-bot/run_rustycore_login_smoke.sh
@@ -468,7 +468,7 @@ elif [[ -n "${WOW_BOT_EXEC_SHA256:-}" ]]; then
   echo "WOW_BOT_EXEC_SHA256 requires WOW_BOT_EXEC" >&2
   exit 2
 else
-  cargo +1.88.0 build --locked --bin wow-test-bot
+  cargo build --locked --bin wow-test-bot
   bot_exec="$PWD/target/debug/wow-test-bot"
 fi
 


### PR DESCRIPTION
Closes #232

## Summary

- pin Rust 1.98.0 and declare Rust 1.98 as the workspace/tool MSRV
- make `rust-toolchain.toml` the single operational compiler source for local commands and GitHub workflows
- remove the Rust 1.88 / LLVM 20 stack, incremental-cache, and package debuginfo workarounds
- update the agent-neutral harnesses, QA bot commands, active operations docs, and compiler contract self-tests

Edition 2024 remains the newest stable Rust edition and is independent of the compiler release number. Historical migration evidence that records old 1.88 commands remains unchanged.

## Validation

- `cargo fmt --all --check`
- standalone bot and architecture-checker formatting
- `./tools/pr-preflight.sh self-test`
- `python3 tools/architecture/check_architecture.py check`
- architecture checker: 308 passed
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check --locked --tests -p world-server` with normal incremental compilation and no `RUST_MIN_STACK`
- focused `world-server` test execution: 1 passed, 445 filtered out, with normal test debuginfo
- `./tools/local-harness.sh final origin/3.4.3`
- workflow YAML parse and `git diff --check`

## Boundaries

No dependencies, gameplay behavior, packet layouts, C++ parity decisions, or architecture ownership boundaries change in this PR.