### PR TITLE
[ARCH.PLAN] Align the modular roadmap, metrics and local-first policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,17 +15,19 @@
 - [ ] Runtime behaviour
 - [ ] Packet / protocol
 - [ ] Database / SQL
+- [ ] Architecture / mechanical module split
 - [ ] Documentation
 - [ ] Tests only
 
 ## Verification
 
-<!-- Check every command that was run. Add extra focused tests when relevant. -->
+<!-- First-party alseif0x PRs use the local harness; external PRs retain remote checks. Add only
+focused tests/evidence required by the behavior actually changed. -->
 
-- [ ] `cargo fmt --all --check`
-- [ ] `cargo check -p wow-data -p wow-database -p wow-network -p wow-world -p world-server`
+- [ ] `./tools/local-harness.sh final origin/3.4.3`
 - [ ] Focused tests:
-- [ ] `git diff --check`
+- [ ] Capture-diff (only packet/metadata/connection/order changes): not needed / result
+- [ ] Runtime QA (only lifecycle/runtime changes): not needed / result
 
 ## Migration notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,11 @@ Work issue #<N> (alseif0x/rustycore).
 3. Smallest faithful change + focused tests (positive/negative); validate with PROTOC=... cargo check/test.
 4. Git: create the branch LINKED to the issue with `gh issue develop <N> --base 3.4.3`
    (not a bare `git checkout -b`), 1 issue = 1 PR into `3.4.3` (put `Closes #<N>` in the PR body), commit per gap, NO push unless asked.
-   Once push is approved, open the PR immediately so CI and the configured Codex reviewer can run; creating the PR is not the same as closing/merging it.
-5. Do not mark "done" until capture-clean vs C++ (capture-diff harness = issue [01]/#66)
-   and the required `Codex reviewer verdict` check is green for the PR's current HEAD.
+   Once push is approved, open the PR immediately; creating the PR is not the same as closing/merging it.
+5. For first-party PRs authored by exactly `alseif0x`, use `tools/local-harness.sh final` plus
+   focused evidence. External PRs retain remote CI/review. Require capture-diff only when bytes,
+   metadata, connection choice or observable ordering changed, and runtime QA only for a live
+   lifecycle/runtime change.
 ```
 
 **Linking the branch/PR to the issue:** the repo's **default branch is `3.4.3`** (the version/
@@ -115,7 +117,11 @@ Every implementation slice must follow this sequence:
 7. Update migration docs/checklists with the new `#NEXT.R8.ENTITIES.xxx` item when closing a represented implementation gap.
 8. Recalculate progress honestly.
 9. Run validation.
-10. Commit on the issue's feature branch, push, and open a PR into `3.4.3` (`Closes #<N>`); merge only after CI and the required `Codex reviewer verdict` check are both green on the PR's current HEAD, and every actionable reviewer comment is either fixed or explicitly documented as intentionally deferred. Tag releases on `3.4.3`.
+10. Commit on the issue's feature branch, push, and open a PR into `3.4.3` (`Closes #<N>`).
+    For an `alseif0x` PR, the local final harness and focused evidence are the required gate;
+    hosted checks intentionally skip. For any other author, require the configured remote checks
+    and reviewer verdict. In both cases, fix or explicitly defer actionable review comments and
+    resolve conversations before merge. Tag releases on `3.4.3`.
 
 Do not do "bulk close" inventory edits. A closed `#NEXT` item must correspond to real code and tests, with exact C++ refs, Rust targets, checks run, and remaining boundaries stated. Discovering or documenting a gap is useful, but it is not an implementation closeout.
 
@@ -142,20 +148,19 @@ cargo clippy -p wow-map -p wow-world --all-targets
 git diff --check
 ```
 
-Local preflight commands mirroring GitHub CI:
+Local-first commands for ordinary development:
 
 ```bash
-# During iteration (diff + format + the core check/build job):
-./tools/pr-preflight.sh quick origin/3.4.3
+# During iteration (path-routed lightweight checks):
+./tools/local-harness.sh quick origin/3.4.3
 
-# Before push, after committing to a clean HEAD (exact CI + capture-diff + local Codex review):
-./tools/pr-preflight.sh full origin/3.4.3
+# Before push, after committing to a clean HEAD:
+./tools/local-harness.sh final origin/3.4.3
 ```
 
-`full` is the standard pre-push gate. Its local Codex result reduces remote review cycles but does
-not satisfy branch protection; the GitHub `Codex reviewer verdict` must still be green for the
-current remote HEAD. See `docs/operations/pr-preflight.md` for all profiles. Live bot QA and fresh
-capture recording are explicit operations and never run as part of `full`.
+Run focused tests explicitly when behavior changes. `tools/pr-preflight.sh` remains available for
+an explicitly requested audit, release preparation, capture QA, or architecture investigation; it
+is not the daily pre-push gate. See `docs/operations/local-first-development.md`.
 
 TSV inventory files must keep 9 tab-separated columns:
 
@@ -387,23 +392,19 @@ git status --short --branch
 # focused tests
 git add <changed files>
 git commit -m "<short faithful summary>"
-./tools/pr-preflight.sh full origin/3.4.3
+./tools/local-harness.sh final origin/3.4.3
 git push origin <feature-branch>        # NO push unless asked
-# after push, open the PR into 3.4.3 with `Closes #<N>` in the body so CI and
-# the configured Codex reviewer can run.
-# Do not merge or close the issue until CI is green and the required
-# `Codex reviewer verdict` check is green for the PR's current HEAD.
-# If Codex leaves feedback, fix or explicitly defer every actionable comment,
-# resolve the review threads, push the fix, comment `@codex review`, and wait
-# for `Codex reviewer verdict` to pass again on the new HEAD.
+# after push, open the PR into 3.4.3 with `Closes #<N>` in the body.
+# alseif0x PRs use the local evidence above and allocate no hosted validation runner.
+# External PRs must satisfy the configured remote checks and reviewer verdict.
+# Resolve or explicitly defer every actionable review comment before merge.
 ```
 
 Only do this after the slice is genuinely validated. If the tree contains changes from another agent, audit them before building on top of them.
 
-Branch protection on `3.4.3` requires strict status checks, linear history, conversation
-resolution, and these checks: `Format`, `Check core crates`, `Focused library tests`, and
-`Codex reviewer verdict`. A PR can show normal CI green while still being blocked if Codex has
-not reviewed the current HEAD or has left unresolved feedback.
+Branch protection on `3.4.3` keeps linear history and conversation resolution. Remote validation
+jobs are author-gated: they skip for the exact trusted login `alseif0x` and remain required for
+external authors. Never broaden trust to an author-association role.
 
 ## Local Context Files
 

--- a/docs/architecture/ownership-and-boundaries.md
+++ b/docs/architecture/ownership-and-boundaries.md
@@ -6,10 +6,11 @@ machine-readable dependency rules live in
 `tools/architecture/dependency-policy.json`; `tools/architecture/check_architecture.py check`
 enforces them. The checked-in issue ledger
 `tools/architecture/architecture-issue-ledger.json` records every architecture epic and
-implementation slice, its parents, its prerequisites, and one deterministic topological display
-of the audited DAG. External prerequisites such as QA issue #177 are explicit nodes rather than
-implicit prose. The checker keeps this document, the ledger, and the JSON policy in agreement
-without contacting GitHub; independent nodes may still execute in parallel.
+implementation slice, including follow-ups omitted by the previous snapshot. It is organized
+around four lanes: physical modules, encapsulation/ownership, runtime/persistence authority, and
+stable crate/extension seams. External prerequisites such as QA issue #177 are explicit nodes.
+The checker keeps this document, the ledger, and the JSON policy in agreement without contacting
+GitHub; the displayed topological order never serializes independent work.
 
 ## Decision
 
@@ -30,13 +31,15 @@ and files such as `Player.cpp`, `Unit.cpp`, and `Spell.cpp` remain large themsel
 therefore may be smaller and more cohesive while preserving the same semantic owners.
 
 This direction also follows Rust's native boundaries: modules control visibility inside a crate,
-while Cargo packages are separate compilation and public-API boundaries. A line count is a signal
-for review, not a universal size rule. The checker reports the largest production/test hotspots.
-For the explicitly audited paths in `runtime-ownership-ledger.json`, the recorded production,
-test, and total counts are independent non-growth ceilings: extraction and reduction pass without
-a baseline edit, while growth in any one metric requires an explicit reviewed baseline change.
-An audited path cannot disappear or be renamed until its ledger row is explicitly retired or
-replaced.
+while Cargo packages are separate compilation and public-API boundaries. The checker publishes
+two independent measurements. The **physical view** counts every real `.rs` file separately, with
+production and tests split; ordinary `mod` extraction therefore appears immediately. Around 2,000
+productive lines triggers review and above 4,000 requires a split plan or explicit cohesive
+exception, but neither is a daily blocking threshold. The **logical view** counts each curated
+owner root together with its reviewed private descendants, so distributing a God object cannot be
+claimed as ownership reduction. Logical production/test/total counts in
+`runtime-ownership-ledger.json` are independent non-growth ceilings. A logical owner row cannot
+disappear until it is explicitly retired or replaced.
 
 ## Dependency direction
 
@@ -115,9 +118,9 @@ last-writer-wins policy.
 | Concept | Current owner and storage | Writers | Readers / delivery | Clock, lifetime, and synchronization | Retirement |
 |---|---|---|---|---|---|
 | Authenticated world connection | `wow-network::accept` and the connection task | socket/authentication task | `WorldSession` dispatch boundary | one connection; created after authentication and dropped on disconnect | Remains a network responsibility. #134 narrowed the listener to transport-owned configuration and authenticated connection outputs. |
-| Gameplay session construction aggregate | private `SessionResources` in `crates/world-server/src/session_resources.rs` | `world-server` bootstrap constructs it; the outer session callback captures and clones the `Arc` | `world-server::create_session` copies stores, registries, DB adapters, and runtime handles into each `WorldSession`; the aggregate never enters `wow-network` | process lifetime; no independent clock | #134 moved the aggregate to composition code and retired the direct `wow-network → wow-database` / `wow-network → wow-instances` edges. #136 next extracts a private session factory. |
+| Gameplay session construction aggregate | private `SessionResources` in `crates/world-server/src/session_resources.rs` | `world-server` bootstrap constructs it; the outer session callback captures and clones the `Arc` | `world-server::create_session` copies stores, registries, DB adapters, and runtime handles into each `WorldSession`; the aggregate never enters `wow-network` | process lifetime; no independent clock | #134 moved the aggregate to composition code; #136 moved the process into a library-backed composition root and extracted the private factory. Capability-specific dependency reduction remains in the physical and ownership lanes. |
 | Session directory | `wow_network::player_registry::PlayerRegistry`; backing storage is a `DashMap<ObjectGuid, PlayerBroadcastInfo>` | session login/logout and state publication write the directory | global routing, handlers, and gameplay fanout currently read broad snapshots | process lifetime; presence and generation/addressability are Session concerns, while gameplay fields are temporary mirrors | #150 introduces the opaque facade; #192-#195 burn down production consumers; #196 closes storage and fixtures; #138 then relocates the already-opaque directory. |
-| Session mailbox and durable rails | `wow_network::player_registry::SessionCommand` plus ordinary and durable payloads in the same network module | session/global runtime and gameplay producers enqueue commands; one session task consumes them | the owning session consumes FIFO commands and publishes acknowledgements | connection/session lifetime; queue identity, capacity, FIFO, incarnation fences, acknowledgements, and shutdown drain are observable | #189 removes durable loot persistence coordination; after #138, #191 relocates the ordinary mailbox protocol and #190 relocates the durable creature-runtime rail. #140 then extracts the pump without changing queue semantics. |
+| Session mailbox and durable rails | `wow_network::player_registry::SessionCommand` plus ordinary and durable payloads in the same network module | session/global runtime and gameplay producers enqueue commands; one session task consumes them | the owning session consumes FIFO commands and publishes acknowledgements | connection/session lifetime; queue identity, capacity, FIFO, incarnation fences, acknowledgements, and shutdown drain are observable | #191 and #190 completed their bounded protocol/rail relocations. #189 removes durable loot persistence coordination; #138 closes broad directory access; #140 owns the remaining pump and mailbox boundary without changing queue semantics. |
 | Group registry and pending invites | `wow_network::group_registry::{GroupRegistry, PendingInvites}`, currently backed by concurrent maps | group handlers and group timer/ready-check paths | group handlers, connected-player fanout, world-server ready-check loop | process lifetime; timed group work is driven outside the network listener | #151 creates opaque facades; #197 and #198 centralize atomic transitions; #199 separates persistence/publication and closes storage; #195 adapts session addressing; #137 finally moves the owner into `wow-social`. |
 | Legacy creature runtime | shared `wow_world::MapManager` behind `Arc<RwLock<_>>` | production `GlobalLegacy` runtime tick plus explicit spawn/respawn bridges; `Session` writer exists only for tests and the diagnostic config override | world handlers, global runtime bridge, visibility/fanout routing | process lifetime; production startup defaults `RuntimeTickOwner` to `GlobalLegacy` and uses the configured map-update interval; session ticks read the shared owner and must skip to prevent double resolution | #188 freezes clocks, phases, and bridge behavior. #28 may perform one bounded authority cut; later cuts retire legacy behavior method-by-method under `docs/migration/adr-runtime-tick-ownership.md`. |
 | Canonical map runtime | `wow_map::MapManager` | canonical global map loop, grid/spawn/respawn paths, explicit selected legacy-result adapters | world-server orchestration and session map/player bridges | process lifetime; canonical loop uses the configured map interval; preserves the C++ `Map::Update` phase order represented by the ADR | #188 records the current phase trace. It becomes the sole map/entity authority only after each later method cut has parity tests and removes the corresponding legacy writer. |
@@ -267,41 +270,32 @@ Do not regenerate a baseline merely to make CI green.
 5. For a handler snapshot or dispatch-side exception, inspect the exact added/removed/changed row
    or arm, retain the C++ metadata contrast test, and assign any temporary one-sided wiring to a
    concrete removal issue.
-6. Run the architecture self-test, architecture check, focused Rust tests, and full PR preflight.
+6. Run the architecture self-test/check, focused evidence, and
+   `tools/local-harness.sh final`. Reserve full preflight for an explicit audit or release.
 
 ## Audited ownership and hotspot evidence
 
-The current baseline was audited on branch `3.4.3` at HEAD `002d3d87`. Production and test lines
-are reported separately because moving an inline test module must not masquerade as ownership
-progress:
+The logical-owner baseline was refreshed on branch `3.4.3` at `c2bb8a85`, after the world-server
+composition split. Production and test lines remain separate:
 
-| Hotspot | Production | Tests | Total | Tests live in |
-|---|---:|---:|---:|---|
-| `crates/wow-world/src/session.rs` | 71,961 | 94,165 | 166,126 | `session_tests.rs` |
-| `crates/wow-world/src/handlers/character.rs` | 20,200 | 10,691 | 30,891 | `character_tests.rs` |
-| `crates/world-server/src/main.rs` | 15,370 | 12,533 | 27,903 | `main_tests.rs` |
-| `crates/wow-map/src/map.rs` | 15,245 | 18,273 | 33,518 | `map_tests.rs` |
-| `crates/wow-world/src/handlers/loot.rs` | 13,744 | 16,081 | 29,825 | `loot_tests.rs` |
-| `crates/wow-entities/src/player.rs` | 9,265 | 8,891 | 18,156 | `player_tests.rs` |
-| `crates/wow-world/src/handlers/quest.rs` | 8,255 | 10,172 | 18,427 | `quest_tests.rs` |
-| `crates/wow-world/src/handlers/misc.rs` | 7,315 | 11,322 | 18,637 | `misc_tests.rs` |
+| Logical owner root | Production | Tests | Total |
+|---|---:|---:|---:|
+| `crates/wow-world/src/session.rs` | 71,961 | 94,165 | 166,126 |
+| `crates/world-server/src/lib.rs` (crate scope) | 24,985 | 21,491 | 46,476 |
+| `crates/wow-map/src/map.rs` | 15,245 | 18,273 | 33,518 |
+| `crates/wow-world/src/handlers/character.rs` | 20,200 | 10,691 | 30,891 |
+| `crates/wow-world/src/handlers/loot.rs` | 13,744 | 16,081 | 29,825 |
+| `crates/wow-world/src/handlers/misc.rs` | 7,315 | 11,322 | 18,637 |
+| `crates/wow-world/src/handlers/quest.rs` | 8,255 | 10,172 | 18,427 |
+| `crates/wow-entities/src/player.rs` | 9,265 | 8,891 | 18,156 |
 
-Counts are per **module**, not per file: a `#[path]` child is part of the module
-that mounts it, so its lines are added to the parent's row and it does not get a
-row of its own. Extracting a `mod tests` into a sibling therefore moves nothing
-the ratchet can see, which is the point — capping only what stayed behind would
-have left 94,042 lines of `session.rs` tests uncapped and retired the protection
-the extraction was supposed to preserve. Where the `#[cfg(test)]` sits on the
-mount rather than inside the child, as it does for
-`character_vendor_atomicity_tests.rs`, the child counts as test lines regardless
-of how the file itself reads.
-
-Every root `mod tests` above was moved to a sibling `#[cfg(test)] #[path = "..._tests.rs"]` file.
-The `Production` column is byte-for-byte unchanged from the pre-extraction audit for all eight
-files, which is the evidence that the move carried no production code: only the `Tests` and `Total`
-columns fell. This is test *placement*, explicitly not ownership progress — the retirement
-conditions in the ledger are untouched, and the hotspot classifier counts a wholly-`cfg(test)`
-sibling as test lines so the extraction cannot be laundered into a smaller production number.
+The physical table is generated live and gives every source file its own row. At this baseline,
+`world-server/src/main.rs` is 15 lines, while `world-server/src/lib.rs` plus its private crate
+descendants remain a 46,476-line logical composition owner. That is the intended distinction:
+#136 materially improved navigation without claiming that bootstrap/runtime ownership vanished.
+Standard adjacent module directories and transitional `#[path]` descendants remain charged to
+their logical root; `logical_scope: crate` is used only for an explicitly reviewed composition
+root. Extracted `*_tests.rs` and `tests/` descendants remain test lines in the logical view.
 
 At the same HEAD, the syntax-aware ratchet records 738 `WorldSession` fields: 727 production and
 11 `cfg(test)` fixtures. It also records all 20 logical inherent-impl owners and 3,339 exact
@@ -359,88 +353,82 @@ merely moving lines.
 
 ## Refactor sequence
 
-The ledger is the offline source of truth for the dependency DAG. The list below is only one
-deterministic topological display used to detect documentation drift; it does **not** serialize
-independent work. Epics #133 and #169 are parents rather than implementation PRs, and external QA
-prerequisite #177 is represented separately in the ledger.
+The ledger is the offline dependency map, not a serial execution queue. Epics #133, #169 and #99
+are parents rather than PRs; external QA prerequisite #177 is separate. The four active lanes are:
 
-1. #135 — executable boundary guardrails;
-2. #143 — interaction provenance;
-3. #146 — effective SpellInfo authority;
-4. #148 — effective SkillLine authority;
-5. #144 — validated trainer load inputs;
-6. #156 — primary-profession capacity;
-7. #163 — effective spell-acquisition metadata;
-8. #164 — deterministic acquisition outcomes;
-9. #157 — trainer offer and eligibility decisions;
-10. #158 — durable prepared spell learning;
-11. #159 — atomic normal trainer teaching;
-12. #160 — durable account-atomic battle-pet ownership;
-13. #161 — recoverable battle-pet trainer purchase;
-14. #142 — dispatcher/registration reconciliation;
-15. #154 — audited policy alignment;
-16. #134 — listener/SessionResources decoupling;
-17. #181 — ownership baseline and submodule ratchets;
-18. #185 — module-aware architecture and handler guards;
-19. #186 — persistence-leak inventory and ratchet;
-20. #188 — world/map clock and bridge trace;
-21. #136 — private world-server session factory;
-22. #187 — persistence transaction/publication golden;
-23. #150 — opaque PlayerRegistry facade in place;
-24. #151 — opaque GroupRegistry/PendingInvites facades in place;
-25. #139 — Calendar thin-capability pathfinder;
-26. #152 — packet admission and dispatch submodules;
-27. #200 — Player lifecycle persistence port;
-28. #189 — durable loot persistence coordination;
-29. #192 — runtime/fanout directory consumer burn-down;
-30. #193 — combat/loot directory consumer burn-down;
-31. #194 — quest/spell/movement directory consumer burn-down;
-32. #197 — atomic invite/create/capacity transitions;
-33. #198 — atomic membership/leadership/ready transitions;
-34. #199 — Group persistence/publication and storage closure;
-35. #195 — social/group session-addressing adapters;
-36. #196 — PlayerRegistry storage and fixture closure;
-37. #138 — opaque session-directory relocation;
-38. #191 — ordinary mailbox-protocol relocation;
-39. #137 — encapsulated Group owner move;
-40. #190 — durable creature-runtime rail relocation;
-41. #140 — ordinary/durable Session command pump;
-42. #182 — logical realm/instance routing;
-43. #183 — Session-only phase driver;
-44. #184 — login/logout lifecycle over persistence ports;
-45. #153 — post-shell re-audit and remaining semantic cuts.
+- physical modules: #139, #152 and #224–#227;
+- encapsulation/ownership: #150–#153, #137–#140 and #182–#184;
+- runtime/persistence authority: #188–#200 plus open follow-up #204;
+- stable crate/extension seams: #228–#231 under #99.
 
-The open dependency graph is:
+#153 is the terminal audit, not a gate that postpones known work. This deterministic topological
+display is checked against the JSON ledger:
 
-```text
-#134 ─► #181
-#134 + #181 ─► #136
-#181 ─► #185, #186, #188
-#181 + #185 ─► #150, #151, #152
-#185 ─► #139
-#186 ─► #187 ─► #189
-#186 + #187 ─► #200
+1. #131 — repository-scoped architecture skills;
+2. #135 — executable boundary guardrails;
+3. #143 — interaction provenance;
+4. #146 — effective SpellInfo authority;
+5. #148 — effective SkillLine authority;
+6. #144 — validated trainer load inputs;
+7. #156 — primary-profession capacity;
+8. #163 — effective spell-acquisition metadata;
+9. #164 — deterministic acquisition outcomes;
+10. #157 — trainer offer and eligibility decisions;
+11. #158 — durable prepared spell learning;
+12. #159 — atomic normal trainer teaching;
+13. #160 — durable account-atomic battle-pet ownership;
+14. #161 — recoverable battle-pet trainer purchase;
+15. #142 — dispatcher/registration reconciliation;
+16. #154 — audited policy alignment;
+17. #134 — listener/SessionResources decoupling;
+18. #181 — ownership baseline and submodule ratchets;
+19. #185 — module-aware architecture and handler guards;
+20. #186 — persistence-leak inventory and ratchet;
+21. #204 — active-trait `Self` constant resolution;
+22. #205 — cfg-aware associated constants;
+23. #206 — faster architecture gate;
+24. #208 — remove gate dead weight;
+25. #210 — remove persistence scan from the PR path;
+26. #213 — persistence-trace gap closure;
+27. #214 — root test-module extraction;
+28. #218 — workflow-scoped persistence traces;
+29. #220 — transitional child-charging hotspot metric;
+30. #223 — roadmap, metrics and local-first synchronization;
+31. #188 — world/map clock and bridge trace;
+32. #136 — world-server composition split;
+33. #187 — Player lifecycle persistence-order golden;
+34. #150 — opaque PlayerRegistry facade;
+35. #151 — opaque GroupRegistry/PendingInvites facades;
+36. #139 — private misc capabilities;
+37. #152 — Session admission/dispatch modules;
+38. #200 — Player lifecycle persistence port;
+39. #189 — durable loot persistence coordination;
+40. #192 — runtime/fanout directory consumers;
+41. #193 — combat/loot directory consumers;
+42. #194 — quest/spell/movement directory consumers;
+43. #197 — atomic group invite/create transitions;
+44. #198 — atomic group membership/leadership transitions;
+45. #199 — Group persistence/publication closure;
+46. #195 — social/group session addressing;
+47. #196 — PlayerRegistry storage closure;
+48. #138 — opaque session-directory relocation;
+49. #191 — mailbox protocol relocation;
+50. #137 — encapsulated Group owner move;
+51. #190 — durable creature-runtime rail relocation;
+52. #140 — Session mailbox pump;
+53. #182 — logical realm/instance routing;
+54. #183 — Session-only phase driver;
+55. #184 — login/logout lifecycle modules;
+56. #224 — character/loot/quest physical modules;
+57. #225 — Map/MapManager physical modules;
+58. #226 — Player/Unit physical modules;
+59. #227 — packet/spell-data physical modules;
+60. #228 — trusted linked external module API;
+61. #229 — deterministic external Cargo composition;
+62. #230 — agent-neutral module CLI and skeleton;
+63. #231 — typed module configuration/fixtures;
+64. #153 — terminal architecture audit.
 
-#150 + #188 ─► #192
-#150 + #187 ─► #193
-#150 + #188 ─► #194
-#151 ─► #197 ─► #198
-#187 + #198 ─► #199
-#150 + #199 ─► #195
-#192 + #193 + #194 + #195 ─► #196
-#136 + #196 ─► #138 ─► #191
-#195 + #199 + #191 ─► #137
-#188 + #191 ─► #190
-
-#152 + #191 + #190 ─► #140
-#140 + external #177 ─► #182
-#182 + #188 ─► #183
-#183 + #187 + #200 + external #177 ─► #184
-#184 ─► #153
-```
-
-Some direct dependencies repeat a transitive evidence gate deliberately; for example #184 names
-#187 even though #200 also depends on it. A slice may start when every declared prerequisite is
-merged and its own branch is current. Unrelated branches may proceed in parallel, but each issue
-still maps to one reviewable PR with focused validation and no behavior-changing extraction hidden
-inside a mechanical move.
+A slice may start once its declared prerequisites are merged and its branch is current. Independent
+physical work remains parallel to semantic authority cuts. Mechanical moves use focused compile and
+contract evidence; they do not acquire gameplay-parity claims merely by reducing a file.

--- a/tools/architecture/architecture-issue-ledger.json
+++ b/tools/architecture/architecture-issue-ledger.json
@@ -11,6 +11,7 @@
     }
   ],
   "sequence": [
+    131,
     135,
     143,
     146,
@@ -30,6 +31,16 @@
     181,
     185,
     186,
+    204,
+    205,
+    206,
+    208,
+    210,
+    213,
+    214,
+    218,
+    220,
+    223,
     188,
     136,
     187,
@@ -55,13 +66,29 @@
     182,
     183,
     184,
+    224,
+    225,
+    226,
+    227,
+    228,
+    229,
+    230,
+    231,
     153
   ],
   "issues": [
     {
+      "number": 131,
+      "state": "closed",
+      "title": "[ARCH.1] Add repository-scoped RustyCore architecture skills",
+      "kind": "slice",
+      "parents": [],
+      "depends_on": []
+    },
+    {
       "number": 133,
       "state": "open",
-      "title": "[ARCH.2] Modularize RustyCore around ownership, clocks and stable boundaries",
+      "title": "[ARCH] Modularize RustyCore: physical structure, ownership and extension seams",
       "kind": "epic",
       "parents": [],
       "depends_on": []
@@ -70,6 +97,16 @@
       "number": 169,
       "state": "open",
       "title": "[ARCH.DB] Establish SQLx-free persistence ownership and dialect adapters",
+      "kind": "epic",
+      "parents": [
+        133
+      ],
+      "depends_on": []
+    },
+    {
+      "number": 99,
+      "state": "open",
+      "title": "[ARCH.MODULES] External module ecosystem: linked Rust first, sandboxed Wasm later",
       "kind": "epic",
       "parents": [
         133
@@ -98,8 +135,8 @@
     },
     {
       "number": 136,
-      "state": "open",
-      "title": "[ARCH.2.3] Extract a private world-server session factory",
+      "state": "closed",
+      "title": "[ARCH.MOD.WORLD-SERVER] Split the composition root and extract the session factory",
       "kind": "slice",
       "parents": [
         133
@@ -139,7 +176,7 @@
     {
       "number": 139,
       "state": "open",
-      "title": "[ARCH.2.6] Extract Calendar as the first thin handler capability",
+      "title": "[ARCH.MOD.MISC] Split misc handlers into private capability modules",
       "kind": "slice",
       "parents": [
         133
@@ -151,7 +188,7 @@
     {
       "number": 140,
       "state": "open",
-      "title": "[ARCH.2.7b] Extract the ordinary/durable Session command pump",
+      "title": "[ARCH.MOD.MAILBOX] Extract Session mailbox protocol, durable rails and pump",
       "kind": "slice",
       "parents": [
         133
@@ -241,7 +278,7 @@
     {
       "number": 152,
       "state": "open",
-      "title": "[ARCH.2.7a] Extract WorldSession packet admission and dispatch submodules",
+      "title": "[ARCH.MOD.SESSION] Split WorldSession admission, dispatch and test structure",
       "kind": "slice",
       "parents": [
         133
@@ -254,7 +291,7 @@
     {
       "number": 153,
       "state": "open",
-      "title": "[ARCH.2.8] Re-audit the Session shell and materialize remaining semantic cuts",
+      "title": "[ARCH.CLOSE] Audit the completed modular architecture and retire remaining exceptions",
       "kind": "slice",
       "parents": [
         133
@@ -394,7 +431,7 @@
     {
       "number": 184,
       "state": "open",
-      "title": "[ARCH.2.7e] Extract Session login/logout lifecycle over persistence ports",
+      "title": "[ARCH.MOD.LIFECYCLE] Extract Session login and logout lifecycle modules",
       "kind": "slice",
       "parents": [
         133
@@ -434,7 +471,7 @@
     {
       "number": 187,
       "state": "open",
-      "title": "[ARCH.DB.2] Freeze persistence transaction and publication order before ports",
+      "title": "[ARCH.DB.2] Freeze Player lifecycle persistence order before its port",
       "kind": "slice",
       "parents": [
         133,
@@ -471,28 +508,23 @@
     },
     {
       "number": 190,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.2.4i] Move durable creature-runtime command storage out of wow-network",
       "kind": "slice",
       "parents": [
         133
       ],
-      "depends_on": [
-        188,
-        191
-      ]
+      "depends_on": []
     },
     {
       "number": 191,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.2.4h] Relocate the session mailbox protocol out of wow-network",
       "kind": "slice",
       "parents": [
         133
       ],
-      "depends_on": [
-        138
-      ]
+      "depends_on": []
     },
     {
       "number": 192,
@@ -611,6 +643,150 @@
         186,
         187
       ]
+    },
+    {
+      "number": 204,
+      "state": "open",
+      "title": "[ARCH.DB.1a] Resolve Self constants through the active trait impl",
+      "kind": "slice",
+      "parents": [133, 169],
+      "depends_on": [186]
+    },
+    {
+      "number": 205,
+      "state": "closed",
+      "title": "[ARCH.DB.1b] Respect cfg attributes on trait associated constants",
+      "kind": "slice",
+      "parents": [133, 169],
+      "depends_on": [186]
+    },
+    {
+      "number": 206,
+      "state": "closed",
+      "title": "[ARCH.PERF] Make the architecture gate fast: release profile, one scan, incremental caches",
+      "kind": "slice",
+      "parents": [133],
+      "depends_on": [185]
+    },
+    {
+      "number": 208,
+      "state": "closed",
+      "title": "[ARCH.PERF.1] Cut the gate's dead weight: redundant check, decorative clippy, unused scan",
+      "kind": "slice",
+      "parents": [133],
+      "depends_on": [206]
+    },
+    {
+      "number": 210,
+      "state": "closed",
+      "title": "[ARCH.PERF.2] Take the exact persistence scan off the PR path",
+      "kind": "slice",
+      "parents": [133],
+      "depends_on": [208]
+    },
+    {
+      "number": 213,
+      "state": "closed",
+      "title": "[ARCH.DB.2a] Close the persistence-trace gaps Codex found on #212",
+      "kind": "slice",
+      "parents": [133, 169],
+      "depends_on": [186]
+    },
+    {
+      "number": 214,
+      "state": "closed",
+      "title": "[ARCH.2.0] Extract the test modules that make the hotspots monstrous",
+      "kind": "slice",
+      "parents": [133],
+      "depends_on": [181]
+    },
+    {
+      "number": 218,
+      "state": "closed",
+      "title": "[ARCH.DB.2a] Scope the persistence recorder to a workflow and correlate its transactions",
+      "kind": "slice",
+      "parents": [133, 169],
+      "depends_on": [186]
+    },
+    {
+      "number": 220,
+      "state": "closed",
+      "title": "[ARCH] Charge ordinary external modules to their parent in the hotspot ratchet",
+      "kind": "slice",
+      "parents": [133],
+      "depends_on": [214]
+    },
+    {
+      "number": 223,
+      "state": "open",
+      "title": "[ARCH.PLAN] Align the modular roadmap, physical metrics and local-first policy",
+      "kind": "slice",
+      "parents": [133],
+      "depends_on": [220]
+    },
+    {
+      "number": 224,
+      "state": "open",
+      "title": "[ARCH.MOD.HANDLERS] Split character, loot and quest into private feature modules",
+      "kind": "slice",
+      "parents": [133],
+      "depends_on": []
+    },
+    {
+      "number": 225,
+      "state": "open",
+      "title": "[ARCH.MOD.MAP] Split Map and MapManager into private runtime modules",
+      "kind": "slice",
+      "parents": [133],
+      "depends_on": []
+    },
+    {
+      "number": 226,
+      "state": "open",
+      "title": "[ARCH.MOD.ENTITIES] Split Player and Unit subsystems into private domain modules",
+      "kind": "slice",
+      "parents": [133],
+      "depends_on": []
+    },
+    {
+      "number": 227,
+      "state": "open",
+      "title": "[ARCH.MOD.PROTOCOL] Split packet and spell-data hotspots by protocol domain",
+      "kind": "slice",
+      "parents": [133],
+      "depends_on": []
+    },
+    {
+      "number": 228,
+      "state": "open",
+      "title": "[ARCH.MODULES.1] Land the trusted linked module API with player.login to message",
+      "kind": "slice",
+      "parents": [133, 99],
+      "depends_on": []
+    },
+    {
+      "number": 229,
+      "state": "open",
+      "title": "[ARCH.MODULES.2] Compose external Cargo modules deterministically",
+      "kind": "slice",
+      "parents": [133, 99],
+      "depends_on": [228]
+    },
+    {
+      "number": 230,
+      "state": "open",
+      "title": "[ARCH.MODULES.3] Ship the agent-neutral module manager and official skeleton",
+      "kind": "slice",
+      "parents": [133, 99],
+      "depends_on": [229]
+    },
+    {
+      "number": 231,
+      "state": "open",
+      "title": "[ARCH.MODULES.4] Add typed module configuration and compatibility fixtures",
+      "kind": "slice",
+      "parents": [133, 99],
+      "depends_on": [230]
     }
   ]
 }

--- a/tools/architecture/check_architecture.py
+++ b/tools/architecture/check_architecture.py
@@ -1018,6 +1018,12 @@ def validate_runtime_ownership_ledger(
                 production = entry.get("production_lines")
                 tests = entry.get("test_lines")
                 total = entry.get("total_lines")
+                logical_scope = entry.get("logical_scope", "module")
+                if logical_scope not in {"module", "crate"}:
+                    raise ArchitectureError(
+                        f"runtime ownership hotspot {entry_id} logical_scope must be "
+                        "module or crate"
+                    )
                 if any(type(value) is not int or value < 0 for value in (production, tests, total)):
                     raise ArchitectureError(
                         f"runtime ownership hotspot {entry_id} needs non-negative line counts"
@@ -2277,7 +2283,35 @@ def run_hotspot_classifier_self_tests() -> int:
     return 1
 
 
-HOTSPOT_ROW_CACHE: dict[pathlib.Path, tuple[int, int, int, str]] = {}
+def run_hotspot_view_self_tests(runtime: dict[str, Any]) -> int:
+    """Prove physical files and logical private descendants stay independent."""
+    physical = {row[3]: row for row in physical_hotspot_rows(limit=None)}
+    main_path = "crates/world-server/src/main.rs"
+    if main_path not in physical or physical[main_path][0] >= 100:
+        raise ArchitectureError(
+            "physical hotspot view did not preserve the thin world-server main file"
+        )
+
+    runtime_root = REPO_ROOT / "crates/world-server/src/runtime/mod.rs"
+    runtime_files = logical_hotspot_files(runtime_root, "module")
+    expected_child = REPO_ROOT / "crates/world-server/src/runtime/delivery.rs"
+    if expected_child not in runtime_files:
+        raise ArchitectureError(
+            "logical hotspot view did not include an ordinary adjacent Rust submodule"
+        )
+
+    logical = {row[3]: row for row in logical_hotspot_rows(runtime, limit=None)}
+    composition_root = "crates/world-server/src/lib.rs"
+    if composition_root not in logical:
+        raise ArchitectureError("logical hotspot view omitted the composition owner")
+    if logical[composition_root][0] <= physical[composition_root][0]:
+        raise ArchitectureError(
+            "logical composition owner did not include its private descendants"
+        )
+    return 3
+
+
+HOTSPOT_ROW_CACHE: dict[tuple[pathlib.Path, str], tuple[int, int, int, str]] = {}
 
 
 PATH_MODULE_MOUNTS_COMMAND = (
@@ -2342,26 +2376,73 @@ def path_module_children(path: pathlib.Path, source: str) -> list[tuple[pathlib.
     return path_module_mounts().get(path, [])
 
 
-def hotspot_row(path: pathlib.Path) -> tuple[int, int, int, str]:
-    cached = HOTSPOT_ROW_CACHE.get(path)
-    if cached is not None:
-        return cached
+def physical_hotspot_row(path: pathlib.Path) -> tuple[int, int, int, str]:
+    """Count one real source file without charging any child module to it."""
     try:
         source = path.read_text(encoding="utf-8")
     except OSError as exc:
         raise ArchitectureError(f"cannot read Rust source {path}: {exc}") from exc
-    total_lines, production_lines, test_lines = hotspot_line_counts(source)
-    # A `#[path]` child counts against the module that mounts it. Without this
-    # the ceiling applies to whatever stayed behind: moving 94,000 test lines
-    # into a sibling would leave the parent capped at what remains and the
-    # sibling capped by nothing, so the extraction would silently retire the
-    # ratchet it was supposed to leave intact.
-    for child, mounted_under_cfg_test in path_module_children(path, source):
-        child_total, child_production, child_tests = hotspot_row(child)[:3]
+    total, production, tests = hotspot_line_counts(source)
+    return total, production, tests, path.relative_to(REPO_ROOT).as_posix()
+
+
+def logical_hotspot_files(path: pathlib.Path, scope: str) -> dict[pathlib.Path, bool]:
+    """Resolve the reviewed private descendants of one logical owner.
+
+    A normal multi-file Rust module keeps descendants below the adjacent
+    directory (`session.rs` + `session/` or `session/mod.rs`). Composition roots
+    may explicitly own their full crate source tree. `#[path]` children are
+    followed as well so the logical view remains compatible with transitional
+    mounts while the physical view always reports each real file separately.
+    """
+    if scope not in {"module", "crate"}:
+        raise ArchitectureError(
+            f"logical hotspot {path} has unsupported logical_scope {scope!r}"
+        )
+    files = {path: False}
+    if scope == "crate":
+        candidates = path.parent.glob("**/*.rs")
+    else:
+        module_dir = path.parent if path.name == "mod.rs" else path.with_suffix("")
+        candidates = module_dir.glob("**/*.rs") if module_dir.is_dir() else ()
+    for candidate in candidates:
+        relative_parts = candidate.relative_to(path.parent).parts
+        files[candidate] = (
+            candidate.stem == "tests"
+            or candidate.stem.endswith("_tests")
+            or "tests" in relative_parts
+        )
+
+    pending = list(files)
+    while pending:
+        parent = pending.pop()
+        try:
+            source = parent.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ArchitectureError(f"cannot read Rust source {parent}: {exc}") from exc
+        for child, mounted_under_cfg_test in path_module_children(parent, source):
+            test_only = files[parent] or mounted_under_cfg_test
+            if child not in files or (test_only and not files[child]):
+                files[child] = test_only
+                pending.append(child)
+    return files
+
+
+def logical_hotspot_row(
+    path: pathlib.Path, scope: str = "module"
+) -> tuple[int, int, int, str]:
+    cache_key = (path, scope)
+    cached = HOTSPOT_ROW_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    total_lines = 0
+    production_lines = 0
+    test_lines = 0
+    logical_files = logical_hotspot_files(path, scope)
+    for source_path, mounted_under_cfg_test in logical_files.items():
+        child_total, child_production, child_tests, _ = physical_hotspot_row(source_path)
         total_lines += child_total
         if mounted_under_cfg_test:
-            # The mount supplies the cfg, so none of the child is production
-            # however the file itself reads.
             test_lines += child_total
         else:
             production_lines += child_production
@@ -2372,23 +2453,29 @@ def hotspot_row(path: pathlib.Path) -> tuple[int, int, int, str]:
         test_lines,
         path.relative_to(REPO_ROOT).as_posix(),
     )
-    HOTSPOT_ROW_CACHE[path] = row
+    HOTSPOT_ROW_CACHE[cache_key] = row
     return row
 
 
-def hotspot_rows(limit: int | None = 10) -> list[tuple[int, int, int, str]]:
+def physical_hotspot_rows(
+    limit: int | None = 10,
+) -> list[tuple[int, int, int, str]]:
     crates_root = REPO_ROOT / "crates"
     sources = sorted(crates_root.glob("*/src/**/*.rs"))
-    mounted: set[pathlib.Path] = set()
-    for path in sources:
-        try:
-            source = path.read_text(encoding="utf-8")
-        except OSError as exc:
-            raise ArchitectureError(f"cannot read Rust source {path}: {exc}") from exc
-        mounted.update(child for child, _ in path_module_children(path, source))
-    # Mounted children are already inside their parent's row; listing them again
-    # would double-count them in the report.
-    rows = [hotspot_row(path) for path in sources if path.resolve() not in mounted]
+    rows = [physical_hotspot_row(path) for path in sources]
+    rows.sort(key=lambda row: (-row[0], row[3]))
+    return rows if limit is None else rows[:limit]
+
+
+def logical_hotspot_rows(
+    runtime: dict[str, Any], limit: int | None = 10
+) -> list[tuple[int, int, int, str]]:
+    rows = [
+        logical_hotspot_row(
+            REPO_ROOT / entry["path"], entry.get("logical_scope", "module")
+        )
+        for entry in runtime["inventories"]["hotspots"]["entries"]
+    ]
     rows.sort(key=lambda row: (-row[0], row[3]))
     return rows if limit is None else rows[:limit]
 
@@ -2407,7 +2494,7 @@ def validate_hotspot_non_growth(
     here.
     """
     if live_rows is None:
-        live_rows = hotspot_rows(limit=None)
+        live_rows = logical_hotspot_rows(runtime, limit=None)
 
     live_by_path: dict[str, tuple[int, int, int]] = {}
     for total, production, tests, path in live_rows:
@@ -2521,12 +2608,16 @@ def run_hotspot_ratchet_self_tests(runtime: dict[str, Any]) -> tuple[int, int]:
     return len(growth_cases) + 1, 1
 
 
-def print_hotspots(limit: int = 10) -> None:
+def print_hotspots(runtime: dict[str, Any], limit: int = 10) -> None:
     print(
-        "Architecture hotspots (reporting; exact top-level #[cfg(test)] item extents):"
+        "Physical Rust files (reporting; each real file counted independently):"
     )
     print(f"{'total':>8} {'prod':>8} {'tests':>8}  path")
-    for total, production, tests, path in hotspot_rows(limit):
+    for total, production, tests, path in physical_hotspot_rows(limit):
+        print(f"{total:8d} {production:8d} {tests:8d}  {path}")
+    print("Logical owners (curated roots including reviewed private descendants):")
+    print(f"{'total':>8} {'prod':>8} {'tests':>8}  owner root")
+    for total, production, tests, path in logical_hotspot_rows(runtime, limit):
         print(f"{total:8d} {production:8d} {tests:8d}  {path}")
 
 
@@ -3464,6 +3555,7 @@ def main() -> int:
             )
             run_path_module_scanner_self_tests()
             hotspot_classifier_fixtures = run_hotspot_classifier_self_tests()
+            hotspot_view_assertions = run_hotspot_view_self_tests(runtime_ledger)
             hotspot_ratchet_rejections, hotspot_reduction_acceptances = (
                 run_hotspot_ratchet_self_tests(runtime_ledger)
             )
@@ -3473,6 +3565,7 @@ def main() -> int:
                 f"{debt_ownership_fixtures} debt-ownership rejections, "
                 f"{runtime_ownership_rejections} runtime-ownership rejections, "
                 f"{hotspot_classifier_fixtures} hotspot-classifier fixture, "
+                f"{hotspot_view_assertions} physical/logical view assertions, "
                 f"{hotspot_ratchet_rejections} hotspot-ratchet rejections, "
                 f"{hotspot_reduction_acceptances} hotspot-reduction acceptance, "
                 f"{handler_module_policy_rejections} handler-module-policy rejections)"
@@ -3480,7 +3573,8 @@ def main() -> int:
         elif args.command == "hotspots":
             if args.limit <= 0:
                 raise ArchitectureError("--limit must be positive")
-            print_hotspots(args.limit)
+            runtime_ledger = load_json(args.runtime_ledger)
+            print_hotspots(runtime_ledger, args.limit)
         else:
             (
                 packages,
@@ -3508,10 +3602,10 @@ def main() -> int:
             )
             print(
                 "Architecture hotspot ratchet: PASS "
-                f"({audited_hotspots} audited files; production/test/total "
+                f"({audited_hotspots} audited logical owners; production/test/total "
                 "metrics are at or below baseline)"
             )
-            print_hotspots()
+            print_hotspots(runtime_ledger)
     except ArchitectureError as exc:
         print(f"architecture check failed: {exc}", file=sys.stderr)
         return 1

--- a/tools/architecture/dependency-policy.json
+++ b/tools/architecture/dependency-policy.json
@@ -144,8 +144,8 @@
     {
       "from": "wow-network",
       "to": "wow-loot",
-      "tracking_issue": 191,
-      "reason": "PlayerBroadcastInfo, durable coordination, and SessionCommand payloads still carry wow-loot values. #189 removes the durable persistence tracker, #138 relocates the opaque directory after its consumers are closed, and #191 relocates the remaining ordinary application mailbox payloads and removes the final direct edge."
+      "tracking_issue": 140,
+      "reason": "PlayerBroadcastInfo and SessionCommand payloads still carry wow-loot values after the completed protocol/rail relocations #191/#190. #189 removes durable persistence coordination, #138 closes the directory path, and #140 owns the remaining mailbox-pump boundary and final direct edge decision."
     },
     {
       "from": "wow-packet",

--- a/tools/architecture/persistence-boundary-policy.json
+++ b/tools/architecture/persistence-boundary-policy.json
@@ -3186,11 +3186,10 @@
       "current_order": "No runtime order is inferred from this shared dependency/type surface; consumers retain their own traced order.",
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
-        136,
         153,
         200
       ],
-      "retirement_condition": "The annotated issues [136, 153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {

--- a/tools/architecture/persistence-boundary-workflows.json
+++ b/tools/architecture/persistence-boundary-workflows.json
@@ -1695,7 +1695,6 @@
       ],
       "boundary": "world-server session composition boundary",
       "target_issues": [
-        136,
         153,
         200
       ],

--- a/tools/architecture/runtime-ownership-ledger.json
+++ b/tools/architecture/runtime-ownership-ledger.json
@@ -98,10 +98,10 @@
         "mirror_direction": "Logical connection selection in Session points to opaque physical handles in wow-network; no gameplay state may flow back into transport.",
         "target_owner": "wow-network for physical transport and fences; transitional wow_world::session::connection, terminal wow-session, for logical routing.",
         "cutover_issues": [
+          153,
           177,
           182,
-          184,
-          153
+          184
         ],
         "rollback_condition": "Restore the previous logical router while retaining both physical sockets if connection choice, packet bytes, FIFO fences, or stale-incarnation rejection changes.",
         "retirement_condition": "WorldSession stores only opaque transport handles and logical route state; no socket task, writer implementation, or raw network registry is owned by gameplay code."
@@ -129,8 +129,8 @@
         "target_owner": "transitional wow_world::session::{admission,dispatch}, terminal wow-session with wow-handler metadata contracts.",
         "cutover_issues": [
           152,
-          183,
-          153
+          153,
+          183
         ],
         "rollback_condition": "Restore the prior private module/re-export if opcode metadata, status gates, processing mode, wildcard behavior, budgets, or packet order differs.",
         "retirement_condition": "Admission and dispatch compile as private cohesive modules, retain one concrete dispatcher, and expose no gameplay service locator."
@@ -155,11 +155,9 @@
         "mirror_direction": "Typed owner outcome to Session delivery only. Delayed payloads must not write stale gameplay values back to Player or Map.",
         "target_owner": "transitional wow_world::session::mailbox, terminal wow-session mailbox; durable map outcomes originate in wow-map.",
         "cutover_issues": [
-          191,
-          190,
           140,
-          188,
-          153
+          153,
+          188
         ],
         "rollback_condition": "Restore the prior protocol location without changing the queue if FIFO, capacity, acknowledgement, incarnation, overload-disconnect, or shutdown behavior changes.",
         "retirement_condition": "wow-network owns no application command payload; gameplay variants are replaced by bounded owner outcomes and Session retains only control/delivery protocol."
@@ -186,19 +184,19 @@
         "mirror_direction": "Player/Group facts are currently projected into directory/session fields; no directory write may become a second gameplay authority.",
         "target_owner": "opaque Session directory for identity/addressing, wow-social for Group/PendingInvites, canonical Player for player-local social references.",
         "cutover_issues": [
+          137,
+          138,
           150,
+          151,
+          153,
           192,
           193,
           194,
           195,
           196,
-          138,
-          151,
           197,
           198,
-          199,
-          137,
-          153
+          199
         ],
         "rollback_condition": "Restore the previous facade adapter if recipient sets, generations, Group invariants, persistence order, or packet order differs; never reopen raw backing storage.",
         "retirement_condition": "WorldSession retains only an opaque directory handle and local Group identity; Group state, pending invites, raw map guards, and broad player projections are absent."
@@ -239,12 +237,12 @@
         "mirror_direction": "Durable rows load into represented Session/Player state; committed application outcomes publish outward. Unknown commit reconciles from durable truth before publication.",
         "target_owner": "wow-session lifecycle orchestration over SQLx-free wow-persistence ports; wow-database remains the sole concrete SQLx/dialect adapter.",
         "cutover_issues": [
-          187,
-          200,
-          189,
-          184,
+          153,
           169,
-          153
+          184,
+          187,
+          189,
+          200
         ],
         "rollback_condition": "Revert the port adapter, not the durable data, if statement/transaction/fence/publication traces differ or unknown-commit recovery is weaker.",
         "retirement_condition": "WorldSession imports no pool, row, SQLx transaction/error, raw SQL, or concrete database aggregate; lifecycle uses typed ports with equivalent failure semantics."
@@ -448,7 +446,6 @@
         "mirror_direction": "These are dependency copies/handles rather than gameplay mirrors, but copying the entire bag into Session obscures the real reader boundary.",
         "target_owner": "world-server bootstrap/composition plus capability-specific immutable wow-data views or narrow application services; final owner must be confirmed per field by #153.",
         "cutover_issues": [
-          136,
           139,
           152,
           153
@@ -489,13 +486,13 @@
         "mirror_direction": "Loaded/respawn state begins canonical to legacy; only explicitly named legacy outcomes flow back to canonical. No generic bidirectional synchronization is allowed.",
         "target_owner": "wow-map runtime/storage for live map entities and clocks; wow-entities for entity state; Session retains only PlayerHandle and delivery adaptation.",
         "cutover_issues": [
-          188,
           28,
-          190,
+          140,
+          153,
+          188,
           192,
           193,
-          194,
-          153
+          194
         ],
         "rollback_condition": "Flip the bounded method back to its previous authoritative implementation if phase trace, recipient set, packet order, or single-tick evidence differs; never enable both writers.",
         "retirement_condition": "Every transition has one canonical Map/Entity writer and clock, its legacy bridge is deleted, and no delivery/await/persistence occurs under Map guards."
@@ -578,12 +575,12 @@
         "mirror_direction": "Character DB loads into represented state; narrow directory snapshots publish outward. Directory or packet payloads may not become a mutable inventory/loot owner.",
         "target_owner": "wow-entities::Player inventory/economy, wow-loot for loot rules/authority, wow-persistence ports for durability, thin wow-world handlers for adaptation.",
         "cutover_issues": [
+          153,
           187,
           189,
           193,
           196,
-          200,
-          153
+          200
         ],
         "rollback_condition": "Restore the prior capability adapter if item identity, money, loot eligibility, roll order, transaction order, or packet bytes differ; do not restore raw directory access.",
         "retirement_condition": "Player/loot owners hold one mutable copy, directory projections are bounded and versioned or removed, and SQL/pool types are absent from handlers and Session."
@@ -765,10 +762,10 @@
         "mirror_direction": "Durable rows and immutable metadata compose into represented state; acquisition outcomes publish after commit. Flat trigger lists or incomplete rows cannot claim complete authority.",
         "target_owner": "canonical wow-entities::Player submodules and populated domain capabilities such as wow-spell; durability through wow-persistence; handlers remain adapters.",
         "cutover_issues": [
-          194,
-          200,
+          153,
           169,
-          153
+          194,
+          200
         ],
         "rollback_condition": "Restore the previous per-capability adapter if spell/quest criteria, order, persistence, or packets differ; retain completed atomic acquisition/saga boundaries.",
         "retirement_condition": "Each complete responsibility has one Player/domain owner, one durable port, and no duplicate Session/directory mutable mirror."
@@ -864,12 +861,12 @@
         "mirror_direction": "WorldSession currently builds canonical Player snapshots and consumes selected Map outcomes. PlayerBroadcastInfo is an outward temporary projection, never a writer.",
         "target_owner": "wow-entities::Player for mutable player state and per-client visibility membership; wow-map for spatial traversal, scheduling and in-world mutation; Session for routing/delivery only.",
         "cutover_issues": [
+          153,
+          183,
           188,
           192,
           194,
-          196,
-          183,
-          153
+          196
         ],
         "rollback_condition": "Re-enable only the previous single owner for the bounded method if phase order, movement ACKs, visibility recipients, combat outcome, or packet order differs.",
         "retirement_condition": "Player/Map are the only mutable owners, Session retains an opaque generation-checked PlayerHandle, and all Session/directory gameplay mirrors for the migrated family are removed."
@@ -908,14 +905,14 @@
         "mirror_direction": "Group facts project to Player/session views and delivery outcomes; session presence must not become membership authority.",
         "target_owner": "wow-social for Group/PendingInvites and stable social rules, canonical Player for player-local views, thin wow-world capability handlers, Session directory for addressing only.",
         "cutover_issues": [
+          137,
           139,
           151,
+          153,
+          195,
           197,
           198,
-          199,
-          195,
-          137,
-          153
+          199
         ],
         "rollback_condition": "Restore the prior adapter if Group atomicity, member order, packet order, persistence, or offline/stale-generation behavior differs; never reopen raw maps.",
         "retirement_condition": "Group/Calendar capabilities own transitions, handlers only decode/adapt/encode, and WorldSession contains only player-local Session state."
@@ -961,10 +958,9 @@
         "mirror_direction": "Auth/realm snapshots flow into Session; Player gameplay state must not flow back into identity fields.",
         "target_owner": "terminal wow-session::identity plus typed immutable realm/account policy supplied by world-server composition.",
         "cutover_issues": [
-          136,
+          153,
           182,
-          184,
-          153
+          184
         ],
         "rollback_condition": "Restore the prior private constructor mapping if authentication identity, feature flags, locale/build gates, or character claims differ.",
         "retirement_condition": "Identity is a cohesive Session value with required construction fields and no gameplay/database/catalog ownership."
@@ -990,11 +986,11 @@
         "target_owner": "transitional wow_world::session::driver/lifecycle, terminal wow-session driver with explicit phase inputs and outputs.",
         "cutover_issues": [
           140,
+          153,
           182,
           183,
           184,
-          188,
-          153
+          188
         ],
         "rollback_condition": "Restore the previous phase driver if command budgets, timer behavior, save/logout order, tick ownership, or packet order differs.",
         "retirement_condition": "The Session driver advances only Session protocol/lifecycle clocks and invokes typed owner capabilities without hidden gameplay mutation."
@@ -1152,9 +1148,9 @@
           ],
           "owner": "world-server composition currently stores concrete adapters; wow-database owns their implementation.",
           "open_retirement_issues": [
+            169,
             187,
-            200,
-            169
+            200
           ],
           "retirement_condition": "Session construction supplies typed wow-persistence capability ports rather than concrete database/pool aggregates."
         },
@@ -1168,12 +1164,11 @@
           ],
           "owner": "world-server composition holds handles; underlying owners are currently wow-network registries/mailboxes.",
           "open_retirement_issues": [
-            150,
-            151,
+            137,
             138,
-            191,
-            190,
-            137
+            140,
+            150,
+            151
           ],
           "retirement_condition": "Only opaque directory, mailbox and Group capability handles are composed; raw storage/payload types are absent."
         },
@@ -1185,9 +1180,9 @@
           ],
           "owner": "world-server composition stores handles; legacy and canonical runtime owners remain distinct and audited by #188.",
           "open_retirement_issues": [
-            188,
-            190,
-            153
+            140,
+            153,
+            188
           ],
           "retirement_condition": "Session receives only the minimal typed runtime ports/PlayerHandle and cannot select or tick duplicate map authorities."
         },
@@ -1372,7 +1367,6 @@
           ],
           "owner": "world-server bootstrap/composition; immutable data remains owned by wow-data or its defining crate.",
           "open_retirement_issues": [
-            136,
             139,
             153
           ],
@@ -1447,7 +1441,6 @@
           ],
           "owner": "world-server composition; semantic consumer not yet classified.",
           "open_retirement_issues": [
-            136,
             153
           ],
           "retirement_condition": "Every remaining field has an exact capability bundle/consumer owner or is removed from Session construction."
@@ -1489,10 +1482,10 @@
           ],
           "owner": "network-owned PlayerRegistry currently; terminal owner is the opaque Session directory for identity, incarnation and addressing only.",
           "open_retirement_issues": [
-            150,
-            196,
             138,
-            191
+            140,
+            150,
+            196
           ],
           "retirement_condition": "The directory stores only generation-checked identity/addressing handles; raw senders and broad entries do not escape."
         },
@@ -1508,12 +1501,11 @@
           ],
           "owner": "Player/session publishes receiver-local delivery state into PlayerRegistry; Map selects spatial candidates and Player owns client-visible membership.",
           "open_retirement_issues": [
+            138,
+            140,
             188,
             192,
-            196,
-            138,
-            191,
-            190
+            196
           ],
           "retirement_condition": "Only bounded generation/versioned delivery handles remain; visibility membership is Player-owned and spatial traversal is Map-owned."
         },
@@ -1573,12 +1565,12 @@
           ],
           "owner": "Temporary PlayerBroadcastInfo projection; canonical owner varies by field and must be recorded field-by-field by #196/#153.",
           "open_retirement_issues": [
+            153,
             192,
             193,
             194,
             195,
-            196,
-            153
+            196
           ],
           "retirement_condition": "Every field is removed or replaced by the minimum immutable versioned query result from its canonical Player/Map/Group owner."
         },
@@ -1623,8 +1615,8 @@
           ],
           "owner": "Temporary PlayerBroadcastInfo projection; canonical owner is deliberately unresolved rather than inferred from its name.",
           "open_retirement_issues": [
-            196,
-            153
+            153,
+            196
           ],
           "retirement_condition": "The #196 field ledger assigns each residual to a canonical owner and cut; no unclassified broad projection remains."
         }
@@ -1663,7 +1655,6 @@
           ],
           "owner": "wow-network currently defines the enum; the owning Session task is the sole consumer and logical routing owner.",
           "open_retirement_issues": [
-            191,
             140,
             182
           ],
@@ -1691,11 +1682,10 @@
           ],
           "owner": "wow-network currently defines payloads; canonical/legacy Map owners commit transitions and Session applies receiver-local delivery/presentation.",
           "open_retirement_issues": [
+            140,
+            153,
             188,
-            190,
-            191,
-            192,
-            153
+            192
           ],
           "retirement_condition": "Map-owned typed outcomes replace gameplay payload variants; Session protocol retains only bounded delivery facts and never rewrites stale gameplay state."
         },
@@ -1711,11 +1701,11 @@
           ],
           "owner": "wow-network currently defines payloads; wow-loot and durable persistence coordination own decisions and commit ordering.",
           "open_retirement_issues": [
+            140,
+            153,
             187,
             189,
-            193,
-            191,
-            153
+            193
           ],
           "retirement_condition": "Loot owner outcomes and persistence outcomes cross the Session boundary without embedding mutable loot authority or trackers."
         },
@@ -1729,9 +1719,9 @@
           ],
           "owner": "wow-network currently defines payloads; represented Player/quest capability owns state and Session owns recipient delivery.",
           "open_retirement_issues": [
-            194,
-            191,
-            153
+            140,
+            153,
+            194
           ],
           "retirement_condition": "Quest capability returns typed outcomes and Session mailbox contains only addressing/delivery data."
         },
@@ -1753,14 +1743,14 @@
           ],
           "owner": "wow-network currently defines payloads; Group/wow-social or canonical Player owns transitions and Session applies receiver-local facts.",
           "open_retirement_issues": [
+            137,
+            140,
             151,
+            153,
             195,
             197,
             198,
-            199,
-            137,
-            191,
-            153
+            199
           ],
           "retirement_condition": "Group/social/Player outcomes are typed at their owner; Session mailbox performs generation-checked delivery without reimplementing invariants."
         }
@@ -1769,7 +1759,8 @@
     "legacy_canonical_bridges": {
       "coverage_source": {
         "files": [
-          "crates/world-server/src/main.rs",
+          "crates/world-server/src/runtime/delivery.rs",
+          "crates/world-server/src/runtime/game_events.rs",
           "crates/wow-world/src/session.rs",
           "crates/wow-world/src/map_manager.rs",
           "crates/wow-world/src/handlers/loot.rs"
@@ -1786,9 +1777,9 @@
           "direction": "canonical wow-map loaded/spawned creature -> legacy wow-world MapManager",
           "owner": "canonical load/spawn path supplies the source; world-server bridge performs the compatibility insertion.",
           "open_retirement_issues": [
-            188,
             28,
-            153
+            153,
+            188
           ],
           "retirement_condition": "Legacy creature storage is no longer read for the complete migrated load/spawn/runtime transition."
         },
@@ -1804,10 +1795,10 @@
           "direction": "selected committed legacy movement/aggro/melee/spell/lifecycle outcomes -> canonical wow-map state, then post-lock delivery",
           "owner": "GlobalLegacy is the production transition writer; named bridge code applies only explicitly modeled outcomes to canonical state.",
           "open_retirement_issues": [
-            188,
             28,
-            190,
-            153
+            140,
+            153,
+            188
           ],
           "retirement_condition": "Each method executes directly under canonical Map authority and the corresponding legacy function, write-back, and delivery compatibility rail are deleted."
         },
@@ -1820,9 +1811,9 @@
           "direction": "represented WorldSession player fields -> rebuilt wow_entities::Player snapshot -> canonical map",
           "owner": "WorldSession remains the current mutable represented-player writer; the snapshot is not an independent writer.",
           "open_retirement_issues": [
+            153,
             194,
-            196,
-            153
+            196
           ],
           "retirement_condition": "Map stores the one canonical mutable Player and Session retains only a generation-checked PlayerHandle."
         },
@@ -1834,10 +1825,10 @@
           "direction": "loot release/state decisions reconcile explicit legacy and canonical creature/GameObject state without shared storage",
           "owner": "current loot handler coordinates both managers; underlying loot and map authorities remain distinct.",
           "open_retirement_issues": [
+            153,
             188,
             189,
-            193,
-            153
+            193
           ],
           "retirement_condition": "Loot reads and mutations use one canonical entity/view owner and no dual-manager reconciliation remains."
         },
@@ -1847,8 +1838,8 @@
           "direction": "unclassified; no direction or ownership may be inferred",
           "owner": "Current containing function until #188 classifies the writer and phase.",
           "open_retirement_issues": [
-            188,
-            153
+            153,
+            188
           ],
           "retirement_condition": "Every discovered bridge site is assigned to a named direction/owner and a concrete method cut, or removed."
         }
@@ -1868,7 +1859,6 @@
           "id": "exact_persistence_semantic_policy",
           "owner": "persistence-boundary-workflows.json is the reviewed semantic authority; persistence-boundary-policy.json is its canonical generated projection over the exact snapshot.",
           "open_retirement_issues": [
-            136,
             153,
             187,
             189,
@@ -1919,14 +1909,14 @@
           ],
           "owner": "Concrete wow-world handler modules; canonical gameplay owner varies by command and is not the handler.",
           "open_retirement_issues": [
+            153,
             192,
             193,
             194,
             195,
             197,
             198,
-            199,
-            153
+            199
           ],
           "retirement_condition": "Each handler decodes, invokes one typed capability, and encodes/delivers an ordered outcome without raw registry, DB, Map guard, or gameplay rules."
         },
@@ -1946,8 +1936,9 @@
     "hotspots": {
       "coverage_source": {
         "command": "python3 tools/architecture/check_architecture.py hotspots --limit 20",
-        "measurement": "physical checked-in Rust source lines; lines from each exact top-level cfg(test) attribute through the end of its attached Rust item are test lines, all other lines are production lines, and each recorded production/test/total metric is an independent non-growth ceiling with reductions accepted",
-        "baseline_commit": "002d3d8795ad895ee2d639375b59f4b6ca38df67"
+        "measurement": "two independent views: every real Rust file is reported physically, while each checked-in row is a logical owner ceiling including its reviewed private descendants; production/test/total remain independent non-growth ceilings",
+        "physical_review_signals": "review a productive file around 2,000 lines; above 4,000 lines require a split plan or explicit cohesive exception; these are review signals, not daily blocking limits",
+        "baseline_commit": "c2bb8a8511ed1db170bc56230d6efd35e910b091"
       },
       "entries": [
         {
@@ -1957,12 +1948,12 @@
           "total_lines": 166126,
           "owner": "wow-world WorldSession/application monolith.",
           "open_retirement_issues": [
-            152,
             140,
+            152,
+            153,
             182,
             183,
-            184,
-            153
+            184
           ],
           "retirement_condition": "Session is a thin protocol/lifecycle shell with no mutable Player/Map gameplay, concrete DB/catalog bag, or external impl growth; LOC alone does not close it."
         },
@@ -1973,9 +1964,10 @@
           "total_lines": 33518,
           "owner": "wow-map canonical MapManager/runtime.",
           "open_retirement_issues": [
-            188,
             28,
-            153
+            153,
+            188,
+            225
           ],
           "retirement_condition": "Map runtime/storage/visibility/respawn submodules have one writer and clock per transition; physical splitting is not combined with authority flips."
         },
@@ -1986,10 +1978,11 @@
           "total_lines": 30891,
           "owner": "wow-world character handler adapter plus mixed gameplay/persistence logic.",
           "open_retirement_issues": [
+            153,
             192,
             194,
             200,
-            153
+            224
           ],
           "retirement_condition": "Character verticals are thin capability adapters with typed owners/ports and no raw directory or concrete persistence access."
         },
@@ -2000,26 +1993,27 @@
           "total_lines": 29825,
           "owner": "wow-world loot handler plus transitional loot/map/persistence coordination.",
           "open_retirement_issues": [
+            153,
             187,
             189,
             193,
-            153
+            224
           ],
           "retirement_condition": "Loot handlers adapt typed wow-loot/Player/Map/persistence outcomes and no longer coordinate dual authorities or durable trackers."
         },
         {
-          "path": "crates/world-server/src/main.rs",
-          "production_lines": 15370,
-          "test_lines": 12533,
-          "total_lines": 27903,
-          "owner": "world-server composition root mixed with bootstrap and runtime orchestration.",
+          "path": "crates/world-server/src/lib.rs",
+          "logical_scope": "crate",
+          "production_lines": 24985,
+          "test_lines": 21491,
+          "total_lines": 46476,
+          "owner": "world-server crate composition root, bootstrap/loaders and runtime orchestration.",
           "open_retirement_issues": [
-            136,
+            153,
             188,
-            192,
-            153
+            192
           ],
-          "retirement_condition": "main owns only CLI/configuration, wiring, start/join and shutdown; gameplay algorithms and hidden mutable clocks are absent."
+          "retirement_condition": "The crate keeps main as a thin entry point and distributes bootstrap/loaders/runtime by cohesive private modules; gameplay algorithms and hidden mutable clocks are absent."
         },
         {
           "path": "crates/wow-world/src/handlers/misc.rs",
@@ -2040,9 +2034,10 @@
           "total_lines": 18427,
           "owner": "wow-world quest handler plus represented Player/persistence logic.",
           "open_retirement_issues": [
+            153,
             194,
             200,
-            153
+            224
           ],
           "retirement_condition": "Quest handler is a thin adapter over canonical Player/quest/persistence capabilities with exact outcome and packet order."
         },
@@ -2053,9 +2048,10 @@
           "total_lines": 18156,
           "owner": "wow-entities partial canonical Player model.",
           "open_retirement_issues": [
+            153,
             194,
             196,
-            153
+            226
           ],
           "retirement_condition": "Player submodules own one mutable representation per responsibility with colocated tests; Session and directory mirrors for migrated families are removed."
         }

--- a/tools/codex-review-policy.md
+++ b/tools/codex-review-policy.md
@@ -31,8 +31,8 @@ Check every relevant change for:
 For build and workflow changes, also verify exact command equivalence between local and GitHub
 execution, the `rust-toolchain.toml` compiler and locked dependency use, protoc 28.3 handling, shell quoting and exit-code
 propagation, shallow-checkout behavior, and that safe default modes never start services or mutate
-databases. Local review must not bypass the required GitHub `Codex reviewer verdict` for the PR's
-current HEAD.
+databases. For trusted `alseif0x` PRs this review is optional local evidence; external PRs retain
+the configured GitHub reviewer verdict.
 
 Report each real defect with the narrowest useful file and line range and a P0-P3 priority. Do not
 invent speculative findings. Treat the patch as correct only when there are no actionable


### PR DESCRIPTION
Closes #223

Parent: #133

## Summary

- reconcile the offline architecture ledger with all 67 GitHub architecture issues, current titles/states, the four execution lanes, and #99's linked-Rust module children
- replace the ambiguous hotspot view with independent physical-file and logical-owner reports
- keep logical non-growth ceilings while allowing ordinary Rust module extraction to visibly reduce real file size
- align AGENTS.md, the PR template, local review policy, ownership docs, and debt owners with the trusted `alseif0x` local-first workflow
- record #136, #190 and #191 as completed and retarget their remaining debt to the open slices that can actually retire it

## Metric result

- physical `world-server/src/main.rs`: 15 lines
- logical `world-server/src/lib.rs` composition owner including private descendants: 46,476 lines
- physical review signals: inspect around 2,000 productive lines; split plan or explicit cohesive exception above 4,000; neither is a daily gate

## Behavior

Documentation/reporting/policy only. No gameplay, packet, persistence, database or runtime behavior changes.

## Validation

- `python3 tools/architecture/check_architecture.py self-test`
- `python3 tools/architecture/check_architecture.py check`
- live GitHub comparison: all 67 ledger titles/states exact, no missing `[ARCH*]` issue
- `env -u RUST_MIN_STACK -u CARGO_INCREMENTAL ./tools/local-harness.sh final origin/3.4.3`
- `git diff --check`
