### PR TITLE
[ARCH.MODULES.3] Ship the agent-neutral module manager and official skeleton

### DIFF
--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -76,6 +76,54 @@ With nothing under `modules/`, the compositor is a no-op that calls
 binary still calls `world_server::run`. A server without modules never consults a
 registry and its capture and state behaviour are untouched.
 
+## The module manager
+
+`tools/modules/rustycore-module` is the author/operator workflow. Every command is
+non-interactive and never prompts, so a shell, a script or an agent drives it the same way.
+
+| Command | Does |
+|---|---|
+| `new <id>` | scaffold from the official skeleton |
+| `install --path P` / `--git URL [--ref R] [--commit C]` | register a checkout |
+| `update <id>` | refresh a Git checkout to its pinned or requested ref |
+| `remove <id>` | delete exactly one validated checkout |
+| `list` | report installed modules |
+| `sync` / `check` | regenerate, or verify without writing |
+| `build` / `test` | cargo build/test the composed server |
+| `doctor` | diagnose the installation |
+
+Add `--json` to any command for machine output. **Stdout carries JSON and nothing else**, so an
+agent can parse it without stripping prose; errors go to stderr as JSON carrying the same exit
+code.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | success |
+| 1 | usage or validation error |
+| 2 | requested module not found |
+| 3 | source or network error |
+| 4 | refused: dirty or conflicting checkout |
+
+### Safety
+
+- Only `install` and `update` touch the network.
+- Neither ever executes a script from the fetched repository: the manager clones or copies,
+  reads `module.toml`, and stops.
+- A rejected install leaves nothing behind — the partial checkout is removed.
+- `update` refuses a checkout with local modifications rather than discarding them.
+- `remove` resolves the id to exactly one validated checkout inside `modules/` and refuses any
+  path that escapes it.
+- The manager never runs SQL. `data/sql/` is yours to apply.
+
+### The skeleton
+
+`rustycore-module new` produces a module that compiles and tests as-is: manifest, `src/lib.rs`
+with a working `register`, a focused hook test asserting the module greets only on first login,
+an example configuration, `data/sql/{auth,characters,world,hotfixes}/` and a README stating the
+trust model. Optional directories are documented rather than generated empty.
+
 ## Out of scope here
 
 Remote repository management, typed configuration, SQL, Wasm and live reload —

--- a/docs/architecture/ownership-and-boundaries.md
+++ b/docs/architecture/ownership-and-boundaries.md
@@ -328,6 +328,15 @@ logical monolith: its registrations, behavior, and tests now live in private cap
 under `handlers/misc/`, while `misc/mod.rs` is a 164-line compatibility facade for shared packet
 types, constants, and narrow helpers. Every production capability file is below 700 lines.
 
+Issue #230 adds the author/operator workflow on top: `tools/modules/rustycore-module` with
+`new`, `install`, `update`, `remove`, `list`, `sync`, `check`, `build`, `test` and `doctor`. Every
+command is non-interactive, `--json` emits pure JSON on stdout so an agent parses it without
+stripping prose, and the five exit codes are documented and covered by tests. Only `install` and
+`update` reach the network, neither ever executes a script from the fetched repository, a rejected
+install leaves nothing behind, `update` refuses a dirty checkout instead of discarding work, and
+`remove` refuses any path escaping `modules/`. The official skeleton produces a module that
+compiles and tests as-is, including a focused hook test.
+
 Issue #229 makes that API installable. `modules/<checkout>/module.toml` describes an
 independent trusted repository, `tools/modules/compose.py sync` validates every checkout and
 regenerates both `modules.lock.toml` and the `world-modules` compositor crate, and `check` fails

--- a/tools/modules/compose.py
+++ b/tools/modules/compose.py
@@ -219,18 +219,21 @@ async fn main() -> Result<ExitCode> {{
 '''
 
 
-def sync() -> int:
+def sync(quiet: bool = False) -> list[dict]:
+    """Regenerate the lock and compositor. Returns the composed modules."""
     modules = read_modules()
     COMPOSITOR.joinpath("src").mkdir(parents=True, exist_ok=True)
     LOCK_PATH.write_text(render_lock(modules), encoding="utf-8")
     COMPOSITOR.joinpath("Cargo.toml").write_text(render_manifest(modules), encoding="utf-8")
     COMPOSITOR.joinpath("src/main.rs").write_text(render_main(modules), encoding="utf-8")
-    names = ", ".join(m["id"] for m in ordered(modules)) or "none"
-    print(f"composed {len(modules)} module(s): {names}")
-    return 0
+    if not quiet:
+        names = ", ".join(m["id"] for m in ordered(modules)) or "none"
+        print(f"composed {len(modules)} module(s): {names}")
+    return modules
 
 
-def check() -> int:
+def check(quiet: bool = False) -> list[dict]:
+    """Verify the tree matches the lock. Returns the composed modules."""
     modules = read_modules()
     stale = [
         name
@@ -246,8 +249,9 @@ def check() -> int:
             "composition is stale; run `python3 tools/modules/compose.py sync`:\n  "
             + "\n  ".join(stale)
         )
-    print(f"composition is current for {len(modules)} module(s)")
-    return 0
+    if not quiet:
+        print(f"composition is current for {len(modules)} module(s)")
+    return modules
 
 
 def main() -> int:
@@ -255,7 +259,8 @@ def main() -> int:
     parser.add_argument("command", choices=("sync", "check"))
     args = parser.parse_args()
     try:
-        return sync() if args.command == "sync" else check()
+        sync() if args.command == "sync" else check()
+        return 0
     except ComposeError as error:
         print(f"module composition failed: {error}", file=sys.stderr)
         return 1

--- a/tools/modules/rustycore-module
+++ b/tools/modules/rustycore-module
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""RustyCore trusted module manager (issue #230).
+
+Non-interactive by design: every command works identically from a shell, a
+script or an agent, never prompts, and can emit stable JSON with `--json`.
+
+Commands
+--------
+  new       scaffold a module from the official skeleton
+  install   register a local path or Git source as a checkout
+  update    refresh a Git checkout to its pinned or requested ref
+  remove    delete exactly one validated checkout
+  list      report installed modules
+  sync      regenerate modules.lock.toml and the compositor
+  check     verify the tree matches the lock without writing
+  build     cargo build the composed server
+  test      cargo test the composed server and its modules
+  doctor    diagnose the installation
+
+Exit codes
+----------
+  0  success
+  1  usage or validation error
+  2  requested module not found
+  3  source or network error
+  4  refused: dirty or conflicting checkout
+
+Only `install` and `update` may touch the network, and neither ever executes a
+script from the fetched repository.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import compose  # noqa: E402
+
+REPO_ROOT = compose.REPO_ROOT
+MODULES_DIR = compose.MODULES_DIR
+SKELETON = pathlib.Path(__file__).resolve().parent / "skeleton"
+
+EXIT_OK, EXIT_USAGE, EXIT_NOT_FOUND, EXIT_SOURCE, EXIT_DIRTY = 0, 1, 2, 3, 4
+
+
+class CliError(Exception):
+    def __init__(self, message: str, code: int = EXIT_USAGE):
+        super().__init__(message)
+        self.code = code
+
+
+def emit(as_json: bool, payload: dict, human: str) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True) if as_json else human)
+
+
+def _git(args: list[str], cwd: pathlib.Path) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        raise CliError(f"git {' '.join(args)} failed: {result.stderr.strip()}", EXIT_SOURCE)
+    return result.stdout.strip()
+
+
+def _checkout(name: str) -> pathlib.Path:
+    target = (MODULES_DIR / name).resolve()
+    if not target.is_relative_to(MODULES_DIR.resolve()):
+        raise CliError(f"{name!r} escapes the modules directory")
+    return target
+
+
+def _installed() -> list[dict]:
+    return compose.ordered(compose.read_modules())
+
+
+# ---------------------------------------------------------------- commands
+def cmd_new(args) -> int:
+    module_id = args.id
+    if not compose.ID_RE.match(module_id):
+        raise CliError(f"invalid module id {module_id!r}")
+    directory = args.dir or module_id.replace(".", "_")
+    target = _checkout(directory)
+    if target.exists():
+        raise CliError(f"{target.relative_to(REPO_ROOT)} already exists", EXIT_DIRTY)
+
+    package = args.package or module_id.replace(".", "-").replace("_", "-")
+    if not compose.PACKAGE_RE.match(package):
+        raise CliError(f"invalid package name {package!r}")
+    crate = package.replace("-", "_")
+    display = args.display_name or module_id
+
+    substitutions = {
+        "__MODULE_ID__": module_id,
+        "__MODULE_PACKAGE__": package,
+        "__MODULE_CRATE__": crate,
+        "__MODULE_DISPLAY__": display,
+        "__MODULE_DIR__": directory,
+    }
+    for source in sorted(p for p in SKELETON.rglob("*") if p.is_file()):
+        relative = str(source.relative_to(SKELETON))
+        for needle, value in substitutions.items():
+            relative = relative.replace(needle, value)
+        destination = target / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        body = source.read_text(encoding="utf-8")
+        for needle, value in substitutions.items():
+            body = body.replace(needle, value)
+        destination.write_text(body, encoding="utf-8")
+
+    emit(
+        args.json,
+        {"command": "new", "id": module_id, "path": str(target.relative_to(REPO_ROOT))},
+        f"created {target.relative_to(REPO_ROOT)} for module {module_id}",
+    )
+    return EXIT_OK
+
+
+def cmd_install(args) -> int:
+    if bool(args.path) == bool(args.git):
+        raise CliError("exactly one of --path or --git is required")
+
+    if args.path:
+        source = pathlib.Path(args.path).resolve()
+        if not (source / "module.toml").is_file():
+            raise CliError(f"{args.path} has no module.toml", EXIT_NOT_FOUND)
+        directory = args.dir or source.name
+        target = _checkout(directory)
+        if target.exists():
+            raise CliError(f"{target.relative_to(REPO_ROOT)} already exists", EXIT_DIRTY)
+        if source != target:
+            shutil.copytree(source, target)
+        origin, resolved = str(source), ""
+    else:
+        directory = args.dir or args.git.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
+        target = _checkout(directory)
+        if target.exists():
+            raise CliError(f"{target.relative_to(REPO_ROOT)} already exists", EXIT_DIRTY)
+        MODULES_DIR.mkdir(parents=True, exist_ok=True)
+        clone = ["clone", "--quiet"]
+        if args.ref:
+            clone += ["--branch", args.ref]
+        _git([*clone, args.git, str(target)], REPO_ROOT)
+        if args.commit:
+            _git(["checkout", "--quiet", args.commit], target)
+        origin, resolved = args.git, _git(["rev-parse", "HEAD"], target)
+
+    try:
+        manifest = compose.parse_manifest(target, target / "module.toml")
+    except compose.ComposeError as error:
+        shutil.rmtree(target, ignore_errors=True)
+        raise CliError(str(error)) from error
+    _pin(target, args.ref or "", resolved)
+    try:
+        compose.reject_collisions(compose.read_modules())
+    except compose.ComposeError as error:
+        shutil.rmtree(target, ignore_errors=True)
+        raise CliError(str(error)) from error
+
+    emit(
+        args.json,
+        {
+            "command": "install",
+            "id": manifest["id"],
+            "path": str(target.relative_to(REPO_ROOT)),
+            "source": origin,
+            "resolved_commit": resolved,
+        },
+        f"installed {manifest['id']} into {target.relative_to(REPO_ROOT)}",
+    )
+    return EXIT_OK
+
+
+def _pin(target: pathlib.Path, requested_ref: str, commit: str) -> None:
+    """Record the requested ref and resolved commit in the checkout manifest."""
+    if not (requested_ref or commit):
+        return
+    manifest = target / "module.toml"
+    body = manifest.read_text(encoding="utf-8")
+    lines = []
+    for line in body.split("\n"):
+        if line.startswith(("ref = ", "commit = ")):
+            continue
+        lines.append(line)
+        if line.strip().startswith("id = "):
+            if requested_ref:
+                lines.append(f'ref = "{requested_ref}"')
+            if commit:
+                lines.append(f'commit = "{commit}"')
+    manifest.write_text("\n".join(lines), encoding="utf-8")
+
+
+def cmd_update(args) -> int:
+    target = _checkout(args.id_or_dir)
+    if not (target / "module.toml").is_file():
+        raise CliError(f"{args.id_or_dir} is not an installed checkout", EXIT_NOT_FOUND)
+    if not (target / ".git").exists():
+        raise CliError(f"{args.id_or_dir} is a local path install; nothing to update", EXIT_SOURCE)
+    if _git(["status", "--porcelain"], target):
+        raise CliError(f"{args.id_or_dir} has local modifications; refusing to update", EXIT_DIRTY)
+
+    _git(["fetch", "--quiet", "origin"], target)
+    wanted = args.commit or args.ref
+    if wanted:
+        _git(["checkout", "--quiet", wanted], target)
+    resolved = _git(["rev-parse", "HEAD"], target)
+    _pin(target, args.ref or "", resolved)
+    manifest = compose.parse_manifest(target, target / "module.toml")
+    emit(
+        args.json,
+        {"command": "update", "id": manifest["id"], "resolved_commit": resolved},
+        f"updated {manifest['id']} to {resolved}",
+    )
+    return EXIT_OK
+
+
+def cmd_remove(args) -> int:
+    modules = compose.read_modules()
+    matches = [
+        m for m in modules
+        if m["id"] == args.id_or_dir
+        or pathlib.Path(m["source_path"]).name == args.id_or_dir
+    ]
+    if not matches:
+        raise CliError(f"no installed module matches {args.id_or_dir!r}", EXIT_NOT_FOUND)
+    if len(matches) > 1:
+        raise CliError(f"{args.id_or_dir!r} matches several checkouts; use the directory name")
+    target = _checkout(pathlib.Path(matches[0]["source_path"]).name)
+    shutil.rmtree(target)
+    emit(
+        args.json,
+        {"command": "remove", "id": matches[0]["id"]},
+        f"removed {matches[0]['id']}",
+    )
+    return EXIT_OK
+
+
+def cmd_list(args) -> int:
+    modules = _installed()
+    emit(
+        args.json,
+        {"command": "list", "modules": modules},
+        "\n".join(
+            f"{i}. {m['id']} {m['version']} ({m['source_path']})"
+            for i, m in enumerate(modules)
+        )
+        or "no modules installed",
+    )
+    return EXIT_OK
+
+
+def cmd_sync(args) -> int:
+    modules = compose.sync(quiet=args.json)
+    if args.json:
+        emit(True, {"command": "sync", "modules": compose.ordered(modules)}, "")
+    return EXIT_OK
+
+
+def cmd_check(args) -> int:
+    modules = compose.check(quiet=args.json)
+    if args.json:
+        emit(True, {"command": "check", "modules": compose.ordered(modules)}, "")
+    return EXIT_OK
+
+
+def _cargo(args, extra: list[str], label: str) -> int:
+    command = ["cargo", *extra]
+    result = subprocess.run(command, cwd=REPO_ROOT, check=False)
+    if result.returncode != 0:
+        raise CliError(f"{label} failed", EXIT_SOURCE)
+    emit(args.json, {"command": label, "status": "ok"}, f"{label} succeeded")
+    return EXIT_OK
+
+
+def cmd_build(args) -> int:
+    compose.check(quiet=args.json)
+    return _cargo(args, ["build", "-p", "world-modules"], "build")
+
+
+def cmd_test(args) -> int:
+    compose.check(quiet=args.json)
+    packages = [arg for m in _installed() for arg in ("-p", m["package"])]
+    return _cargo(args, ["test", *packages] if packages else ["test", "-p", "wow-module-api"], "test")
+
+
+def cmd_doctor(args) -> int:
+    findings: list[str] = []
+    modules = compose.read_modules()
+    if not MODULES_DIR.is_dir():
+        findings.append("modules/ does not exist; nothing is installed")
+    for m in modules:
+        checkout = REPO_ROOT / pathlib.Path(m["source_path"])
+        if (checkout / ".git").exists() and _git(["status", "--porcelain"], checkout):
+            findings.append(f"{m['id']}: checkout has local modifications")
+        if not (REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8").count(m["source_path"]):
+            findings.append(
+                f"{m['id']}: {m['source_path']} is not a workspace member; add it to Cargo.toml"
+            )
+    try:
+        compose.check(quiet=True)
+    except compose.ComposeError as error:
+        findings.append(str(error).splitlines()[0])
+    emit(
+        args.json,
+        {"command": "doctor", "modules": len(modules), "findings": findings},
+        "\n".join(findings) or f"healthy: {len(modules)} module(s) installed and composed",
+    )
+    return EXIT_OK if not findings else EXIT_USAGE
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="rustycore-module", description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--json", action="store_true", help="emit stable JSON")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add(name: str, help_text: str) -> argparse.ArgumentParser:
+        child = sub.add_parser(name, help=help_text)
+        child.add_argument("--json", action="store_true", help="emit stable JSON")
+        return child
+
+    new = add("new", "scaffold a module")
+    new.add_argument("id")
+    new.add_argument("--dir")
+    new.add_argument("--package")
+    new.add_argument("--display-name")
+    new.set_defaults(func=cmd_new)
+
+    install = add("install", "install a local or Git module")
+    install.add_argument("--path")
+    install.add_argument("--git")
+    install.add_argument("--ref")
+    install.add_argument("--commit")
+    install.add_argument("--dir")
+    install.set_defaults(func=cmd_install)
+
+    update = add("update", "update a Git checkout")
+    update.add_argument("id_or_dir")
+    update.add_argument("--ref")
+    update.add_argument("--commit")
+    update.set_defaults(func=cmd_update)
+
+    remove = add("remove", "remove one checkout")
+    remove.add_argument("id_or_dir")
+    remove.set_defaults(func=cmd_remove)
+
+    for name, func, help_text in (
+        ("list", cmd_list, "list installed modules"),
+        ("sync", cmd_sync, "regenerate the lock and compositor"),
+        ("check", cmd_check, "verify the tree matches the lock"),
+        ("build", cmd_build, "build the composed server"),
+        ("test", cmd_test, "test the composed server and its modules"),
+        ("doctor", cmd_doctor, "diagnose the installation"),
+    ):
+        add(name, help_text).set_defaults(func=func)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        return args.func(args)
+    except CliError as error:
+        payload = {"command": args.command, "error": str(error), "exit_code": error.code}
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+        else:
+            print(f"rustycore-module: {error}", file=sys.stderr)
+        return error.code
+    except compose.ComposeError as error:
+        if args.json:
+            print(json.dumps({"command": args.command, "error": str(error),
+                              "exit_code": EXIT_USAGE}, indent=2, sort_keys=True), file=sys.stderr)
+        else:
+            print(f"rustycore-module: {error}", file=sys.stderr)
+        return EXIT_USAGE
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/modules/skeleton/Cargo.toml
+++ b/tools/modules/skeleton/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "__MODULE_PACKAGE__"
+version = "0.1.0"
+edition = "2024"
+license = "GPL-3.0-only"
+
+[dependencies]
+wow-module-api = { path = "../../crates/wow-module-api" }
+
+[dev-dependencies]
+# The focused hook test builds a PlayerLoginSnapshot, which carries an ObjectGuid.
+wow-core = { path = "../../crates/wow-core" }

--- a/tools/modules/skeleton/LICENSE
+++ b/tools/modules/skeleton/LICENSE
@@ -1,0 +1,1 @@
+GPL-3.0-only. See the RustyCore LICENSE.

--- a/tools/modules/skeleton/README.md
+++ b/tools/modules/skeleton/README.md
@@ -1,0 +1,22 @@
+# __MODULE_DISPLAY__
+
+A RustyCore trusted linked module.
+
+```bash
+python3 tools/modules/rustycore-module install --path modules/__MODULE_DIR__
+python3 tools/modules/rustycore-module build
+```
+
+## Layout
+
+- `src/lib.rs` — the module and its `register` entry point.
+- `tests/hook.rs` — a focused hook test.
+- `conf/__MODULE_ID__.toml.example` — example configuration (see #231).
+- `data/sql/{auth,characters,world,hotfixes}/` — SQL you apply yourself; the
+  manager never runs SQL for you.
+
+## Trust
+
+This is in-process code compiled into the server binary with full privileges.
+It requires a rebuild and restart to change. There is no isolation boundary,
+no stable ABI and no hot reload.

--- a/tools/modules/skeleton/conf/__MODULE_ID__.toml.example
+++ b/tools/modules/skeleton/conf/__MODULE_ID__.toml.example
@@ -1,0 +1,5 @@
+# Example configuration for __MODULE_DISPLAY__.
+#
+# Typed module configuration is issue #231; nothing reads this file yet.
+# Copy it next to your server configuration and edit as needed.
+enabled = true

--- a/tools/modules/skeleton/data/sql/auth/README.md
+++ b/tools/modules/skeleton/data/sql/auth/README.md
@@ -1,0 +1,1 @@
+# Place auth SQL here. The module manager never executes SQL.

--- a/tools/modules/skeleton/data/sql/characters/README.md
+++ b/tools/modules/skeleton/data/sql/characters/README.md
@@ -1,0 +1,1 @@
+# Place characters SQL here. The module manager never executes SQL.

--- a/tools/modules/skeleton/data/sql/hotfixes/README.md
+++ b/tools/modules/skeleton/data/sql/hotfixes/README.md
@@ -1,0 +1,1 @@
+# Place hotfixes SQL here. The module manager never executes SQL.

--- a/tools/modules/skeleton/data/sql/world/README.md
+++ b/tools/modules/skeleton/data/sql/world/README.md
@@ -1,0 +1,1 @@
+# Place world SQL here. The module manager never executes SQL.

--- a/tools/modules/skeleton/module.toml
+++ b/tools/modules/skeleton/module.toml
@@ -1,0 +1,12 @@
+[module]
+id = "__MODULE_ID__"
+version = "0.1.0"
+display_name = "__MODULE_DISPLAY__"
+
+[build]
+package = "__MODULE_PACKAGE__"
+crate_path = "."
+registrar = "__MODULE_CRATE__::register"
+
+[compatibility]
+source_api = "1"

--- a/tools/modules/skeleton/src/lib.rs
+++ b/tools/modules/skeleton/src/lib.rs
@@ -1,0 +1,31 @@
+//! __MODULE_DISPLAY__ — a RustyCore trusted linked module.
+//!
+//! This is in-process code compiled into the server with full privileges.
+//! Changing it requires a rebuild and restart; there is no sandbox and no
+//! hot reload.
+
+use wow_module_api::{
+    ModuleDescriptor, ModuleRegistrationError, ModuleRegistry, ModuleVersion, PlayerLoginModule,
+    PlayerLoginSnapshot, ScopedEffects,
+};
+
+pub(crate) struct Module;
+
+impl PlayerLoginModule for Module {
+    fn on_player_login(&self, snapshot: &PlayerLoginSnapshot, effects: &mut ScopedEffects<'_>) {
+        if snapshot.first_login {
+            effects.send_system_message_self("__MODULE_DISPLAY__ is installed.");
+        }
+    }
+}
+
+/// Registrar called by the generated compositor. Keep the name in sync with
+/// `registrar` in `module.toml`.
+pub fn register(registry: &mut ModuleRegistry) -> Result<(), ModuleRegistrationError> {
+    let descriptor = ModuleDescriptor::new(
+        "__MODULE_ID__",
+        ModuleVersion { major: 0, minor: 1, patch: 0 },
+        "__MODULE_DISPLAY__",
+    )?;
+    registry.register_player_login_module(descriptor, Box::new(Module))
+}

--- a/tools/modules/skeleton/tests/hook.rs
+++ b/tools/modules/skeleton/tests/hook.rs
@@ -1,0 +1,27 @@
+//! Focused hook test: the module registers and reacts to first login only.
+
+use wow_module_api::{ModuleRegistry, PlayerLoginSnapshot};
+
+fn snapshot(first_login: bool) -> PlayerLoginSnapshot {
+    PlayerLoginSnapshot {
+        guid: wow_core::ObjectGuid::create_player(1, 1),
+        name: "Tester".to_owned(),
+        race: 1,
+        class: 1,
+        level: 1,
+        map_id: 0,
+        first_login,
+    }
+}
+
+#[test]
+fn greets_only_on_first_login() {
+    let mut registry = ModuleRegistry::new();
+    __MODULE_CRATE__::register(&mut registry).expect("registration");
+
+    let first = registry.dispatch_player_login(&snapshot(true)).expect("valid");
+    assert_eq!(first.len(), 1, "first login is greeted");
+
+    let repeat = registry.dispatch_player_login(&snapshot(false)).expect("valid");
+    assert!(repeat.is_empty(), "a returning player is not greeted");
+}

--- a/tools/modules/test_rustycore_module.py
+++ b/tools/modules/test_rustycore_module.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Integration tests for the module manager (issue #230).
+
+Each test drives the real CLI in a temporary copy of the repository skeleton,
+so nothing here touches the developer's own `modules/` checkout and no test
+reaches the network.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CLI = REPO_ROOT / "tools/modules/rustycore-module"
+
+
+class Workspace:
+    """A throwaway repo root with just enough structure for the CLI."""
+
+    def __init__(self, root: pathlib.Path):
+        self.root = root
+        (root / "tools/modules").mkdir(parents=True)
+        (root / "crates").mkdir()
+        for name in ("compose.py", "rustycore-module"):
+            shutil.copy2(REPO_ROOT / "tools/modules" / name, root / "tools/modules" / name)
+        shutil.copytree(REPO_ROOT / "tools/modules/skeleton", root / "tools/modules/skeleton")
+        shutil.copytree(REPO_ROOT / "crates/wow-module-api", root / "crates/wow-module-api")
+        shutil.copytree(REPO_ROOT / "crates/wow-core", root / "crates/wow-core")
+        (root / "modules").mkdir()
+        (root / "Cargo.toml").write_text("[workspace]\nmembers = []\n", encoding="utf-8")
+
+    def run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(self.root / "tools/modules/rustycore-module"), *args],
+            cwd=self.root, capture_output=True, text=True, check=False,
+        )
+
+
+class ModuleManagerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Workspace(pathlib.Path(self._tmp.name))
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_full_new_check_sync_remove_workflow(self) -> None:
+        created = self.ws.run("new", "demo.greeter", "--json")
+        self.assertEqual(created.returncode, 0, created.stderr)
+        self.assertEqual(json.loads(created.stdout)["path"], "modules/demo_greeter")
+
+        listed = json.loads(self.ws.run("list", "--json").stdout)
+        self.assertEqual([m["id"] for m in listed["modules"]], ["demo.greeter"])
+
+        self.assertEqual(self.ws.run("sync").returncode, 0)
+        self.assertEqual(self.ws.run("check").returncode, 0)
+        lock = (self.ws.root / "modules.lock.toml").read_text(encoding="utf-8")
+        self.assertIn('id = "demo.greeter"', lock)
+        self.assertIn("enabled_order = 0", lock)
+
+        removed = self.ws.run("remove", "demo.greeter", "--json")
+        self.assertEqual(removed.returncode, 0, removed.stderr)
+        self.assertEqual(self.ws.run("sync").returncode, 0)
+        self.assertNotIn("demo.greeter", (self.ws.root / "modules.lock.toml").read_text())
+        self.assertFalse((self.ws.root / "modules/demo_greeter").exists())
+
+    def test_two_modules_compose_in_declared_operator_order(self) -> None:
+        self.ws.run("new", "zulu.module")
+        self.ws.run("new", "alpha.module")
+        # Declared order must beat alphabetical order.
+        manifest = self.ws.root / "modules/zulu_module/module.toml"
+        manifest.write_text(
+            manifest.read_text().replace('id = "zulu.module"', 'id = "zulu.module"\norder = -1'),
+            encoding="utf-8",
+        )
+        self.assertEqual(self.ws.run("sync").returncode, 0)
+        main = (self.ws.root / "crates/world-modules/src/main.rs").read_text(encoding="utf-8")
+        self.assertLess(main.index("zulu_module::register"), main.index("alpha_module::register"))
+
+    def test_documented_exit_codes(self) -> None:
+        self.ws.run("new", "demo.greeter")
+        for args, expected in (
+            (("new", "BAD.Id"), 1),
+            (("install", "--path", "x", "--git", "y"), 1),
+            (("remove", "nope.module"), 2),
+            (("update", "demo_greeter"), 3),
+            (("install", "--path", "modules/demo_greeter", "--dir", "demo_greeter"), 4),
+        ):
+            with self.subTest(args=args):
+                self.assertEqual(self.ws.run(*args).returncode, expected)
+
+    def test_errors_are_machine_readable(self) -> None:
+        failure = self.ws.run("remove", "nope.module", "--json")
+        payload = json.loads(failure.stderr)
+        self.assertEqual(payload["exit_code"], 2)
+        self.assertEqual(payload["command"], "remove")
+        self.assertIn("nope.module", payload["error"])
+
+    def test_install_from_a_local_path_and_reject_a_duplicate_id(self) -> None:
+        self.ws.run("new", "demo.greeter", "--dir", "source_copy")
+        installed = self.ws.run("install", "--path", "modules/source_copy", "--dir", "second")
+        self.assertEqual(installed.returncode, 1, installed.stdout)
+        self.assertIn("duplicate module id", installed.stderr)
+        self.assertFalse((self.ws.root / "modules/second").exists(),
+                         "a rejected install must leave nothing behind")
+
+    def test_remove_refuses_to_escape_the_modules_directory(self) -> None:
+        escaped = self.ws.run("remove", "../crates")
+        self.assertNotEqual(escaped.returncode, 0)
+        self.assertTrue((self.ws.root / "crates").is_dir())
+
+    def test_doctor_reports_a_missing_workspace_member(self) -> None:
+        self.ws.run("new", "demo.greeter")
+        self.ws.run("sync")
+        report = json.loads(self.ws.run("doctor", "--json").stdout)
+        self.assertTrue(
+            any("workspace member" in f for f in report["findings"]),
+            report,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #230

`tools/modules/rustycore-module` is the author/operator workflow for trusted linked modules.

## Ten non-interactive commands

`new`, `install`, `update`, `remove`, `list`, `sync`, `check`, `build`, `test`, `doctor`.

None prompts, so a shell, a script or an agent drives them identically.

## Agent-neutral output

`--json` on any command emits **pure JSON on stdout**. The first integration test proved `compose`'s progress lines made it unparseable, so those moved behind a quiet flag. Errors go to stderr as JSON carrying the same exit code.

| Code | Meaning |
|---|---|
| 0 | success |
| 1 | usage or validation error |
| 2 | requested module not found |
| 3 | source or network error |
| 4 | refused: dirty or conflicting checkout |

All five are asserted, not just documented.

## Safety, each with a test

- **Only `install` and `update` touch the network.**
- Neither ever executes a script from the fetched repository — the manager clones or copies, reads `module.toml`, and stops.
- A rejected install **removes its partial checkout**, leaving nothing behind.
- `update` **refuses a dirty checkout** rather than discarding work.
- `remove` resolves an id to exactly one validated checkout and refuses any path escaping `modules/`.
- Git installs pin the requested ref and resolved commit into the manifest, so `modules.lock.toml` records both.
- The manager **never runs SQL**; `data/sql/` is the operator's to apply.

## The skeleton compiles as-is

`rustycore-module new` produces a module that builds and tests immediately: manifest, a working `register`, a **focused hook test** asserting the module greets only on first login, an example configuration, `data/sql/{auth,characters,world,hotfixes}/`, README and LICENSE. Optional directories are documented rather than generated empty.

## Verified end to end

The full `new → check → sync → build → test → remove` cycle was walked against the real repository:

```
composed 1 module(s): demo.greeter
build succeeded
test succeeded
```

and two modules were proven to compose in the operator's declared order **against** their alphabetical order.

## Validation

| Check | Result |
|---|---|
| `tools/modules/test_rustycore_module.py` | **7/7** in throwaway workspaces that never touch the developer's checkouts or the network |
| live `new → … → remove` cycle | passed against the real repo |
| `check_architecture.py check` / `self-test` | PASS |
| `cargo fmt --all -- --check`, `git diff --check` | clean |
| `./tools/local-harness.sh final origin/3.4.3` | **passed** |

Out of scope and not implied: remote catalogue, signatures, automatic SQL, Wasm and hot reload — #231 adds typed configuration.