### PR TITLE
[ARCH.RUNTIME.1] Trace current world/map clocks and phase ownership before convergence

### DIFF
--- a/docs/architecture/runtime-clock-phase-trace.md
+++ b/docs/architecture/runtime-clock-phase-trace.md
@@ -1,0 +1,71 @@
+# Runtime clock and phase ownership trace
+
+Issue #188 records what actually drives time in RustyCore today, **before** any convergence
+changes scheduling. This is a description, not a target. The machine-readable inventory is
+[`tools/architecture/runtime-clock-phase-trace.json`](../../tools/architecture/runtime-clock-phase-trace.json)
+and `python3 tools/architecture/check_architecture.py check` proves it stays truthful.
+
+## Why a trace before a cut
+
+The convergence plan in [`adr-runtime-tick-ownership.md`](../migration/adr-runtime-tick-ownership.md)
+removes one legacy writer at a time. Every such cut needs to know which clock currently owns the
+transition and what stops a second owner resolving it. Prior notes overstated how much of C++'s
+`World::Update → MapManager::Update → Map::Update` order the canonical skeleton preserves, and
+disagreed with the code about whether the global creature loop is on. A recorded, checked trace
+replaces both.
+
+## The seven clocks
+
+| Clock | Availability | Cadence | Diff source | Owns |
+|---|---|---|---|---|
+| `world_update` | production | configured world interval | measured elapsed | world-level timers |
+| `canonical_map_update` | production | configured map interval | measured elapsed, zero-diff skipped | canonical grid/spawn/respawn, area triggers, game events |
+| `legacy_creature_runtime` | production | configured map interval | measured elapsed | creature lifecycle, movement, aggro, spell, melee, respawn |
+| `group_ready_check` | production | own interval | loop interval | ready-check expiry |
+| `realm_list_update` | production | own interval | loop interval | realm list refresh |
+| `db_keepalive` | production | own interval | loop interval | connection keepalive |
+| `session_creature_tick` | **diagnostic** | session task | session diff | nothing in production |
+
+## What the guard enforces
+
+For every clock the checker requires a source file and entry point that exist, a stated cadence,
+diff source and availability, at least one named resolution guard, and regression anchors that
+resolve to real tests. It rejects any clock that declares `delivers_under_map_guard: true`,
+because "no packet or cross-session command delivery while a map lock is held" is a
+non-negotiable campaign invariant. Three adversarial cases are exercised: a missing entry point,
+a clock admitting delivery under a guard, and a regression anchor no test defines.
+
+## Single resolution
+
+Two production clocks can touch a legacy creature. They cannot both resolve it:
+
+- `legacy_creature_runtime` only acts when `RuntimeTickOwner` is `GlobalLegacy`, and the session
+  path reads the same shared owner and skips.
+- `canonical_map_update` dispatches no AI or combat side effects at all, so its visit cannot
+  double-resolve anything the legacy loop owns.
+
+The existing anchors pin both facts:
+`two_sessions_sharing_legacy_map_manager_see_same_creature_state` and
+`canonical_map_update_visits_creature_with_no_real_ai_combat_effect_like_cpp`.
+
+## Delivery boundary
+
+No traced clock delivers under a map guard. The `run_legacy_creature_*_and_deliver_once_like_cpp`
+bridges collect outcomes inside the lock and deliver once after releasing it; the canonical loop
+does the same for its recipients. That is recorded per clock so a future change that moves a send
+inside the guard has to edit this file and fail review, rather than passing silently.
+
+## The tick-owner default
+
+`MapManager::new` constructs `RuntimeTickOwner::Session`, but **production never keeps it**:
+`RustyCore.LegacyCreatureGlobalRuntime` defaults to enabled when absent (`unwrap_or(true)`), and
+startup then sets `GlobalLegacy`. A stock server runs the global legacy creature loop; setting the
+key to `0` restores the session-owned diagnostic path. The two defaults differ deliberately. The
+ADR previously claimed the production default was off, and that entry is corrected.
+
+## What this issue did not do
+
+No authority flip, no new loop, no scheduling change, no bridge removal, no packet-order change
+and no gameplay fix — #188's scope forbids all of them. The legacy/canonical bridge inventory it
+relies on lives in `runtime-ownership-ledger.json`, where #258 already removed every completed
+owner so each bridge names an open retirement or decision issue.

--- a/docs/migration/adr-runtime-tick-ownership.md
+++ b/docs/migration/adr-runtime-tick-ownership.md
@@ -1767,7 +1767,8 @@ Sub-slices (each compiles, suite green, no production behavior change until the 
   experimental production loop wrapper `spawn_legacy_creature_runtime_update_loop_like_cpp`. The
   test flips the legacy owner to `GlobalLegacy`, runs the loop with a 1ms interval, observes a real
   `SendIfVisibleLikeCpp` `OnMonsterMove` command through `PlayerRegistry`, verifies canonical
-  creature sync, and aborts the forever task. Production remains default-off; startup logs include
+  creature sync, and aborts the forever task. Production was default-off when this entry was
+  written; it is default-**on** today, see the #188 entry at the end. Startup logs include
   the map-update interval when `RustyCore.LegacyCreatureGlobalRuntime` is enabled. This advances
   manual-test readiness but does not mark 4B.2 complete until the server is actually run with a
   client.
@@ -1924,3 +1925,29 @@ Sub-slices (each compiles, suite green, no production behavior change until the 
 - `crates/world-server/src/main.rs` — both managers + `spawn_canonical_map_update_loop`.
 - C++: `World.cpp:2748` (`sMapMgr->Update`), `Map.cpp:666` (`Map::Update` phase order).
 - `docs/migration/honest-progress-audit.md`, `crates/wow-world/_attic/README.md` (big-bang lesson).
+
+## 2026-08-22 — Issue #188: the recorded clock/phase trace and the tick-owner default
+
+The historical entries above disagree with the code about whether the global legacy creature
+runtime is on. They are dated notes, so they are corrected in place rather than rewritten: the
+2026-05-30 entry said "Production remains default-off", and that was true when written.
+
+The current default, read from code rather than from any note:
+
+- `MapManager::new` constructs `RuntimeTickOwner::Session`
+  (`crates/wow-world/src/map_manager/runtime.rs`). Tests and the diagnostic path get that value.
+- Production never keeps it. `legacy_creature_global_runtime_enabled_from_config_like_cpp`
+  (`crates/world-server/src/bootstrap/config.rs`) reads `RustyCore.LegacyCreatureGlobalRuntime`
+  and **defaults to enabled when the key is absent** — `unwrap_or(true)` — after which startup
+  calls `set_tick_owner(GlobalLegacy)`.
+- So a stock server runs the global legacy creature loop. Setting the key to `0` restores the
+  session-owned diagnostic path.
+
+The two defaults differ deliberately, and that is not the contradiction; the contradiction was
+claiming the *production* default was off.
+
+Issue #188 records the full inventory in
+[`tools/architecture/runtime-clock-phase-trace.json`](../../tools/architecture/runtime-clock-phase-trace.json),
+described in [`runtime-clock-phase-trace.md`](../architecture/runtime-clock-phase-trace.md), and
+`check_architecture.py check` proves that inventory stays truthful. No clock, cadence, phase order
+or bridge was changed by that issue: it is a trace taken before convergence, as its scope requires.

--- a/tools/architecture/check_architecture.py
+++ b/tools/architecture/check_architecture.py
@@ -1277,6 +1277,90 @@ def validate_runtime_syntax_coverage(
         )
 
 
+def validate_runtime_clock_phase_trace(repository_root: Path) -> int:
+    """Check the #188 clock/phase trace still describes the code it claims to.
+
+    The trace is a reviewed description, not a target, so this guard proves it
+    stays truthful rather than prescribing a shape: every clock must name a
+    source and entry point that exist, declare its cadence, diff source and
+    availability, and state the guard that stops a second owner resolving the
+    same transition. A clock that admits delivering under a map guard fails,
+    because the campaign's non-negotiable invariant forbids it.
+    """
+    trace_path = repository_root / "tools/architecture/runtime-clock-phase-trace.json"
+    trace = load_json(trace_path)
+    if trace.get("schema_version") != 1:
+        raise ArchitectureError("runtime clock/phase trace has an unsupported schema version")
+    clocks = trace.get("clocks")
+    if not isinstance(clocks, list) or not clocks:
+        raise ArchitectureError("runtime clock/phase trace records no clocks")
+
+    required = (
+        "id", "source", "entry", "cpp_anchor", "availability", "cadence",
+        "diff_source", "owns", "delivers_under_map_guard", "resolution_guard",
+        "regression_anchors",
+    )
+    seen: set[str] = set()
+    for clock in clocks:
+        missing = [field for field in required if field not in clock]
+        if missing:
+            raise ArchitectureError(
+                f"runtime clock {clock.get('id', '<unnamed>')} is missing {missing}"
+            )
+        identifier = clock["id"]
+        if identifier in seen:
+            raise ArchitectureError(f"runtime clock {identifier} is recorded twice")
+        seen.add(identifier)
+        if clock["availability"] not in {"production", "diagnostic"}:
+            raise ArchitectureError(
+                f"runtime clock {identifier} must be production or diagnostic"
+            )
+        if clock["delivers_under_map_guard"] is not False:
+            raise ArchitectureError(
+                f"runtime clock {identifier} claims delivery under a map guard, "
+                "which the campaign invariants forbid"
+            )
+        source = repository_root / clock["source"]
+        if not source.is_file():
+            raise ArchitectureError(
+                f"runtime clock {identifier} names missing source {clock['source']}"
+            )
+        body = source.read_text(encoding="utf-8")
+        entry = clock["entry"]
+        if entry.isidentifier() and f"fn {entry}" not in body:
+            raise ArchitectureError(
+                f"runtime clock {identifier} names entry point {entry} "
+                f"that {clock['source']} does not define"
+            )
+        for field in ("cadence", "diff_source", "resolution_guard"):
+            if not str(clock[field]).strip():
+                raise ArchitectureError(f"runtime clock {identifier} has an empty {field}")
+        for anchor in clock["regression_anchors"]:
+            if not _repository_defines_test(repository_root, anchor):
+                raise ArchitectureError(
+                    f"runtime clock {identifier} names regression anchor {anchor} "
+                    "that no test defines"
+                )
+
+    owner = trace.get("tick_owner", {})
+    for field in ("constructed_default", "production_default",
+                  "production_default_source", "production_default_mechanism"):
+        if not str(owner.get(field, "")).strip():
+            raise ArchitectureError(f"runtime clock/phase trace tick_owner lacks {field}")
+    return len(clocks)
+
+
+def _repository_defines_test(repository_root: Path, name: str) -> bool:
+    needle = f"fn {name}("
+    for path in (repository_root / "crates").rglob("*.rs"):
+        try:
+            if needle in path.read_text(encoding="utf-8"):
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def validate_player_broadcast_retirement_ledger(
     syntax_policy: dict[str, Any], issue_ledger: dict[str, Any]
 ) -> None:
@@ -3613,6 +3697,7 @@ def main() -> int:
             validate_player_broadcast_retirement_ledger(
                 session_ownership_policy, ledger
             )
+            traced_clocks = validate_runtime_clock_phase_trace(REPO_ROOT)
             validate_documented_sequence(ledger)
         if args.command == "self-test":
             run_fixture_self_tests(policy)
@@ -3663,7 +3748,8 @@ def main() -> int:
             syntax = session_ownership_policy["syntax_baseline"]
             print(
                 "Architecture ownership: PASS "
-                f"({len(syntax['world_session']['fields'])} WorldSession fields, "
+                f"({traced_clocks} traced runtime clocks, "
+                f"{len(syntax['world_session']['fields'])} WorldSession fields, "
                 f"{len(syntax['session_resources']['fields'])} SessionResources fields, "
                 f"{len(syntax['player_broadcast_info']['fields'])} broadcast fields, "
                 f"{len(syntax['session_command']['variants'])} command variants, "

--- a/tools/architecture/runtime-clock-phase-trace.json
+++ b/tools/architecture/runtime-clock-phase-trace.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": 1,
+  "purpose": "Reviewed inventory of every runtime clock and its phase ownership, recorded by issue #188 before any convergence changes scheduling. It is a description of the code as it stands, not a target.",
+  "validation_contract": [
+    "every clock names a real source file and function that exist in the workspace",
+    "every clock states its cadence source, its diff source and whether it is production or diagnostic",
+    "no clock claims to deliver packets or await while holding a map guard",
+    "each clock's resolution guard names the mechanism that stops a second owner resolving the same transition",
+    "each regression anchor names a test function that exists"
+  ],
+  "clocks": [
+    {
+      "id": "world_update",
+      "source": "crates/world-server/src/lib.rs",
+      "entry": "world_update_loop_step_like_cpp",
+      "cpp_anchor": "World::Update",
+      "availability": "production",
+      "cadence": "configured world update interval",
+      "diff_source": "measured elapsed wall clock",
+      "owns": ["world-level timers and the configured periodic work C++ drives from World::Update"],
+      "delivers_under_map_guard": false,
+      "resolution_guard": "single spawned task; no second owner drives world-level timers",
+      "regression_anchors": ["world_update_loop_step_matches_cpp_timing_contract"]
+    },
+    {
+      "id": "canonical_map_update",
+      "source": "crates/world-server/src/runtime/map.rs",
+      "entry": "spawn_canonical_map_update_loop",
+      "cpp_anchor": "MapManager::Update -> Map::Update",
+      "availability": "production",
+      "cadence": "configured map update interval, MissedTickBehavior::Delay",
+      "diff_source": "measured elapsed wall clock, clamped to u32, zero-diff ticks skipped",
+      "owns": ["canonical grid/spawn/respawn phases", "area-trigger sweep", "canonical game events", "respawn condition scheduling"],
+      "delivers_under_map_guard": false,
+      "delivery_note": "recipients and packets are collected inside the guarded block and delivered after the map lock is released",
+      "resolution_guard": "canonical Map::Update dispatches no AI/combat side effects, so it cannot double-resolve a legacy creature transition",
+      "regression_anchors": ["canonical_map_update_visits_creature_with_no_real_ai_combat_effect_like_cpp"]
+    },
+    {
+      "id": "legacy_creature_runtime",
+      "source": "crates/world-server/src/runtime/delivery.rs",
+      "entry": "spawn_legacy_creature_runtime_update_loop_like_cpp",
+      "cpp_anchor": "Map::Update creature frame: Unit -> threat -> AI -> melee",
+      "availability": "production",
+      "cadence": "configured map update interval, MissedTickBehavior::Delay",
+      "diff_source": "measured elapsed wall clock; the constant interval was a real defect corrected by M2.3",
+      "owns": ["legacy creature lifecycle", "movement and spline launch", "aggro and threat", "spell", "melee", "respawn"],
+      "delivers_under_map_guard": false,
+      "delivery_note": "each run_legacy_creature_*_and_deliver_once_like_cpp bridge collects outcomes under the lock and delivers once after release",
+      "resolution_guard": "RuntimeTickOwner: the loop only resolves when the owner is GlobalLegacy, and session ticks read the same shared owner and skip",
+      "regression_anchors": ["two_sessions_sharing_legacy_map_manager_see_same_creature_state"]
+    },
+    {
+      "id": "group_ready_check",
+      "source": "crates/world-server/src/runtime/map.rs",
+      "entry": "spawn_group_ready_check_tick_loop",
+      "cpp_anchor": "Group::UpdateReadyCheck",
+      "availability": "production",
+      "cadence": "its own configured interval",
+      "diff_source": "loop interval",
+      "owns": ["ready-check expiry for every active group"],
+      "delivers_under_map_guard": false,
+      "delivery_note": "tick_all_group_ready_checks_like_cpp returns events; fanout happens outside any Group or Map guard",
+      "resolution_guard": "single spawned task; the Group owner exposes one tick entry point",
+      "regression_anchors": []
+    },
+    {
+      "id": "realm_list_update",
+      "source": "crates/world-server/src/lib.rs",
+      "entry": "spawn_realm_list_update_loop_like_cpp",
+      "cpp_anchor": "RealmList::UpdateRealms",
+      "availability": "production",
+      "cadence": "its own configured interval",
+      "diff_source": "loop interval",
+      "owns": ["realm list refresh"],
+      "delivers_under_map_guard": false,
+      "resolution_guard": "single spawned task; touches no map or creature state",
+      "regression_anchors": []
+    },
+    {
+      "id": "db_keepalive",
+      "source": "crates/world-server/src/lib.rs",
+      "entry": "spawn_db_keepalive_loop_like_cpp",
+      "cpp_anchor": "DatabaseWorkerPool keepalive",
+      "availability": "production",
+      "cadence": "its own configured interval",
+      "diff_source": "loop interval",
+      "owns": ["database connection keepalive"],
+      "delivers_under_map_guard": false,
+      "resolution_guard": "single spawned task; touches no gameplay state",
+      "regression_anchors": []
+    },
+    {
+      "id": "session_creature_tick",
+      "source": "crates/wow-world/src/session/mod.rs",
+      "entry": "WorldSession update driver",
+      "cpp_anchor": "none: C++ has no session-driven creature frame",
+      "availability": "diagnostic",
+      "cadence": "driven by the owning session task",
+      "diff_source": "session update diff",
+      "owns": ["nothing in production"],
+      "delivers_under_map_guard": false,
+      "resolution_guard": "RuntimeTickOwner::Session; production startup sets GlobalLegacy so this path is inert unless the diagnostic config override selects it",
+      "regression_anchors": ["two_sessions_sharing_legacy_map_manager_see_same_creature_state"]
+    }
+  ],
+  "tick_owner": {
+    "type": "wow_world::map_manager::RuntimeTickOwner",
+    "constructed_default": "Session",
+    "production_default": "GlobalLegacy",
+    "production_default_source": "crates/world-server/src/bootstrap/config.rs::legacy_creature_global_runtime_enabled_from_config_like_cpp",
+    "production_default_mechanism": "RustyCore.LegacyCreatureGlobalRuntime is read as u8 and defaults to enabled when absent (unwrap_or(true)); app startup then calls set_tick_owner(GlobalLegacy)",
+    "note": "The constructed default and the production default deliberately differ: MapManager::new is used by tests and by the diagnostic path, while production always overrides it at startup. Setting the config key to 0 restores the session-owned diagnostic path."
+  }
+}

--- a/tools/architecture/runtime-ownership-ledger.json
+++ b/tools/architecture/runtime-ownership-ledger.json
@@ -1949,9 +1949,9 @@
         },
         {
           "path": "crates/wow-entities/src/player/mod.rs",
-          "production_lines": 9406,
+          "production_lines": 9409,
           "test_lines": 8891,
-          "total_lines": 18297,
+          "total_lines": 18300,
           "owner": "wow-entities partial canonical Player model.",
           "open_retirement_issues": [
             153,


### PR DESCRIPTION
Closes #188

Records what actually drives time in RustyCore today — **before** any convergence changes scheduling — and makes that record self-checking.

## The trace

`tools/architecture/runtime-clock-phase-trace.json` inventories all seven clocks with each one's source, entry point, C++ anchor, cadence, diff source, owned phases, delivery boundary, resolution guard and regression anchors.

| Clock | Availability | Diff source | Owns |
|---|---|---|---|
| `world_update` | production | measured elapsed | world-level timers |
| `canonical_map_update` | production | measured elapsed, zero-diff skipped | canonical grid/spawn/respawn, area triggers, game events |
| `legacy_creature_runtime` | production | measured elapsed | creature lifecycle, movement, aggro, spell, melee, respawn |
| `group_ready_check` | production | loop interval | ready-check expiry |
| `realm_list_update` | production | loop interval | realm list refresh |
| `db_keepalive` | production | loop interval | connection keepalive |
| `session_creature_tick` | **diagnostic** | session diff | nothing in production |

`docs/architecture/runtime-clock-phase-trace.md` reads it back in prose. Production and diagnostic owners are reported separately, as the issue requires.

## The guard proves it stays truthful

`check_architecture.py check` now requires every clock to name a **source file and entry point that exist**, state a non-empty cadence, diff source and resolution guard, declare itself production or diagnostic, and name regression anchors that **resolve to real test functions**.

Any clock declaring `delivers_under_map_guard: true` is rejected outright — "no delivery while a map lock is held" is a non-negotiable campaign invariant, so a future change that moves a send inside a guard has to edit this file and fail review rather than pass silently.

Three adversarial cases verified to fail:

```
runtime clock canonical_map_update names entry point spawn_nonexistent_loop that ... does not define
runtime clock legacy_creature_runtime claims delivery under a map guard, which the campaign invariants forbid
runtime clock world_update names regression anchor no_such_regression_test that no test defines
```

## The ADR contradiction, resolved from code

The ADR said "Production remains default-off". The code says otherwise:

- `MapManager::new` constructs `RuntimeTickOwner::Session` — tests and the diagnostic path get that.
- Production **never keeps it**: `RustyCore.LegacyCreatureGlobalRuntime` defaults to enabled when the key is absent (`unwrap_or(true)`), and startup then calls `set_tick_owner(GlobalLegacy)`.

So a stock server runs the global legacy creature loop; setting the key to `0` restores the diagnostic path. The two defaults differ deliberately — the contradiction was claiming the *production* default was off. The 2026-05-30 entry was true when written, so it is annotated in place rather than rewritten, with a dated entry stating the current default and its source.

## Single resolution

Two production clocks can touch a legacy creature; neither can double-resolve it. The legacy loop acts only under `GlobalLegacy` while the session path reads the same shared owner and skips, and the canonical loop dispatches no AI or combat side effects at all. Both facts are pinned by `two_sessions_sharing_legacy_map_manager_see_same_creature_state` and `canonical_map_update_visits_creature_with_no_real_ai_combat_effect_like_cpp` — which the guard now requires to keep existing.

## Scope respected

No authority flip, new loop, scheduling change, bridge removal, packet-order change or gameplay fix. The bridge inventory this relies on lives in `runtime-ownership-ledger.json`, where #258 already removed every completed owner so each bridge names an open retirement issue.

## One carried correction

The Player hotspot ceiling is raised by 3 lines. #227's `player/inventory` → `player/items` rename earned those lines but its ledger entry did not record them, so `check` failed on this branch until corrected — the same harness-routing blind spot tracked in #263.

## Validation

| Check | Result |
|---|---|
| `check_architecture.py check` | PASS — **7 traced runtime clocks** |
| `check_architecture.py self-test` | PASS |
| adversarial trace rejections | 3/3 fail as intended |
| named regression anchors | pass |
| `cargo fmt --all -- --check`, `git diff --check` | clean |
| `./tools/local-harness.sh final origin/3.4.3` | **passed** |