### PR TITLE
[QA] Repair preserved SRP6 arithmetic and crypto direction tests

### DIFF
--- a/tools/wow-test-bot/src/srp6_auth.rs
+++ b/tools/wow-test-bot/src/srp6_auth.rs
@@ -119,8 +119,10 @@ impl SRP6Client {
         let v = self.calculate_v();
         let u = self.calculate_u();
 
-        // k*v
-        let kv = &self.k * &v;
+        // Reduce k*v before the modular subtraction. Since BigUint cannot
+        // represent a negative intermediate, leaving k*v unreduced can
+        // underflow below even though the final SRP value is modulo N.
+        let kv = (&self.k * &v) % &self.N;
 
         // B - k*v (mod N)
         let base = if self.B >= kv {

--- a/tools/wow-test-bot/src/wow_crypto.rs
+++ b/tools/wow-test-bot/src/wow_crypto.rs
@@ -224,7 +224,9 @@ mod tests {
 
         let plaintext = b"Hello, World!";
         let (ciphertext, tag) = client_crypt.encrypt_client(plaintext, &[]).unwrap();
-        let decrypted = server_crypt.decrypt_server(&ciphertext, &tag, &[]).unwrap();
+        // Client and server traffic use distinct nonce domains. This fixture
+        // encrypts client-to-server traffic, so decrypt it in that direction.
+        let decrypted = server_crypt.decrypt_client(&ciphertext, &tag, &[]).unwrap();
 
         assert_eq!(plaintext[..], decrypted[..]);
     }


### PR DESCRIPTION
## Summary

- reduce `k * v` modulo `N` before the unsigned SRP6 modular subtraction
- decrypt client-direction AES-GCM test traffic with the client nonce domain
- rescue the two valid fixes preserved only in the old `25-23-...` notes branch

## Validation

- `cargo test --manifest-path tools/wow-test-bot/Cargo.toml test_srp6_calculations -- --nocapture`
- `cargo test --manifest-path tools/wow-test-bot/Cargo.toml test_crypt_roundtrip -- --nocapture`
- `cargo test --manifest-path tools/wow-test-bot/Cargo.toml` — 141 passed
- `./tools/local-harness.sh final origin/3.4.3`

Closes #240