### PR TITLE
[ARCH.2.5a] Introduce opaque group registry facades

### DIFF
--- a/crates/wow-network/src/group_registry.rs
+++ b/crates/wow-network/src/group_registry.rs
@@ -1277,8 +1277,58 @@ impl GroupInfo {
     }
 }
 
-/// Thread-safe registry of all active groups, keyed by group GUID.
-pub type GroupRegistry = DashMap<u64, GroupInfo>;
+/// Thread-safe owner of all active groups, keyed by group GUID.
+///
+/// Read access returns owned snapshots so callers cannot retain a backing-map
+/// guard. The narrowly retained mutable compatibility methods are removed by
+/// the transition issues named on each method (#197/#198/#199).
+#[derive(Debug, Default)]
+pub struct GroupRegistry {
+    groups: DashMap<u64, GroupInfo>,
+}
+
+impl GroupRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return an immutable owned snapshot of one group.
+    pub fn get(&self, group_guid: &u64) -> Option<GroupInfo> {
+        self.groups.get(group_guid).map(|group| group.clone())
+    }
+
+    /// Return whether the identified group currently exists.
+    pub fn contains_key(&self, group_guid: &u64) -> bool {
+        self.groups.contains_key(group_guid)
+    }
+
+    /// Return immutable owned snapshots of every current group.
+    pub fn snapshots(&self) -> Vec<GroupInfo> {
+        self.groups
+            .iter()
+            .map(|group| group.value().clone())
+            .collect()
+    }
+
+    /// Transitional invite/create/join compatibility; owned by #197.
+    pub fn insert(&self, group_guid: u64, group: GroupInfo) -> Option<GroupInfo> {
+        self.groups.insert(group_guid, group)
+    }
+
+    /// Transitional membership/disband compatibility; owned by #198.
+    pub fn remove(&self, group_guid: &u64) -> Option<(u64, GroupInfo)> {
+        self.groups.remove(group_guid)
+    }
+
+    /// Transitional mutation compatibility; all callers are assigned to
+    /// #197 or #198 and the method itself is removed by #199.
+    pub fn get_mut(
+        &self,
+        group_guid: &u64,
+    ) -> Option<dashmap::mapref::one::RefMut<'_, u64, GroupInfo>> {
+        self.groups.get_mut(group_guid)
+    }
+}
 
 /// Result of the existing-group join portion of C++
 /// `WorldSession::HandlePartyInviteResponseOpcode`.
@@ -1346,6 +1396,7 @@ pub fn tick_all_group_ready_checks_like_cpp(
 ) -> Vec<(u64, Vec<ReadyCheckEventLikeCpp>)> {
     // Collect keys first so we don't hold the iter() ref while mutating.
     let active_keys: Vec<u64> = registry
+        .groups
         .iter()
         .filter(|entry| entry.value().ready_check_started)
         .map(|entry| *entry.key())
@@ -1459,12 +1510,84 @@ impl PendingInviteLikeCpp {
     }
 }
 
-/// Pending invites: invited_guid → represented C++ group invite.
-pub type PendingInvites = DashMap<ObjectGuid, PendingInviteLikeCpp>;
+/// Owner of pending invites: invited_guid → represented C++ group invite.
+#[derive(Debug, Default)]
+pub struct PendingInvites {
+    invites: DashMap<ObjectGuid, PendingInviteLikeCpp>,
+}
+
+impl PendingInvites {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return an immutable owned invite snapshot.
+    pub fn get(&self, invited_guid: &ObjectGuid) -> Option<PendingInviteLikeCpp> {
+        self.invites.get(invited_guid).map(|invite| *invite)
+    }
+
+    pub fn contains_key(&self, invited_guid: &ObjectGuid) -> bool {
+        self.invites.contains_key(invited_guid)
+    }
+
+    pub fn matching_guids(&self, invite: PendingInviteLikeCpp) -> Vec<ObjectGuid> {
+        self.invites
+            .iter()
+            .filter(|entry| *entry.value() == invite)
+            .map(|entry| *entry.key())
+            .collect()
+    }
+
+    /// Transitional invite mutation compatibility; owned by #197.
+    pub fn insert(
+        &self,
+        invited_guid: ObjectGuid,
+        invite: PendingInviteLikeCpp,
+    ) -> Option<PendingInviteLikeCpp> {
+        self.invites.insert(invited_guid, invite)
+    }
+
+    /// Transitional invite mutation compatibility; owned by #197.
+    pub fn remove(&self, invited_guid: &ObjectGuid) -> Option<(ObjectGuid, PendingInviteLikeCpp)> {
+        self.invites.remove(invited_guid)
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn group_registry_reads_are_owned_and_absent_groups_stay_absent() {
+        let registry = GroupRegistry::new();
+        let leader = ObjectGuid::create_player(1, 42);
+        let group = GroupInfo::new(leader);
+        let group_guid = group.group_guid;
+        registry.insert(group_guid, group);
+
+        let mut snapshot = registry.get(&group_guid).expect("group snapshot");
+        snapshot.leader_guid = ObjectGuid::create_player(1, 99);
+
+        assert_eq!(registry.get(&group_guid).unwrap().leader_guid, leader);
+        assert!(registry.get(&u64::MAX).is_none());
+        assert!(!registry.contains_key(&u64::MAX));
+    }
+
+    #[test]
+    fn pending_invite_reads_are_owned_and_absent_invites_stay_absent() {
+        let pending = PendingInvites::new();
+        let leader = ObjectGuid::create_player(1, 42);
+        let invited = ObjectGuid::create_player(1, 43);
+        let invite = PendingInviteLikeCpp::new_pending_group(leader, 0);
+        pending.insert(invited, invite);
+
+        let snapshot = pending.get(&invited).expect("invite snapshot");
+
+        assert_eq!(snapshot, invite);
+        assert_eq!(pending.matching_guids(invite), vec![invited]);
+        assert!(pending.get(&ObjectGuid::create_player(1, 99)).is_none());
+        assert!(!pending.contains_key(&ObjectGuid::create_player(1, 99)));
+    }
 
     #[test]
     fn new_group_uses_cpp_personal_loot_default() {

--- a/crates/wow-world/src/handlers/chat.rs
+++ b/crates/wow-world/src/handlers/chat.rs
@@ -1340,9 +1340,9 @@ impl WorldSession {
         }
 
         registry
-            .iter()
-            .find(|entry| entry.value().members.contains(&sender_guid))
-            .map(|entry| entry.value().clone())
+            .snapshots()
+            .into_iter()
+            .find(|group| group.members.contains(&sender_guid))
     }
 
     fn broadcast_group_chat_packet_like_cpp(

--- a/crates/wow-world/src/handlers/group.rs
+++ b/crates/wow-world/src/handlers/group.rs
@@ -82,12 +82,12 @@ fn current_group_guid_like_cpp(
     }
     // 2. Fallback: scan for any group containing sender in the requested category.
     group_reg
-        .iter()
-        .find(|entry| {
-            entry.value().members.contains(&sender_guid)
-                && entry.value().matches_party_index_like_cpp(party_index)
+        .snapshots()
+        .into_iter()
+        .find(|group| {
+            group.members.contains(&sender_guid) && group.matches_party_index_like_cpp(party_index)
         })
-        .map(|entry| *entry.key())
+        .map(|group| group.group_guid)
 }
 
 fn pending_invite_matches_party_index_like_cpp(
@@ -101,11 +101,7 @@ fn pending_group_invite_keys_like_cpp(
     pending: &PendingInvites,
     invite: PendingInviteLikeCpp,
 ) -> Vec<ObjectGuid> {
-    pending
-        .iter()
-        .filter(|entry| *entry.value() == invite)
-        .map(|entry| *entry.key())
-        .collect()
+    pending.matching_guids(invite)
 }
 
 fn remove_all_pending_group_invites_like_cpp(
@@ -160,7 +156,8 @@ fn pending_invite_for_new_or_existing_group_like_cpp(
         ));
     }
 
-    pending.get(&inviter_guid).map(|invite| *invite.value())
+    let invite = pending.get(&inviter_guid);
+    invite
 }
 
 // ── inventory registrations ───────────────────────────────────────────────────
@@ -1445,7 +1442,7 @@ impl WorldSession {
         };
 
         // 1. Must have a pending C++ `GroupInvite`.
-        let invite = match pending.get(&my_guid).map(|e| *e.value()) {
+        let invite = match pending.get(&my_guid) {
             Some(invite) => invite,
             None => return,
         };
@@ -1782,7 +1779,7 @@ impl WorldSession {
                 if let Some(pending_invites) = pending_invites.as_ref() {
                     let invite_belongs_to_group = pending_invites
                         .get(&uninvite.target_guid)
-                        .is_some_and(|invite| invite.value().group_guid == Some(group_guid));
+                        .is_some_and(|invite| invite.group_guid == Some(group_guid));
                     if invite_belongs_to_group {
                         pending_invites.remove(&uninvite.target_guid);
                         return;
@@ -1909,7 +1906,7 @@ impl WorldSession {
             current_group_guid_like_cpp(&group_reg, self.group_guid, my_guid, party_index);
         let pending_invite = pending_invites
             .as_ref()
-            .and_then(|pending| pending.get(&my_guid).map(|invite| *invite.value()));
+            .and_then(|pending| pending.get(&my_guid));
 
         if real_group_guid.is_none() && pending_invite.is_none() {
             return;

--- a/crates/wow-world/src/handlers/quest.rs
+++ b/crates/wow-world/src/handlers/quest.rs
@@ -4357,8 +4357,8 @@ impl WorldSession {
             return;
         };
 
-        let same_represented_group = group_registry.iter().any(|entry| {
-            let members = &entry.value().members;
+        let same_represented_group = group_registry.snapshots().into_iter().any(|group| {
+            let members = &group.members;
             members.contains(&receiver_guid) && members.contains(&pending.sender_guid)
         });
         if !same_represented_group {

--- a/crates/wow-world/src/session/mod.rs
+++ b/crates/wow-world/src/session/mod.rs
@@ -35211,7 +35211,7 @@ impl WorldSession {
             return party_type;
         };
 
-        for group in group_registry.iter() {
+        for group in group_registry.snapshots() {
             let category = group.group_category_like_cpp();
             if category < wow_network::group_registry::MAX_GROUP_CATEGORY_LIKE_CPP
                 && group.members.contains(&player_guid)
@@ -45971,14 +45971,15 @@ impl WorldSession {
         let player_group_size = player_group.members.len();
         drop(player_group);
 
-        let Some(inviter_group_entry) = group_registry
-            .iter()
-            .find(|entry| entry.value().members.contains(&inviter_guid))
+        let Some(inviter_group) = group_registry
+            .snapshots()
+            .into_iter()
+            .find(|group| group.members.contains(&inviter_guid))
         else {
             return;
         };
-        let inviter_group_guid = *inviter_group_entry.key();
-        let inviter_group_size = inviter_group_entry.value().members.len();
+        let inviter_group_guid = inviter_group.group_guid;
+        let inviter_group_size = inviter_group.members.len();
 
         if player_group_size != inviter_group_size {
             return;

--- a/docs/architecture/group-registry-consumer-map.md
+++ b/docs/architecture/group-registry-consumer-map.md
@@ -1,0 +1,26 @@
+# GroupRegistry and PendingInvites cutover map
+
+Issue #151 replaces the two public `DashMap` aliases with opaque owner types. Immutable access now
+returns owned `GroupInfo` / `PendingInviteLikeCpp` snapshots, and whole-registry searches consume
+owned snapshot collections. The backing maps are private to `wow_network::group_registry`.
+
+The remaining mutable compatibility surface is intentionally unchanged in behavior and assigned
+exactly once in
+[`group-registry-consumer-map.tsv`](group-registry-consumer-map.tsv):
+
+- #197 owns pending-invite create/replace/cancel/accept, group creation and capacity-safe joins.
+- #198 owns membership/disband, leadership, subgroup/role, difficulty, marker, loot-state and
+  ready-check mutations.
+- #199 owns database loading, persistence/publication separation, fixture builders and final
+  removal of `insert`, `remove`, `get_mut` and their exposed guards.
+
+C++ anchors are `Groups/GroupMgr.h:28-55` and `Groups/GroupMgr.cpp:78-110` for private store plus
+identity lookup/update ownership, `Entities/Player/Player.h:2558-2562` for the player-local pending
+invite pointer, and `Handlers/GroupHandler.cpp:105-210` for the invite/category/capacity sequence.
+This boundary slice deliberately preserves the represented Rust behavior; #197 performs the
+atomic invite/create/join convergence.
+
+The syntax-aware `session-ownership-policy.json` is the executable non-growth inventory. At this
+slice it drops from 621 to 613 exact direct-registry rows. Bounded owned `get`, `contains_key`,
+`snapshots` and `matching_guids` queries are stable facade operations, not
+permission to expose a map iterator or backing entry.

--- a/docs/architecture/group-registry-consumer-map.tsv
+++ b/docs/architecture/group-registry-consumer-map.tsv
@@ -1,0 +1,10 @@
+owner_type	consumer_family	current_compatibility	transition_issue	final_shape
+GroupRegistry	invite acceptance and first group creation	insert/get_mut	#197	atomic typed create-or-join outcome
+PendingInvites	invite create replace cancel expire and accept	insert/remove	#197	named atomic invite transitions
+GroupRegistry	member removal leave and disband	get_mut/remove	#198	typed membership outcome
+GroupRegistry	leader subgroup role loot difficulty icon and marker updates	get_mut	#198	typed state-transition outcome
+GroupRegistry	ready-check start response and timer expiry	get_mut	#198	typed ready-check events
+GroupRegistry	instance ownership and recent-instance updates	get_mut	#198	typed instance-state outcome
+GroupRegistry	character-database group load	insert/get_mut	#199	owner-local load and persistence intents
+GroupRegistry	all tests and fixtures	insert/remove/get_mut	#199	test-only invariant-preserving builders
+PendingInvites	all tests and fixtures	insert/remove	#199	test-only invariant-preserving builders

--- a/docs/architecture/ownership-and-boundaries.md
+++ b/docs/architecture/ownership-and-boundaries.md
@@ -312,7 +312,7 @@ composition-side `SessionResources` has 243 fields, of which 186 are optional;
 reachable payload types. The factory has 247 `set_*` and one `install_*` call: two setters are
 multiline calls that the earlier text-only count missed. The generated-input surface has 44 exact
 records, and direct access to `PlayerRegistry`, `GroupRegistry`, or `PendingInvites` is frozen as
-685 exact AST rows with multiplicity 705. The workspace-wide persistence inventory contains 23,510
+613 exact AST rows. The workspace-wide persistence inventory contains 23,510
 exact rows—12,978 production and 10,532 test-fixture—with multiplicity 25,748 (14,490 production and
 11,258 test). Six generated-source inputs are an orthogonal subset, not a third source class. Schema
 v3 covers SQLx and concrete `wow_database` types/imports, typed statements/results/errors,

--- a/tools/architecture/session-ownership-policy.json
+++ b/tools/architecture/session-ownership-policy.json
@@ -57674,45 +57674,6 @@
           "count": 1
         },
         {
-          "package": "wow-network",
-          "module": "crate::group_registry",
-          "source": "crates/wow-network/src/group_registry.rs",
-          "enclosing": "fn tick_all_group_ready_checks_like_cpp",
-          "registry": "GroupRegistry",
-          "operation": "iter",
-          "symbol": "iter",
-          "visibility": "pub",
-          "cfg": [],
-          "fingerprint": "iter()",
-          "count": 1
-        },
-        {
-          "package": "wow-network",
-          "module": "crate::group_registry",
-          "source": "crates/wow-network/src/group_registry.rs",
-          "enclosing": "module",
-          "registry": "GroupRegistry",
-          "operation": "type_alias",
-          "symbol": "GroupRegistry",
-          "visibility": "pub",
-          "cfg": [],
-          "fingerprint": "DashMap < u64 , GroupInfo >",
-          "count": 1
-        },
-        {
-          "package": "wow-network",
-          "module": "crate::group_registry",
-          "source": "crates/wow-network/src/group_registry.rs",
-          "enclosing": "module",
-          "registry": "PendingInvites",
-          "operation": "type_alias",
-          "symbol": "PendingInvites",
-          "visibility": "pub",
-          "cfg": [],
-          "fingerprint": "DashMap < ObjectGuid , PendingInviteLikeCpp >",
-          "count": 1
-        },
-        {
           "package": "wow-world",
           "module": "crate::handlers::character",
           "source": "crates/wow-world/src/handlers/character.rs",
@@ -57892,19 +57853,6 @@
           "visibility": "",
           "cfg": [],
           "fingerprint": "get(& group_guid)",
-          "count": 1
-        },
-        {
-          "package": "wow-world",
-          "module": "crate::handlers::chat",
-          "source": "crates/wow-world/src/handlers/chat.rs",
-          "enclosing": "impl WorldSession::current_chat_group_like_cpp",
-          "registry": "GroupRegistry",
-          "operation": "iter",
-          "symbol": "iter",
-          "visibility": "",
-          "cfg": [],
-          "fingerprint": "iter()",
           "count": 1
         },
         {
@@ -58171,19 +58119,6 @@
           "package": "wow-world",
           "module": "crate::handlers::group",
           "source": "crates/wow-world/src/handlers/group.rs",
-          "enclosing": "fn current_group_guid_like_cpp",
-          "registry": "GroupRegistry",
-          "operation": "iter",
-          "symbol": "iter",
-          "visibility": "",
-          "cfg": [],
-          "fingerprint": "iter()",
-          "count": 1
-        },
-        {
-          "package": "wow-world",
-          "module": "crate::handlers::group",
-          "source": "crates/wow-world/src/handlers/group.rs",
           "enclosing": "fn current_player_party_invite_map_instance_like_cpp",
           "registry": "PlayerRegistry",
           "operation": "type_reference",
@@ -58301,19 +58236,6 @@
           "package": "wow-world",
           "module": "crate::handlers::group",
           "source": "crates/wow-world/src/handlers/group.rs",
-          "enclosing": "fn pending_group_invite_keys_like_cpp",
-          "registry": "PendingInvites",
-          "operation": "iter",
-          "symbol": "iter",
-          "visibility": "",
-          "cfg": [],
-          "fingerprint": "iter()",
-          "count": 1
-        },
-        {
-          "package": "wow-world",
-          "module": "crate::handlers::group",
-          "source": "crates/wow-world/src/handlers/group.rs",
           "enclosing": "fn pending_invite_for_new_or_existing_group_like_cpp",
           "registry": "GroupRegistry",
           "operation": "type_reference",
@@ -58347,6 +58269,19 @@
           "visibility": "",
           "cfg": [],
           "fingerprint": "& PendingInvites",
+          "count": 1
+        },
+        {
+          "package": "wow-world",
+          "module": "crate::handlers::group",
+          "source": "crates/wow-world/src/handlers/group.rs",
+          "enclosing": "fn pending_invite_for_new_or_existing_group_like_cpp",
+          "registry": "PendingInvites",
+          "operation": "return",
+          "symbol": "guard",
+          "visibility": "",
+          "cfg": [],
+          "fingerprint": "invite",
           "count": 1
         },
         {
@@ -61406,19 +61341,6 @@
         },
         {
           "package": "wow-world",
-          "module": "crate::handlers::quest",
-          "source": "crates/wow-world/src/handlers/quest.rs",
-          "enclosing": "impl WorldSession::handle_quest_confirm_accept",
-          "registry": "GroupRegistry",
-          "operation": "iter",
-          "symbol": "iter",
-          "visibility": "pub",
-          "cfg": [],
-          "fingerprint": "iter()",
-          "count": 1
-        },
-        {
-          "package": "wow-world",
           "module": "crate::handlers::social",
           "source": "crates/wow-world/src/handlers/social.rs",
           "enclosing": "impl WorldSession::friend_status_for_guid_like_cpp",
@@ -61636,19 +61558,6 @@
           "visibility": "pub (crate)",
           "cfg": [],
           "fingerprint": "get(& player_group_guid)",
-          "count": 1
-        },
-        {
-          "package": "wow-world",
-          "module": "crate::session",
-          "source": "crates/wow-world/src/session/mod.rs",
-          "enclosing": "impl WorldSession::accept_represented_wargame_invite_like_cpp",
-          "registry": "GroupRegistry",
-          "operation": "iter",
-          "symbol": "iter",
-          "visibility": "pub (crate)",
-          "cfg": [],
-          "fingerprint": "iter()",
           "count": 1
         },
         {
@@ -62871,19 +62780,6 @@
           "visibility": "pub (crate)",
           "cfg": [],
           "fingerprint": "player_guid:GroupRegistry",
-          "count": 1
-        },
-        {
-          "package": "wow-world",
-          "module": "crate::session",
-          "source": "crates/wow-world/src/session/mod.rs",
-          "enclosing": "impl WorldSession::party_member_party_type_like_cpp",
-          "registry": "GroupRegistry",
-          "operation": "iter",
-          "symbol": "iter",
-          "visibility": "pub (crate)",
-          "cfg": [],
-          "fingerprint": "iter()",
           "count": 1
         },
         {


### PR DESCRIPTION
Closes #151

## Summary
- replace public `DashMap` aliases with opaque `GroupRegistry` and `PendingInvites` owners
- return owned immutable snapshots for identity, lookup and registry scans
- inventory every remaining mutable compatibility family for #197, #198 or #199
- tighten the exact direct-registry ratchet from 621 to 613 rows

## C++ anchors
- `src/server/game/Groups/GroupMgr.h:28-55`
- `src/server/game/Groups/GroupMgr.cpp:78-110`
- `src/server/game/Entities/Player/Player.h:2558-2562`
- `src/server/game/Handlers/GroupHandler.cpp:105-210`

## Validation
- `cargo test -p wow-network group_registry::tests --lib` (69 passed)
- `cargo test -p wow-world group --lib` (240 passed)
- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p world-server`
- `session-ownership-check check --syntax-only` (613 exact rows)
- `./tools/local-harness.sh final origin/3.4.3`