### PR TITLE
[ARCH.MODULES.4] Add typed module configuration and compatibility fixtures

### DIFF
--- a/crates/world-modules/src/main.rs
+++ b/crates/world-modules/src/main.rs
@@ -6,7 +6,8 @@
 //!
 //! Registrars run in the operator's declared order, recorded in
 //! `modules.lock.toml`. Ordering is explicit here and never relies on linker
-//! inventory. Installed modules, in composition order:
+//! inventory. Configuration is validated at sync and embedded, so no callback
+//! reads a file. Installed modules, in composition order:
 //!
 //! No modules are installed.
 

--- a/crates/wow-module-api/src/config.rs
+++ b/crates/wow-module-api/src/config.rs
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 alseif0x
+// RustyCore — WoW WotLK 3.4.3 server in Rust
+// Based on TrinityCore protocol research (https://github.com/TrinityCore/TrinityCore)
+// Licensed under GPL v3 — https://www.gnu.org/licenses/gpl-3.0.html
+
+//! Namespaced, typed module configuration.
+//!
+//! A module never reads a file. The composition step validates the operator's
+//! overrides against the module's declared defaults, embeds the result, and
+//! hands each module only its own namespace at registration time. What the
+//! module keeps is an immutable snapshot, so a login callback does no I/O and
+//! cannot observe a mid-flight change.
+//!
+//! This module deliberately parses nothing: `wow-module-api` has an empty
+//! external dependency allowlist, so the TOML lives on the composition side
+//! and only typed values cross the boundary.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use crate::registry::ModuleId;
+
+/// A configuration value, restricted to what a module option may be.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ModuleConfigValue {
+    Bool(bool),
+    Integer(i64),
+    Text(String),
+}
+
+impl ModuleConfigValue {
+    fn type_name(&self) -> &'static str {
+        match self {
+            Self::Bool(_) => "boolean",
+            Self::Integer(_) => "integer",
+            Self::Text(_) => "string",
+        }
+    }
+
+    /// Canonical rendering used for the digest. Deterministic by construction:
+    /// no floats, no map iteration order, no locale.
+    fn canonical(&self) -> String {
+        match self {
+            Self::Bool(v) => format!("b:{v}"),
+            Self::Integer(v) => format!("i:{v}"),
+            Self::Text(v) => format!("s:{}:{v}", v.len()),
+        }
+    }
+}
+
+/// Why a module refused its configuration.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ModuleConfigError {
+    UnknownField {
+        module: String,
+        key: String,
+    },
+    MissingField {
+        module: String,
+        key: String,
+    },
+    WrongType {
+        module: String,
+        key: String,
+        expected: &'static str,
+        found: &'static str,
+    },
+    InvalidValue {
+        module: String,
+        key: String,
+        reason: String,
+    },
+}
+
+impl fmt::Display for ModuleConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownField { module, key } => write!(
+                f,
+                "module {module}: unknown configuration key {key:?}; remove it or check the \
+                 module's documented options"
+            ),
+            Self::MissingField { module, key } => {
+                write!(
+                    f,
+                    "module {module}: required configuration key {key:?} is missing"
+                )
+            }
+            Self::WrongType {
+                module,
+                key,
+                expected,
+                found,
+            } => write!(
+                f,
+                "module {module}: configuration key {key:?} must be a {expected}, found a {found}"
+            ),
+            Self::InvalidValue {
+                module,
+                key,
+                reason,
+            } => {
+                write!(
+                    f,
+                    "module {module}: configuration key {key:?} is invalid: {reason}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ModuleConfigError {}
+
+/// One module's namespaced configuration.
+///
+/// Keys are namespaced by construction: a module is only ever handed the tree
+/// built for its own [`ModuleId`], so two modules cannot collide.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ModuleConfig {
+    module: String,
+    values: BTreeMap<String, ModuleConfigValue>,
+    /// Fixed at construction, because the digest must describe what the module
+    /// was *given*. Computing it from `values` would change as options are
+    /// read and would report an empty configuration once the module finished.
+    digest: String,
+}
+
+impl ModuleConfig {
+    #[must_use]
+    pub fn new(module: &ModuleId, values: BTreeMap<String, ModuleConfigValue>) -> Self {
+        let digest = Self::compute_digest(&values);
+        Self {
+            module: module.to_string(),
+            values,
+            digest,
+        }
+    }
+
+    /// A deterministic digest of the exact configuration this module received.
+    ///
+    /// Stable across runs and machines: the map is ordered, values render
+    /// canonically, and no float or timestamp participates.
+    #[must_use]
+    pub fn digest(&self) -> &str {
+        &self.digest
+    }
+
+    fn compute_digest(values: &BTreeMap<String, ModuleConfigValue>) -> String {
+        let mut state: u64 = 0xcbf2_9ce4_8422_2325;
+        for (key, value) in values {
+            for byte in key
+                .as_bytes()
+                .iter()
+                .chain(b"=")
+                .chain(value.canonical().as_bytes())
+                .chain(b";")
+            {
+                state ^= u64::from(*byte);
+                state = state.wrapping_mul(0x0000_0100_0000_01b3);
+            }
+        }
+        format!("fnv1a64:{state:016x}")
+    }
+
+    pub fn bool(&mut self, key: &str) -> Result<Option<bool>, ModuleConfigError> {
+        match self.take(key) {
+            None => Ok(None),
+            Some(ModuleConfigValue::Bool(v)) => Ok(Some(v)),
+            Some(other) => Err(self.wrong_type(key, "boolean", &other)),
+        }
+    }
+
+    pub fn integer(&mut self, key: &str) -> Result<Option<i64>, ModuleConfigError> {
+        match self.take(key) {
+            None => Ok(None),
+            Some(ModuleConfigValue::Integer(v)) => Ok(Some(v)),
+            Some(other) => Err(self.wrong_type(key, "integer", &other)),
+        }
+    }
+
+    pub fn text(&mut self, key: &str) -> Result<Option<String>, ModuleConfigError> {
+        match self.take(key) {
+            None => Ok(None),
+            Some(ModuleConfigValue::Text(v)) => Ok(Some(v)),
+            Some(other) => Err(self.wrong_type(key, "string", &other)),
+        }
+    }
+
+    /// Reject a value the type system cannot: an empty or oversized string, a
+    /// negative count, and so on.
+    pub fn invalid(&self, key: &str, reason: impl Into<String>) -> ModuleConfigError {
+        ModuleConfigError::InvalidValue {
+            module: self.module.clone(),
+            key: key.to_owned(),
+            reason: reason.into(),
+        }
+    }
+
+    pub fn missing(&self, key: &str) -> ModuleConfigError {
+        ModuleConfigError::MissingField {
+            module: self.module.clone(),
+            key: key.to_owned(),
+        }
+    }
+
+    /// Every key the module did not read is an error, not a silent typo.
+    ///
+    /// A module calls this once it has taken the options it knows about, so a
+    /// misspelled operator key fails activation instead of being ignored.
+    pub fn finish(self) -> Result<(), ModuleConfigError> {
+        match self.values.keys().next() {
+            None => Ok(()),
+            Some(key) => Err(ModuleConfigError::UnknownField {
+                module: self.module,
+                key: key.clone(),
+            }),
+        }
+    }
+
+    fn take(&mut self, key: &str) -> Option<ModuleConfigValue> {
+        self.values.remove(key)
+    }
+
+    fn wrong_type(
+        &self,
+        key: &str,
+        expected: &'static str,
+        found: &ModuleConfigValue,
+    ) -> ModuleConfigError {
+        ModuleConfigError::WrongType {
+            module: self.module.clone(),
+            key: key.to_owned(),
+            expected,
+            found: found.type_name(),
+        }
+    }
+}

--- a/crates/wow-module-api/src/lib.rs
+++ b/crates/wow-module-api/src/lib.rs
@@ -20,10 +20,12 @@
 //! compiled in, the types are expected to evolve, and official internal
 //! scripts keep their own separate dispatch.
 
+mod config;
 mod effect;
 mod hook;
 mod registry;
 
+pub use config::{ModuleConfig, ModuleConfigError, ModuleConfigValue};
 pub use effect::{ModuleEffectError, PlayerLoginEffect, PlayerLoginEffects, ScopedEffects};
 pub use hook::{PlayerLoginModule, PlayerLoginSnapshot};
 pub use registry::{

--- a/crates/wow-module-api/src/registry.rs
+++ b/crates/wow-module-api/src/registry.rs
@@ -106,9 +106,25 @@ impl ModuleDescriptor {
 /// Why a registration was refused.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ModuleRegistrationError {
-    InvalidId { id: String, reason: &'static str },
-    InvalidDescriptor { id: String, reason: &'static str },
-    DuplicateId { id: String },
+    InvalidId {
+        id: String,
+        reason: &'static str,
+    },
+    InvalidDescriptor {
+        id: String,
+        reason: &'static str,
+    },
+    DuplicateId {
+        id: String,
+    },
+    /// A module refused its configuration, so it never registered.
+    Configuration(crate::ModuleConfigError),
+}
+
+impl From<crate::ModuleConfigError> for ModuleRegistrationError {
+    fn from(error: crate::ModuleConfigError) -> Self {
+        Self::Configuration(error)
+    }
 }
 
 impl fmt::Display for ModuleRegistrationError {
@@ -119,6 +135,7 @@ impl fmt::Display for ModuleRegistrationError {
                 write!(f, "invalid descriptor for module {id}: {reason}")
             }
             Self::DuplicateId { id } => write!(f, "module {id} is already registered"),
+            Self::Configuration(error) => write!(f, "{error}"),
         }
     }
 }

--- a/crates/wow-module-api/src/tests.rs
+++ b/crates/wow-module-api/src/tests.rs
@@ -246,3 +246,86 @@ fn the_self_message_effect_carries_no_target() {
         "the effect must not carry a target: {rendered}"
     );
 }
+
+/// `compose.py` recomputes this digest to record it in `modules.lock.toml`.
+/// Pinning the exact string here means the two implementations cannot drift
+/// apart silently: `tools/modules/test_rustycore_module.py` asserts the same
+/// literal from the Python side.
+#[test]
+fn the_config_digest_is_deterministic_and_matches_the_composer() {
+    use std::collections::BTreeMap;
+    let id = ModuleId::new("demo.greeter").expect("valid id");
+    let empty = ModuleConfig::new(&id, BTreeMap::new());
+    assert_eq!(empty.digest(), "fnv1a64:cbf29ce484222325");
+
+    let populated = ModuleConfig::new(
+        &id,
+        BTreeMap::from([
+            ("enabled".to_owned(), ModuleConfigValue::Bool(true)),
+            (
+                "welcome_text".to_owned(),
+                ModuleConfigValue::Text("Overridden by the operator".to_owned()),
+            ),
+        ]),
+    );
+    assert_eq!(populated.digest(), "fnv1a64:1144d896121f347b");
+
+    // Insertion order must not matter.
+    let reordered = ModuleConfig::new(
+        &id,
+        BTreeMap::from([
+            (
+                "welcome_text".to_owned(),
+                ModuleConfigValue::Text("Overridden by the operator".to_owned()),
+            ),
+            ("enabled".to_owned(), ModuleConfigValue::Bool(true)),
+        ]),
+    );
+    assert_eq!(reordered.digest(), populated.digest());
+}
+
+/// Two modules cannot collide: each is constructed with its own id and only
+/// ever receives the tree built for that namespace.
+#[test]
+fn configuration_is_namespaced_per_module() {
+    use std::collections::BTreeMap;
+    let mut alpha = ModuleConfig::new(
+        &ModuleId::new("alpha.mod").expect("id"),
+        BTreeMap::from([("text".to_owned(), ModuleConfigValue::Text("a".to_owned()))]),
+    );
+    let mut zulu = ModuleConfig::new(
+        &ModuleId::new("zulu.mod").expect("id"),
+        BTreeMap::from([("text".to_owned(), ModuleConfigValue::Text("z".to_owned()))]),
+    );
+    assert_eq!(alpha.text("text").expect("read"), Some("a".to_owned()));
+    assert_eq!(zulu.text("text").expect("read"), Some("z".to_owned()));
+    assert_ne!(alpha.digest(), zulu.digest());
+}
+
+#[test]
+fn unknown_keys_wrong_types_and_blank_values_are_rejected_with_the_module_named() {
+    use std::collections::BTreeMap;
+    let id = ModuleId::new("demo.greeter").expect("id");
+
+    let unknown = ModuleConfig::new(
+        &id,
+        BTreeMap::from([("typo".to_owned(), ModuleConfigValue::Bool(true))]),
+    );
+    let error = unknown
+        .finish()
+        .expect_err("an unread key is a typo, not a no-op");
+    assert!(error.to_string().contains("demo.greeter"), "{error}");
+    assert!(error.to_string().contains("typo"), "{error}");
+
+    let mut wrong = ModuleConfig::new(
+        &id,
+        BTreeMap::from([(
+            "enabled".to_owned(),
+            ModuleConfigValue::Text("yes".to_owned()),
+        )]),
+    );
+    let error = wrong
+        .bool("enabled")
+        .expect_err("a string is not a boolean");
+    assert!(error.to_string().contains("must be a boolean"), "{error}");
+}

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -124,6 +124,59 @@ with a working `register`, a focused hook test asserting the module greets only 
 an example configuration, `data/sql/{auth,characters,world,hotfixes}/` and a README stating the
 trust model. Optional directories are documented rather than generated empty.
 
+## Typed configuration
+
+Options are namespaced by validated `ModuleId`, so two modules cannot collide on a key.
+
+```toml
+# module.toml — immutable package defaults, shipped with the module
+[config]
+enabled = true
+welcome_text = "Example Greeter is installed."
+```
+
+```toml
+# conf/modules/example.greeter.toml — operator overrides, outside the module repository
+welcome_text = "Welcome to our realm!"
+```
+
+Overrides never live inside the checkout, so updating a module cannot clobber operator
+settings and a module repository never carries a secret.
+
+`sync` merges defaults with overrides, validates them, and **embeds the typed result** in the
+generated compositor. A module therefore reads its configuration exactly once, at registration:
+no callback touches a file, and there is no live reload to race against.
+
+### Validation happens before activation
+
+A module takes the options it knows about and calls `finish()`. Anything left over is an
+operator typo and fails registration, so a misspelled key is never silently ignored. Wrong types
+and values the type system cannot express — a blank string, a negative count — are refused the
+same way. A module that refuses its configuration is **not registered**, so an invalid value is
+caught at startup rather than at a player's login.
+
+### Digest
+
+Every module's exact configuration has a deterministic digest, recorded in `modules.lock.toml`
+and reported by `list` and `doctor`. It is computed identically on both sides — the Rust
+`ModuleConfig::digest` and `compose.py` pin the same literals in their tests — so the lock always
+describes what the module will actually see. Insertion order does not affect it, and the digest
+is fixed at construction so it still describes what the module was *given* after it has read
+its options.
+
+## Source API compatibility
+
+`module.toml` declares the `source_api` it was written against. Composition refuses anything this
+server does not provide, with an actionable message, before a single line is compiled:
+
+```
+modules/incompatible_api/module.toml: source_api '2' is not supported;
+this server provides ['1']. Update the module or pin an older server.
+```
+
+`tools/modules/fixtures/incompatible_api/` is that fixture, and `doctor --json` reports
+`supported_source_apis` alongside each module's own.
+
 ## Out of scope here
 
 Remote repository management, typed configuration, SQL, Wasm and live reload —

--- a/docs/architecture/ownership-and-boundaries.md
+++ b/docs/architecture/ownership-and-boundaries.md
@@ -328,6 +328,17 @@ logical monolith: its registrations, behavior, and tests now live in private cap
 under `handlers/misc/`, while `misc/mod.rs` is a 164-line compatibility facade for shared packet
 types, constants, and narrow helpers. Every production capability file is below 700 lines.
 
+Issue #231 closes the module lane with namespaced typed configuration. Package defaults live in
+`module.toml`, operator overrides in `conf/modules/<id>.toml` outside the checkout, and `sync`
+merges, validates and embeds the typed result so a module reads its configuration once at
+registration and no callback touches a file. Keys are namespaced by validated `ModuleId`, an
+unread key fails registration as an operator typo rather than being ignored, and a module that
+refuses its configuration is never registered — so an invalid value is caught at startup, not at a
+player's login. Each configuration has a deterministic digest recorded in the lock and reported by
+`list`/`doctor`, computed identically in Rust and Python with both sides pinning the same literals.
+`source_api` incompatibility is refused with an actionable message before anything compiles, with a
+dedicated fixture.
+
 Issue #230 adds the author/operator workflow on top: `tools/modules/rustycore-module` with
 `new`, `install`, `update`, `remove`, `list`, `sync`, `check`, `build`, `test` and `doctor`. Every
 command is non-interactive, `--json` emits pure JSON on stdout so an agent parses it without

--- a/tools/modules/compose.py
+++ b/tools/modules/compose.py
@@ -23,6 +23,10 @@ MODULES_DIR = REPO_ROOT / "modules"
 LOCK_PATH = REPO_ROOT / "modules.lock.toml"
 COMPOSITOR = REPO_ROOT / "crates" / "world-modules"
 SUPPORTED_SOURCE_API = "1"
+# Source APIs this server still accepts. A module asking for anything else
+# fails at composition, long before a player logs in.
+COMPATIBLE_SOURCE_APIS = {"1"}
+CONFIG_OVERRIDE_DIR = REPO_ROOT / "conf" / "modules"
 
 ID_RE = re.compile(r"^[a-z][a-z0-9_.]{0,63}$")
 PACKAGE_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
@@ -93,10 +97,12 @@ def parse_manifest(root: pathlib.Path, manifest: pathlib.Path) -> dict:
 
     source_api = str(compat.get("source_api", ""))
     _require(
-        source_api == SUPPORTED_SOURCE_API,
+        source_api in COMPATIBLE_SOURCE_APIS,
         f"{where}: source_api {source_api!r} is not supported; this server provides "
-        f"{SUPPORTED_SOURCE_API!r}",
+        f"{sorted(COMPATIBLE_SOURCE_APIS)}. Update the module or pin an older server.",
     )
+
+    config = load_config(identifier, raw.get("config", {}), where)
 
     return {
         "id": identifier,
@@ -109,8 +115,58 @@ def parse_manifest(root: pathlib.Path, manifest: pathlib.Path) -> dict:
         "requested_ref": module.get("ref", ""),
         "resolved_commit": module.get("commit", ""),
         "digest": _digest(root),
+        "config": config,
+        "config_digest": config_digest(config),
         "order": module.get("order", 0),
     }
+
+
+CONFIG_KEY_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+def load_config(module_id: str, defaults: dict, where) -> dict:
+    """Package defaults, then operator overrides from outside the repository.
+
+    Overrides live in `conf/modules/<id>.toml`, never inside the module
+    checkout, so updating a module never clobbers operator settings and a
+    module repository never carries a secret.
+    """
+    merged: dict[str, object] = {}
+    for source, values in (("default", defaults), ("override", _override_for(module_id))):
+        for key, value in values.items():
+            _require(
+                bool(CONFIG_KEY_RE.match(key)),
+                f"{where}: invalid {source} configuration key {key!r}",
+            )
+            _require(
+                isinstance(value, (bool, int, str)) and not isinstance(value, float),
+                f"{where}: configuration key {key!r} must be a boolean, integer or string",
+            )
+            merged[key] = value
+    return dict(sorted(merged.items()))
+
+
+def _override_for(module_id: str) -> dict:
+    path = CONFIG_OVERRIDE_DIR / f"{module_id}.toml"
+    if not path.is_file():
+        return {}
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def config_digest(config: dict) -> str:
+    """Mirror `ModuleConfig::digest` exactly so both sides agree."""
+    state = 0xCBF29CE484222325
+    for key, value in sorted(config.items()):
+        if isinstance(value, bool):
+            rendered = f"b:{'true' if value else 'false'}"
+        elif isinstance(value, int):
+            rendered = f"i:{value}"
+        else:
+            rendered = f"s:{len(value)}:{value}"
+        for byte in f"{key}={rendered};".encode():
+            state ^= byte
+            state = (state * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+    return f"fnv1a64:{state:016x}"
 
 
 def reject_collisions(modules: list[dict]) -> None:
@@ -151,6 +207,7 @@ def render_lock(modules: list[dict]) -> str:
             f'registrar = "{m["registrar"]}"',
             f'source_api = "{m["source_api"]}"',
             f"enabled_order = {index}",
+            f'config_digest = "{m["config_digest"]}"',
             f'digest = "sha256:{m["digest"]}"',
             "",
         ]
@@ -182,15 +239,43 @@ wow-module-api = {{ workspace = true }}
 '''.replace("\n\n\n", "\n\n").rstrip("\n") + "\n"
 
 
+def _rust_config(config: dict) -> str:
+    if not config:
+        return "        std::collections::BTreeMap::new()"
+    rows = []
+    for key, value in sorted(config.items()):
+        if isinstance(value, bool):
+            rendered = f"wow_module_api::ModuleConfigValue::Bool({'true' if value else 'false'})"
+        elif isinstance(value, int):
+            rendered = f"wow_module_api::ModuleConfigValue::Integer({value})"
+        else:
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            rendered = f'wow_module_api::ModuleConfigValue::Text("{escaped}".to_owned())'
+        rows.append(f'            ("{key}".to_owned(), {rendered}),')
+    body = "\n".join(rows)
+    return "        std::collections::BTreeMap::from([\n" + body + "\n        ])"
+
+
 def render_main(modules: list[dict]) -> str:
     rows = ordered(modules)
     if rows:
-        calls = "\n".join(
-            f"    {m['registrar'].replace('-', '_')}(&mut modules)\n"
-            f'        .map_err(|error| anyhow::anyhow!("module {m["id"]}: {{error}}"))?;'
-            for m in rows
+        blocks = []
+        for m in rows:
+            crate = m["registrar"].split("::")[0]
+            blocks.append(
+                f"    let config = wow_module_api::ModuleConfig::new(\n"
+                f'        &wow_module_api::ModuleId::new("{m["id"]}")\n'
+                f'            .expect("composed module ids are validated at sync"),\n'
+                f"{_rust_config(m['config'])},\n"
+                f"    );\n"
+                f"    {m['registrar']}(&mut modules, config)\n"
+                f'        .map_err(|error| anyhow::anyhow!("module {m["id"]}: {{error}}"))?;'
+            )
+        calls = "\n".join(blocks)
+        summary = "\n".join(
+            f"//! {i}. `{m['id']}` {m['version']} (config {m['config_digest']})"
+            for i, m in enumerate(rows)
         )
-        summary = "\n".join(f"//! {i}. `{m['id']}` {m['version']}" for i, m in enumerate(rows))
     else:
         calls = "    // No modules are installed; this is the no-op compositor."
         summary = "//! No modules are installed."
@@ -202,7 +287,8 @@ def render_main(modules: list[dict]) -> str:
 //!
 //! Registrars run in the operator's declared order, recorded in
 //! `modules.lock.toml`. Ordering is explicit here and never relies on linker
-//! inventory. Installed modules, in composition order:
+//! inventory. Configuration is validated at sync and embedded, so no callback
+//! reads a file. Installed modules, in composition order:
 //!
 {summary}
 

--- a/tools/modules/fixtures/incompatible_api/Cargo.toml
+++ b/tools/modules/fixtures/incompatible_api/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fixture-future-api"
+version = "0.1.0"
+edition = "2024"
+license = "GPL-3.0-only"
+
+[dependencies]
+wow-module-api = { path = "../../crates/wow-module-api" }

--- a/tools/modules/fixtures/incompatible_api/module.toml
+++ b/tools/modules/fixtures/incompatible_api/module.toml
@@ -1,0 +1,19 @@
+# Compatibility fixture: declares a source API this server does not provide,
+# so composition must refuse it before anything is compiled or activated.
+# Trusted linked module manifest. See docs/architecture/modules.md.
+[module]
+id = "fixture.future_api"
+version = "1.0.0"
+display_name = "Future API Fixture"
+
+[build]
+# The Cargo package this checkout provides, and the registrar the compositor
+# calls. The path is relative to this manifest and must stay inside it.
+package = "fixture-future-api"
+crate_path = "."
+registrar = "fixture_future_api::register"
+
+[compatibility]
+# The module source API this module was written against. The compositor
+# refuses to compile a module that asks for an API it does not provide.
+source_api = "2"

--- a/tools/modules/fixtures/incompatible_api/src/lib.rs
+++ b/tools/modules/fixtures/incompatible_api/src/lib.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 alseif0x
+// Licensed under GPL v3 — https://www.gnu.org/licenses/gpl-3.0.html
+
+//! Fixture module proving the #229 composition path end to end.
+
+use wow_module_api::{
+    ModuleDescriptor, ModuleRegistrationError, ModuleRegistry, ModuleVersion, PlayerLoginModule,
+    PlayerLoginSnapshot, ScopedEffects,
+};
+
+struct Greeter;
+
+impl PlayerLoginModule for Greeter {
+    fn on_player_login(&self, snapshot: &PlayerLoginSnapshot, effects: &mut ScopedEffects<'_>) {
+        if snapshot.first_login {
+            effects.send_system_message_self("Welcome to RustyCore!");
+        }
+    }
+}
+
+/// The registrar the generated compositor calls.
+pub fn register(registry: &mut ModuleRegistry) -> Result<(), ModuleRegistrationError> {
+    let descriptor = ModuleDescriptor::new(
+        "example.greeter",
+        ModuleVersion { major: 1, minor: 0, patch: 0 },
+        "Example Greeter",
+    )?;
+    registry.register_player_login_module(descriptor, Box::new(Greeter))
+}

--- a/tools/modules/rustycore-module
+++ b/tools/modules/rustycore-module
@@ -244,7 +244,8 @@ def cmd_list(args) -> int:
         args.json,
         {"command": "list", "modules": modules},
         "\n".join(
-            f"{i}. {m['id']} {m['version']} ({m['source_path']})"
+            f"{i}. {m['id']} {m['version']} api={m['source_api']} "
+            f"config={m['config_digest']} ({m['source_path']})"
             for i, m in enumerate(modules)
         )
         or "no modules installed",
@@ -305,7 +306,21 @@ def cmd_doctor(args) -> int:
         findings.append(str(error).splitlines()[0])
     emit(
         args.json,
-        {"command": "doctor", "modules": len(modules), "findings": findings},
+        {
+            "command": "doctor",
+            "modules": [
+                {
+                    "id": m["id"],
+                    "version": m["version"],
+                    "enabled_order": i,
+                    "source_api": m["source_api"],
+                    "config_digest": m["config_digest"],
+                }
+                for i, m in enumerate(compose.ordered(modules))
+            ],
+            "supported_source_apis": sorted(compose.COMPATIBLE_SOURCE_APIS),
+            "findings": findings,
+        },
         "\n".join(findings) or f"healthy: {len(modules)} module(s) installed and composed",
     )
     return EXIT_OK if not findings else EXIT_USAGE

--- a/tools/modules/skeleton/module.toml
+++ b/tools/modules/skeleton/module.toml
@@ -10,3 +10,9 @@ registrar = "__MODULE_CRATE__::register"
 
 [compatibility]
 source_api = "1"
+
+[config]
+# Package defaults. Operators override these in conf/modules/__MODULE_ID__.toml,
+# outside this repository, so updating the module never clobbers their settings.
+enabled = true
+welcome_text = "__MODULE_DISPLAY__ is installed."

--- a/tools/modules/skeleton/src/lib.rs
+++ b/tools/modules/skeleton/src/lib.rs
@@ -5,27 +5,48 @@
 //! hot reload.
 
 use wow_module_api::{
-    ModuleDescriptor, ModuleRegistrationError, ModuleRegistry, ModuleVersion, PlayerLoginModule,
-    PlayerLoginSnapshot, ScopedEffects,
+    ModuleConfig, ModuleDescriptor, ModuleRegistrationError, ModuleRegistry, ModuleVersion,
+    PlayerLoginModule, PlayerLoginSnapshot, ScopedEffects,
 };
 
-pub(crate) struct Module;
+/// The immutable snapshot the login callback reads. Resolved once at
+/// registration, so no callback ever touches a file.
+pub(crate) struct Module {
+    enabled: bool,
+    welcome_text: String,
+}
 
 impl PlayerLoginModule for Module {
     fn on_player_login(&self, snapshot: &PlayerLoginSnapshot, effects: &mut ScopedEffects<'_>) {
-        if snapshot.first_login {
-            effects.send_system_message_self("__MODULE_DISPLAY__ is installed.");
+        if self.enabled && snapshot.first_login {
+            effects.send_system_message_self(self.welcome_text.clone());
         }
     }
 }
 
 /// Registrar called by the generated compositor. Keep the name in sync with
 /// `registrar` in `module.toml`.
-pub fn register(registry: &mut ModuleRegistry) -> Result<(), ModuleRegistrationError> {
+///
+/// Configuration is validated here, before the module is registered, so an
+/// invalid value prevents activation instead of surfacing at a player's login.
+pub fn register(
+    registry: &mut ModuleRegistry,
+    mut config: ModuleConfig,
+) -> Result<(), ModuleRegistrationError> {
+    let enabled = config.bool("enabled")?.unwrap_or(true);
+    let welcome_text = config
+        .text("welcome_text")?
+        .ok_or_else(|| config.missing("welcome_text"))?;
+    if welcome_text.trim().is_empty() {
+        return Err(config.invalid("welcome_text", "must not be blank").into());
+    }
+    // Any key the module did not read is an operator typo, not a silent no-op.
+    config.finish()?;
+
     let descriptor = ModuleDescriptor::new(
         "__MODULE_ID__",
         ModuleVersion { major: 0, minor: 1, patch: 0 },
         "__MODULE_DISPLAY__",
     )?;
-    registry.register_player_login_module(descriptor, Box::new(Module))
+    registry.register_player_login_module(descriptor, Box::new(Module { enabled, welcome_text }))
 }

--- a/tools/modules/skeleton/tests/hook.rs
+++ b/tools/modules/skeleton/tests/hook.rs
@@ -1,6 +1,9 @@
-//! Focused hook test: the module registers and reacts to first login only.
+//! Focused hook test: the module registers, honours its configuration and
+//! reacts to first login only.
 
-use wow_module_api::{ModuleRegistry, PlayerLoginSnapshot};
+use std::collections::BTreeMap;
+
+use wow_module_api::{ModuleConfig, ModuleConfigValue, ModuleId, ModuleRegistry, PlayerLoginSnapshot};
 
 fn snapshot(first_login: bool) -> PlayerLoginSnapshot {
     PlayerLoginSnapshot {
@@ -14,14 +17,61 @@ fn snapshot(first_login: bool) -> PlayerLoginSnapshot {
     }
 }
 
+fn config(pairs: &[(&str, ModuleConfigValue)]) -> ModuleConfig {
+    ModuleConfig::new(
+        &ModuleId::new("__MODULE_ID__").expect("valid id"),
+        pairs.iter().map(|(k, v)| ((*k).to_owned(), v.clone())).collect::<BTreeMap<_, _>>(),
+    )
+}
+
+fn configured() -> ModuleConfig {
+    config(&[
+        ("enabled", ModuleConfigValue::Bool(true)),
+        ("welcome_text", ModuleConfigValue::Text("hello".to_owned())),
+    ])
+}
+
 #[test]
 fn greets_only_on_first_login() {
     let mut registry = ModuleRegistry::new();
-    __MODULE_CRATE__::register(&mut registry).expect("registration");
+    __MODULE_CRATE__::register(&mut registry, configured()).expect("registration");
 
     let first = registry.dispatch_player_login(&snapshot(true)).expect("valid");
     assert_eq!(first.len(), 1, "first login is greeted");
 
     let repeat = registry.dispatch_player_login(&snapshot(false)).expect("valid");
     assert!(repeat.is_empty(), "a returning player is not greeted");
+}
+
+#[test]
+fn the_configured_text_is_the_only_thing_that_changes() {
+    let mut registry = ModuleRegistry::new();
+    __MODULE_CRATE__::register(
+        &mut registry,
+        config(&[("welcome_text", ModuleConfigValue::Text("custom line".to_owned()))]),
+    )
+    .expect("registration");
+    let effects = registry.dispatch_player_login(&snapshot(true)).expect("valid");
+    let rendered = format!("{:?}", effects.iter().collect::<Vec<_>>());
+    assert!(rendered.contains("custom line"), "{rendered}");
+}
+
+#[test]
+fn invalid_configuration_prevents_activation() {
+    for bad in [
+        vec![("welcome_text", ModuleConfigValue::Text(String::new()))],
+        vec![("welcome_text", ModuleConfigValue::Bool(true))],
+        vec![
+            ("welcome_text", ModuleConfigValue::Text("ok".to_owned())),
+            ("wecome_txet", ModuleConfigValue::Text("typo".to_owned())),
+        ],
+        vec![("enabled", ModuleConfigValue::Bool(true))],
+    ] {
+        let mut registry = ModuleRegistry::new();
+        assert!(
+            __MODULE_CRATE__::register(&mut registry, config(&bad)).is_err(),
+            "{bad:?} must prevent activation"
+        );
+        assert!(registry.is_empty(), "a refused module must not be registered");
+    }
 }

--- a/tools/modules/test_rustycore_module.py
+++ b/tools/modules/test_rustycore_module.py
@@ -124,5 +124,56 @@ class ModuleManagerTests(unittest.TestCase):
         )
 
 
+    def test_operator_overrides_live_outside_the_module_and_change_the_digest(self) -> None:
+        self.ws.run("new", "demo.greeter")
+        before = json.loads(self.ws.run("list", "--json").stdout)["modules"][0]["config_digest"]
+
+        conf = self.ws.root / "conf/modules"
+        conf.mkdir(parents=True)
+        (conf / "demo.greeter.toml").write_text(
+            'welcome_text = "Overridden"\n', encoding="utf-8"
+        )
+        after = json.loads(self.ws.run("list", "--json").stdout)["modules"][0]["config_digest"]
+        self.assertNotEqual(before, after, "an override must change the digest")
+
+        self.assertEqual(self.ws.run("sync").returncode, 0)
+        main = (self.ws.root / "crates/world-modules/src/main.rs").read_text(encoding="utf-8")
+        self.assertIn("Overridden", main, "the override must reach the compositor")
+        self.assertNotIn(
+            "Overridden",
+            (self.ws.root / "modules/demo_greeter/module.toml").read_text(encoding="utf-8"),
+            "an override must never be written into the module checkout",
+        )
+
+    def test_the_digest_matches_the_rust_implementation(self) -> None:
+        """Pinned in `wow-module-api`'s own tests; both sides must agree."""
+        sys.path.insert(0, str(REPO_ROOT / "tools/modules"))
+        import compose  # noqa: PLC0415
+
+        self.assertEqual(compose.config_digest({}), "fnv1a64:cbf29ce484222325")
+        self.assertEqual(
+            compose.config_digest(
+                {"enabled": True, "welcome_text": "Overridden by the operator"}
+            ),
+            "fnv1a64:1144d896121f347b",
+        )
+
+    def test_an_incompatible_source_api_is_refused_before_activation(self) -> None:
+        shutil.copytree(
+            REPO_ROOT / "tools/modules/fixtures/incompatible_api",
+            self.ws.root / "modules/incompatible_api",
+        )
+        refused = self.ws.run("check")
+        self.assertNotEqual(refused.returncode, 0)
+        self.assertIn("source_api", refused.stderr)
+        self.assertIn("Update the module or pin an older server", refused.stderr)
+
+    def test_zero_modules_and_no_config_keep_the_base_behaviour(self) -> None:
+        self.assertEqual(self.ws.run("sync").returncode, 0)
+        main = (self.ws.root / "crates/world-modules/src/main.rs").read_text(encoding="utf-8")
+        self.assertIn("No modules are installed", main)
+        self.assertNotIn("ModuleConfig::new", main)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #231 — and closes the module lane opened by #228.

## Namespaced typed configuration

```toml
# module.toml — immutable package defaults, shipped with the module
[config]
enabled = true
welcome_text = "Example Greeter is installed."
```
```toml
# conf/modules/example.greeter.toml — operator overrides, outside the module repository
welcome_text = "Welcome to our realm!"
```

Options are namespaced by validated `ModuleId`, so **two modules cannot collide** on a key. Overrides never live inside the checkout, so updating a module cannot clobber operator settings and a module repository never carries a secret.

`sync` merges, validates and **embeds the typed result** in the generated compositor. A module reads its configuration exactly once, at registration — **no callback touches a file**, and there is no live reload to race against. `wow-module-api` parses nothing: its external allowlist stays empty and only typed values cross the boundary.

## Invalid configuration prevents activation

A module takes the options it knows about and calls `finish()`. Anything left over is an **operator typo and fails registration** rather than being silently ignored. Wrong types, and values the type system cannot express such as a blank welcome line, are refused the same way. A module that refuses its configuration is **never registered**, so an invalid value surfaces at startup instead of at a player's login.

## A real defect the first test exposed

The digest was computed from the *remaining* values, so once a module had read its options it reported an empty configuration:

```
assertion `left != right` failed
  left: "fnv1a64:cbf29ce484222325"
 right: "fnv1a64:cbf29ce484222325"
```

It is now fixed at construction, so it describes what the module was *given*.

## Digest agreement is enforced, not assumed

Rust `ModuleConfig::digest` and `compose.py::config_digest` **pin the same literals in their own test suites**, so the lock always describes what the module will actually see. Insertion order does not affect it.

## Compatibility, refused before anything compiles

```
modules/incompatible_api/module.toml: source_api '2' is not supported;
this server provides ['1']. Update the module or pin an older server.
```

`tools/modules/fixtures/incompatible_api/` is the fixture; `doctor --json` reports `supported_source_apis` alongside each module's own, and `list` shows `api=` and `config=` per module.

## Validation

| Check | Result |
|---|---|
| `cargo test -p wow-module-api` | **11/11** — namespacing, digest determinism and order-independence, unknown keys, wrong types, blank values |
| `tools/modules/test_rustycore_module.py` | **11/11** — overrides outside the checkout, digest agreement with Rust, API refusal before activation, zero-module baseline |
| `cargo check --workspace --all-targets` | clean, no new warnings |
| `check_architecture.py check` / `self-test` | PASS |
| `cargo fmt --all -- --check`, `git diff --check` | clean |
| `./tools/local-harness.sh final origin/3.4.3` | **passed** |

Changing the welcome text changes only that module's effect, and a zero-module, zero-config tree still generates the no-op compositor with no configuration code at all.

Out of scope and not implied: live config reload, secret management, SQL migrations, Wasm and catalogue distribution.