### PR TITLE
[ARCH.DB.2] Freeze Player lifecycle persistence contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3420,6 +3420,8 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "rand",
+ "serde",
+ "serde_json",
  "sqlx",
  "tokio",
  "tracing",

--- a/crates/wow-world/Cargo.toml
+++ b/crates/wow-world/Cargo.toml
@@ -40,3 +40,5 @@ sqlx = { workspace = true }
 [dev-dependencies]
 # Real Detour navmesh fixtures for the live creature-pathfinding regressions.
 wow-recastdetour = { workspace = true, features = ["test-fixtures"] }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/wow-world/src/lib.rs
+++ b/crates/wow-world/src/lib.rs
@@ -24,6 +24,8 @@ pub(crate) mod trainer_offer;
 
 #[cfg(test)]
 mod handler_contract_tests;
+#[cfg(test)]
+mod player_lifecycle_contract;
 
 pub use map_manager::{
     ChaseTargetSnapshotLikeCpp, GridCoord, MapManager, SharedMapManager, WorldCreature,

--- a/crates/wow-world/src/player_lifecycle_contract.rs
+++ b/crates/wow-world/src/player_lifecycle_contract.rs
@@ -1,0 +1,314 @@
+//! Focused executable contract for the Player persistence port (#200).
+//!
+//! This deliberately describes lifecycle boundaries, not every statement in
+//! `Player::SaveToDB`. The statement inventory is still incomplete in Rust;
+//! freezing it here would turn that incompleteness into the target. C++ anchors:
+//! `Player::LoadFromDB`, both `Player::SaveToDB` overloads, and
+//! `WorldSession::LogoutPlayer`.
+
+use serde::{Deserialize, Serialize};
+use wow_database::persistence_trace::{CommitOutcome, ConnectionAffinity, LogicalDatabase};
+
+const GOLDEN: &str = include_str!("../tests/fixtures/player-lifecycle-contract.json");
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ParameterClass {
+    AccountId,
+    PlayerGuid,
+    PlayerSnapshot,
+    WallClock,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "step", rename_all = "snake_case", deny_unknown_fields)]
+enum Step {
+    Boundary {
+        name: String,
+    },
+    Fence {
+        name: String,
+    },
+    Read {
+        database: LogicalDatabase,
+        connection: ConnectionAffinity,
+        name: String,
+        params: Vec<ParameterClass>,
+    },
+    TransactionBegin {
+        database: LogicalDatabase,
+    },
+    WriteGroup {
+        database: LogicalDatabase,
+        connection: ConnectionAffinity,
+        name: String,
+        params: Vec<ParameterClass>,
+    },
+    Commit {
+        database: LogicalDatabase,
+        outcome: CommitOutcome,
+    },
+    Rollback {
+        database: LogicalDatabase,
+    },
+    Publication {
+        name: String,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Scenario {
+    name: String,
+    steps: Vec<Step>,
+}
+
+fn boundary(name: &str) -> Step {
+    Step::Boundary { name: name.into() }
+}
+
+fn fence(name: &str) -> Step {
+    Step::Fence { name: name.into() }
+}
+
+fn publication(name: &str) -> Step {
+    Step::Publication { name: name.into() }
+}
+
+fn player_save_steps(outcome: CommitOutcome) -> Vec<Step> {
+    let mut steps = vec![
+        fence("player.save.mutations_closed"),
+        fence("player.save.pending_durable_work_drained"),
+        Step::TransactionBegin {
+            database: LogicalDatabase::Character,
+        },
+        Step::WriteGroup {
+            database: LogicalDatabase::Character,
+            connection: ConnectionAffinity::Transaction,
+            name: "player.save.represented_snapshot".into(),
+            params: vec![
+                ParameterClass::PlayerGuid,
+                ParameterClass::PlayerSnapshot,
+                ParameterClass::WallClock,
+            ],
+        },
+    ];
+
+    match outcome {
+        CommitOutcome::Committed => {
+            steps.push(Step::Commit {
+                database: LogicalDatabase::Character,
+                outcome,
+            });
+            steps.push(publication("player.save.dirty_state_clean"));
+        }
+        CommitOutcome::RolledBack => steps.push(Step::Rollback {
+            database: LogicalDatabase::Character,
+        }),
+        CommitOutcome::Unknown => {
+            steps.push(Step::Commit {
+                database: LogicalDatabase::Character,
+                outcome,
+            });
+            steps.push(fence("player.save.relogin_required"));
+        }
+    }
+    steps
+}
+
+fn scenarios() -> Vec<Scenario> {
+    let mut periodic = vec![boundary("player.save.periodic")];
+    periodic.extend(player_save_steps(CommitOutcome::Committed));
+
+    let mut manual_rollback = vec![boundary("player.save.manual")];
+    manual_rollback.extend(player_save_steps(CommitOutcome::RolledBack));
+
+    let mut manual_unknown = vec![boundary("player.save.manual")];
+    manual_unknown.extend(player_save_steps(CommitOutcome::Unknown));
+
+    let mut logout = vec![
+        boundary("player.logout.started"),
+        fence("player.logout.loot_idle"),
+    ];
+    logout.extend(player_save_steps(CommitOutcome::Committed));
+    logout.extend([
+        Step::TransactionBegin {
+            database: LogicalDatabase::Login,
+        },
+        Step::WriteGroup {
+            database: LogicalDatabase::Login,
+            connection: ConnectionAffinity::Transaction,
+            name: "player.logout.account_collections".into(),
+            params: vec![ParameterClass::AccountId],
+        },
+        Step::Commit {
+            database: LogicalDatabase::Login,
+            outcome: CommitOutcome::Committed,
+        },
+        Step::WriteGroup {
+            database: LogicalDatabase::Character,
+            connection: ConnectionAffinity::Pooled,
+            name: "player.logout.offline_state".into(),
+            params: vec![ParameterClass::PlayerGuid, ParameterClass::AccountId],
+        },
+        publication("player.logout.runtime_removed"),
+        publication("player.logout.offline_visible"),
+        boundary("player.logout.login_claim_released"),
+        boundary("player.login.reconnect_may_claim"),
+    ]);
+
+    vec![
+        Scenario {
+            name: "load_success".into(),
+            steps: vec![
+                boundary("player.login.claimed"),
+                Step::Read {
+                    database: LogicalDatabase::Character,
+                    connection: ConnectionAffinity::Pooled,
+                    name: "player.load.query_holder".into(),
+                    params: vec![ParameterClass::PlayerGuid, ParameterClass::AccountId],
+                },
+                publication("player.login.runtime_published"),
+            ],
+        },
+        Scenario {
+            name: "periodic_save_success".into(),
+            steps: periodic,
+        },
+        Scenario {
+            name: "manual_save_precommit_failure".into(),
+            steps: manual_rollback,
+        },
+        Scenario {
+            name: "manual_save_commit_unknown".into(),
+            steps: manual_unknown,
+        },
+        Scenario {
+            name: "logout_success_then_reconnect".into(),
+            steps: logout,
+        },
+    ]
+}
+
+#[test]
+fn player_lifecycle_contract_matches_small_golden() {
+    let expected: Vec<Scenario> = serde_json::from_str(GOLDEN).expect("valid lifecycle golden");
+    assert_eq!(scenarios(), expected);
+}
+
+#[test]
+fn publication_must_follow_a_successful_commit() {
+    let steps = player_save_steps(CommitOutcome::Committed);
+    let commit = steps
+        .iter()
+        .position(|step| {
+            matches!(
+                step,
+                Step::Commit {
+                    outcome: CommitOutcome::Committed,
+                    ..
+                }
+            )
+        })
+        .expect("committed boundary");
+    let publication = steps
+        .iter()
+        .position(|step| matches!(step, Step::Publication { .. }))
+        .expect("post-commit publication");
+    assert!(commit < publication);
+
+    for outcome in [CommitOutcome::RolledBack, CommitOutcome::Unknown] {
+        assert!(
+            !player_save_steps(outcome)
+                .iter()
+                .any(|step| matches!(step, Step::Publication { .. })),
+            "{outcome:?} must preserve dirty runtime state"
+        );
+    }
+}
+
+#[test]
+fn rollback_and_unknown_commit_remain_distinct_terminal_states() {
+    let rollback = player_save_steps(CommitOutcome::RolledBack);
+    assert!(matches!(
+        rollback.last(),
+        Some(Step::Rollback {
+            database: LogicalDatabase::Character
+        })
+    ));
+
+    let unknown = player_save_steps(CommitOutcome::Unknown);
+    assert!(unknown.iter().any(|step| matches!(
+        step,
+        Step::Commit {
+            database: LogicalDatabase::Character,
+            outcome: CommitOutcome::Unknown
+        }
+    )));
+    assert!(matches!(
+        unknown.last(),
+        Some(Step::Fence { name }) if name == "player.save.relogin_required"
+    ));
+}
+
+#[test]
+fn player_save_writes_keep_character_transaction_affinity() {
+    for outcome in [
+        CommitOutcome::Committed,
+        CommitOutcome::RolledBack,
+        CommitOutcome::Unknown,
+    ] {
+        let writes = player_save_steps(outcome)
+            .into_iter()
+            .filter_map(|step| match step {
+                Step::WriteGroup {
+                    database,
+                    connection,
+                    ..
+                } => Some((database, connection)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            writes,
+            vec![(LogicalDatabase::Character, ConnectionAffinity::Transaction)]
+        );
+    }
+}
+
+#[test]
+fn golden_detects_reordered_publication_and_changed_affinity() {
+    let expected: Vec<Scenario> = serde_json::from_str(GOLDEN).expect("valid lifecycle golden");
+
+    let mut reordered = scenarios();
+    let steps = &mut reordered
+        .iter_mut()
+        .find(|scenario| scenario.name == "periodic_save_success")
+        .expect("periodic scenario")
+        .steps;
+    let commit = steps
+        .iter()
+        .position(|step| matches!(step, Step::Commit { .. }))
+        .expect("commit");
+    steps.swap(commit, commit + 1);
+    assert_ne!(reordered, expected, "publication order is contract data");
+
+    let mut wrong_affinity = scenarios();
+    let steps = &mut wrong_affinity
+        .iter_mut()
+        .find(|scenario| scenario.name == "periodic_save_success")
+        .expect("periodic scenario")
+        .steps;
+    let write = steps
+        .iter_mut()
+        .find_map(|step| match step {
+            Step::WriteGroup { connection, .. } => Some(connection),
+            _ => None,
+        })
+        .expect("save write");
+    *write = ConnectionAffinity::Pooled;
+    assert_ne!(
+        wrong_affinity, expected,
+        "connection affinity is contract data"
+    );
+}

--- a/crates/wow-world/src/session/mod.rs
+++ b/crates/wow-world/src/session/mod.rs
@@ -30282,6 +30282,7 @@ impl WorldSession {
 
         let money_tracker = Arc::clone(&self.durable_loot_money_persistence_like_cpp);
         let money_save_fence = money_tracker.close_admission_for_save_like_cpp();
+        wow_database::persistence_trace::record_fence("player.save.mutations_closed");
         self.wait_for_durable_item_loot_persistence_like_cpp().await;
         self.apply_pending_durable_item_loot_completions_with_objective_drain_like_cpp(false)
             .await;
@@ -30297,6 +30298,7 @@ impl WorldSession {
                 .await;
             return;
         }
+        wow_database::persistence_trace::record_fence("player.save.pending_durable_work_drained");
         let money_mutation_lock = money_tracker.lock_money_mutation_like_cpp().await;
         if money_tracker.is_indeterminate_like_cpp() {
             self.kick(
@@ -30361,6 +30363,9 @@ impl WorldSession {
             Ok(()) => {
                 cancellation_fence.disarm_like_cpp();
                 self.mark_current_player_save_to_db_committed_like_cpp(&plan);
+                wow_database::persistence_trace::record_publication(
+                    "player.save.dirty_state_clean",
+                );
                 info!(
                     guid = snapshot.guid.counter(),
                     statement_count,
@@ -30381,6 +30386,7 @@ impl WorldSession {
                 // committed, so preserve dirty flags and force a reload before
                 // any further money mutation can race an unknown durable base.
                 money_tracker.mark_indeterminate_like_cpp();
+                wow_database::persistence_trace::record_fence("player.save.relogin_required");
                 cancellation_fence.disarm_like_cpp();
                 self.kick(
                     "Player::SaveToDB COMMIT outcome is unknown; relog required before another money mutation",

--- a/crates/wow-world/tests/fixtures/player-lifecycle-contract.json
+++ b/crates/wow-world/tests/fixtures/player-lifecycle-contract.json
@@ -1,0 +1,66 @@
+[
+  {
+    "name": "load_success",
+    "steps": [
+      { "step": "boundary", "name": "player.login.claimed" },
+      { "step": "read", "database": "character", "connection": "pooled", "name": "player.load.query_holder", "params": ["player_guid", "account_id"] },
+      { "step": "publication", "name": "player.login.runtime_published" }
+    ]
+  },
+  {
+    "name": "periodic_save_success",
+    "steps": [
+      { "step": "boundary", "name": "player.save.periodic" },
+      { "step": "fence", "name": "player.save.mutations_closed" },
+      { "step": "fence", "name": "player.save.pending_durable_work_drained" },
+      { "step": "transaction_begin", "database": "character" },
+      { "step": "write_group", "database": "character", "connection": "transaction", "name": "player.save.represented_snapshot", "params": ["player_guid", "player_snapshot", "wall_clock"] },
+      { "step": "commit", "database": "character", "outcome": "committed" },
+      { "step": "publication", "name": "player.save.dirty_state_clean" }
+    ]
+  },
+  {
+    "name": "manual_save_precommit_failure",
+    "steps": [
+      { "step": "boundary", "name": "player.save.manual" },
+      { "step": "fence", "name": "player.save.mutations_closed" },
+      { "step": "fence", "name": "player.save.pending_durable_work_drained" },
+      { "step": "transaction_begin", "database": "character" },
+      { "step": "write_group", "database": "character", "connection": "transaction", "name": "player.save.represented_snapshot", "params": ["player_guid", "player_snapshot", "wall_clock"] },
+      { "step": "rollback", "database": "character" }
+    ]
+  },
+  {
+    "name": "manual_save_commit_unknown",
+    "steps": [
+      { "step": "boundary", "name": "player.save.manual" },
+      { "step": "fence", "name": "player.save.mutations_closed" },
+      { "step": "fence", "name": "player.save.pending_durable_work_drained" },
+      { "step": "transaction_begin", "database": "character" },
+      { "step": "write_group", "database": "character", "connection": "transaction", "name": "player.save.represented_snapshot", "params": ["player_guid", "player_snapshot", "wall_clock"] },
+      { "step": "commit", "database": "character", "outcome": "unknown" },
+      { "step": "fence", "name": "player.save.relogin_required" }
+    ]
+  },
+  {
+    "name": "logout_success_then_reconnect",
+    "steps": [
+      { "step": "boundary", "name": "player.logout.started" },
+      { "step": "fence", "name": "player.logout.loot_idle" },
+      { "step": "fence", "name": "player.save.mutations_closed" },
+      { "step": "fence", "name": "player.save.pending_durable_work_drained" },
+      { "step": "transaction_begin", "database": "character" },
+      { "step": "write_group", "database": "character", "connection": "transaction", "name": "player.save.represented_snapshot", "params": ["player_guid", "player_snapshot", "wall_clock"] },
+      { "step": "commit", "database": "character", "outcome": "committed" },
+      { "step": "publication", "name": "player.save.dirty_state_clean" },
+      { "step": "transaction_begin", "database": "login" },
+      { "step": "write_group", "database": "login", "connection": "transaction", "name": "player.logout.account_collections", "params": ["account_id"] },
+      { "step": "commit", "database": "login", "outcome": "committed" },
+      { "step": "write_group", "database": "character", "connection": "pooled", "name": "player.logout.offline_state", "params": ["player_guid", "account_id"] },
+      { "step": "publication", "name": "player.logout.runtime_removed" },
+      { "step": "publication", "name": "player.logout.offline_visible" },
+      { "step": "boundary", "name": "player.logout.login_claim_released" },
+      { "step": "boundary", "name": "player.login.reconnect_may_claim" }
+    ]
+  }
+]

--- a/docs/migration/player-lifecycle-persistence-contract.md
+++ b/docs/migration/player-lifecycle-persistence-contract.md
@@ -1,0 +1,49 @@
+# Player lifecycle persistence contract
+
+Issue #187 freezes the narrow contract that the Player persistence port in #200 must preserve.
+It is not a claim that Rust already implements all of `Player::LoadFromDB` or `Player::SaveToDB`.
+The executable fixture is
+`crates/wow-world/tests/fixtures/player-lifecycle-contract.json`.
+
+## C++ anchors
+
+- Load: `Player::LoadFromDB` and the `LoginQueryHolder` path in
+  `src/server/game/Handlers/CharacterHandler.cpp`.
+- Save: both `Player::SaveToDB` overloads in
+  `src/server/game/Entities/Player/Player.cpp`. The Character transaction is committed before the
+  Login transaction; runtime dirty state may only be cleared after the relevant commit succeeds.
+- Logout: `WorldSession::LogoutPlayer` in
+  `src/server/game/Server/WorldSession.cpp`. The player is saved while it is still present in its
+  map/session context, then removed and the login boundary is released.
+
+The fixture records semantic groups and parameter classes rather than values or the incomplete
+Rust statement inventory. It therefore contains no account name, credential, session key, or raw
+SQL.
+
+## Deliberately frozen boundaries
+
+- Player load reads belong to CharacterDatabase on a pooled connection and runtime publication
+  follows successful loading.
+- Periodic and manual saves share one CharacterDatabase transaction for the represented snapshot.
+- A definite pre-COMMIT failure rolls back and keeps runtime dirty state unpublished.
+- A successful commit precedes dirty-state publication.
+- An unknown COMMIT outcome is not treated as rollback or success; it fences further mutation and
+  requires a fresh login.
+- Logout drains pending durable work before save, persists account collections in LoginDatabase,
+  publishes offline/removal state, and only then releases the sole-login claim so reconnect may
+  proceed.
+
+## Known Rust/C++ discrepancies (not corrected by #187)
+
+- C++ loads the Player through a prepared `LoginQueryHolder`; Rust still issues a sequence of
+  individual load queries from `handle_continue_player_login`.
+- C++ appends account collection writes to one LoginDatabase transaction inside `SaveToDB`. Rust
+  currently commits mounts, toys, heirlooms, appearances, and illusions as separate transactions
+  after the CharacterDatabase save.
+- Rust's represented Player save is partial and its extra offline writes do not yet equal the full
+  C++ save inventory.
+- Rust explicitly fences an indeterminate COMMIT and forces relogin. The fixture preserves that
+  current safety behavior without claiming it is a completed C++ parity implementation.
+
+These discrepancies are inputs to #200 and later parity work. Changing them in the architecture
+move requires an explicit behavior PR rather than silently changing the fixture.


### PR DESCRIPTION
Closes #187

## What changed

- adds one focused, deterministic Player lifecycle fixture for load, periodic/manual save, rollback, unknown COMMIT, and logout-to-reconnect
- freezes transaction boundaries, logical database and connection affinity, typed/redacted parameter classes, fences, and post-COMMIT publication order
- instruments the real represented Player save with the existing short-lived recorder calls at mutation/drain fences, successful publication, and unknown-COMMIT relog fencing
- documents the C++ anchors and the known Rust/C++ gaps without changing behavior in this tracing PR

## Local evidence

- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-world player_lifecycle_contract --lib` — 5 passed
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-database persistence_trace --lib` — 24 passed
- `./tools/local-harness.sh final origin/3.4.3` — passed

## Scope

This is the focused contract required by #200. It does not revive the retired universal recorder/tokenizer scope and does not claim that the current partial Rust Player save already has full C++ parity.