### PR TITLE
[00] Record the module registry surface in the ownership inventories

### DIFF
--- a/tools/architecture/runtime-ownership-ledger.json
+++ b/tools/architecture/runtime-ownership-ledger.json
@@ -38,7 +38,7 @@
       "member_key": "name",
       "zero_gaps": true,
       "zero_overlap": true,
-      "expected_field_count": 738,
+      "expected_field_count": 739,
       "validation": "Compare the sorted AST names with the sorted concatenation of every family.field_names; reject a missing name, duplicate name, stale name, family count mismatch, or total count mismatch."
     },
     "families": [
@@ -235,7 +235,7 @@
       },
       {
         "id": "immutable_catalogs_configuration_and_services",
-        "expected_field_count": 186,
+        "expected_field_count": 187,
         "field_names": [
           "access_requirement_store",
           "adventure_map_poi_store",
@@ -330,6 +330,7 @@
           "map_store",
           "max_player_level_config_like_cpp",
           "mmap_runtime_config_like_cpp",
+          "module_registry_like_cpp",
           "mount_capability_store",
           "mount_definition_store_like_cpp",
           "mount_store",
@@ -1077,9 +1078,9 @@
         "retirement_condition": "This residual is empty, or every remaining field has an explicit reviewed stable-Session justification and a dedicated exact-membership rule."
       }
     ],
-    "expected_field_count": 738,
-    "expected_unique_field_count": 738,
-    "expected_production_field_count": 727,
+    "expected_field_count": 739,
+    "expected_unique_field_count": 739,
+    "expected_production_field_count": 728,
     "expected_test_fixture_field_count": 11
   },
   "inventories": {
@@ -1092,8 +1093,8 @@
         "cross_check": "tools/architecture/session-ownership-policy.json#syntax_baseline.session_resources.fields"
       },
       "audited_summary": {
-        "field_count": 243,
-        "option_field_count": 186,
+        "field_count": 244,
+        "option_field_count": 187,
         "count_kind": "baseline observation; AST is authoritative"
       },
       "coverage_rule": {
@@ -1101,7 +1102,7 @@
         "member_key": "name",
         "zero_gaps": true,
         "zero_overlap": true,
-        "expected_field_count": 243,
+        "expected_field_count": 244,
         "validation": "Compare sorted AST field names with the sorted concatenation of every entry.field_names; reject gaps, duplicates, stale names, entry count drift, or total count drift."
       },
       "entries": [
@@ -1136,9 +1137,10 @@
         },
         {
           "id": "session_resources_runtime_handles",
-          "expected_field_count": 1,
+          "expected_field_count": 2,
           "field_names": [
-            "instance_lock_mgr"
+            "instance_lock_mgr",
+            "module_registry"
           ],
           "owner": "world-server composition stores handles; legacy and canonical runtime owners remain distinct and audited by #188.",
           "open_retirement_issues": [
@@ -1407,7 +1409,7 @@
           "retirement_condition": "Every remaining field has an exact capability bundle/consumer owner or is removed from Session construction."
         }
       ],
-      "expected_field_count": 243
+      "expected_field_count": 244
     },
     "player_broadcast_info": {
       "coverage_source": {

--- a/tools/architecture/session-ownership-policy.json
+++ b/tools/architecture/session-ownership-policy.json
@@ -1487,6 +1487,13 @@
           "source_class": "production"
         },
         {
+          "name": "module_registry_like_cpp",
+          "type": "Option < Arc < wow_module_api :: ModuleRegistry > >",
+          "visibility": "private",
+          "cfg": [],
+          "source_class": "production"
+        },
+        {
           "name": "monthly_quests_completed_like_cpp",
           "type": "HashSet < u32 >",
           "visibility": "pub (crate)",
@@ -24720,6 +24727,19 @@
           "module": "crate::session",
           "trait_path": null,
           "kind": "method",
+          "name": "dispatch_module_player_login_like_cpp",
+          "visibility": "pub (crate)",
+          "signature": "fn dispatch_module_player_login_like_cpp (& self , first_login : bool)",
+          "cfg": [],
+          "source_class": "production",
+          "guards": [
+            "visible"
+          ]
+        },
+        {
+          "module": "crate::session",
+          "trait_path": null,
+          "kind": "method",
           "name": "dispatch_packet",
           "visibility": "pub (crate)",
           "signature": "async fn dispatch_packet (& mut self , mut pkt : WorldPacket)",
@@ -42632,6 +42652,20 @@
           "module": "crate::session",
           "trait_path": null,
           "kind": "method",
+          "name": "set_module_registry_like_cpp",
+          "visibility": "pub",
+          "signature": "fn set_module_registry_like_cpp (& mut self , registry : Arc < wow_module_api :: ModuleRegistry >)",
+          "cfg": [],
+          "source_class": "production",
+          "guards": [
+            "setter",
+            "visible"
+          ]
+        },
+        {
+          "module": "crate::session",
+          "trait_path": null,
+          "kind": "method",
           "name": "set_mount_capability_store",
           "visibility": "pub",
           "signature": "fn set_mount_capability_store (& mut self , store : Arc < MountCapabilityStore >)",
@@ -50032,6 +50066,13 @@
           "source_class": "production"
         },
         {
+          "name": "module_registry",
+          "type": "Option < Arc < wow_module_api :: ModuleRegistry > >",
+          "visibility": "pub (super)",
+          "cfg": [],
+          "source_class": "production"
+        },
+        {
           "name": "mount_capability_store",
           "type": "Option < Arc < wow_data :: MountCapabilityStore > >",
           "visibility": "pub (super)",
@@ -50911,7 +50952,7 @@
         {
           "module": "crate::app",
           "callee": "SessionResources",
-          "argument_count": 243,
+          "argument_count": 244,
           "cfg": [],
           "source_class": "production",
           "count": 1
@@ -50927,7 +50968,7 @@
         "source_class": "production"
       },
       "signature": "async fn create_session (account : AccountInfo , pkt_rx : flume :: Receiver < wow_packet :: WorldPacket > , send_tx : flume :: Sender < Vec < u8 > > , send_write_fence_like_cpp : wow_network :: SocketWriteFenceLikeCpp , socket_timeouts : SocketTimeoutsLikeCpp , resources : Arc < SessionResources > , session_mgr : Arc < SessionManager > , shared_map : SharedMapManager , canonical_map_manager : SharedCanonicalMapManager , canonical_spawn_metadata : SharedCanonicalSpawnMetadataLikeCpp , loaded_grid_creature_respawn_caches : LoadedGridCreatureRespawnCachesLikeCpp , object_accessor : wow_world :: SharedObjectAccessor , instance_port : u16 , max_expansion : u8 , mmap_runtime_config : MMapRuntimeConfigLikeCpp , mmap_pathfinder : Option < Arc < WorldMMapPathfinderWorkerLikeCpp > > , active_session_registry : Arc < ActiveWorldSessionRegistryLikeCpp > , legacy_creature_aggro_config : wow_world :: session :: LegacyCreatureAggroConfigLikeCpp , world_runtime_state : Arc < WorldRuntimeStateLikeCpp > , battle_pet_account_registry : Arc < BattlePetAccountRegistryLikeCpp > ,)",
-      "body_fingerprint": "fnv1a64x2:6bb73c764dd8692b01c9b4590921ee88:len=33065",
+      "body_fingerprint": "fnv1a64x2:0dc389e61b002f7253054753c9a142b5:len=33191",
       "session_helper_bodies": [
         {
           "module": "crate::session_factory",
@@ -52126,6 +52167,14 @@
         {
           "module": "crate::session_factory",
           "callee": "session.set_mmap_runtime_config_like_cpp",
+          "argument_count": 1,
+          "cfg": [],
+          "source_class": "production",
+          "count": 1
+        },
+        {
+          "module": "crate::session_factory",
+          "callee": "session.set_module_registry_like_cpp",
           "argument_count": 1,
           "cfg": [],
           "source_class": "production",
@@ -65350,7 +65399,7 @@
               "multiplicity": 2
             }
           ],
-          "fingerprint": "signature=async fn create_session (account : AccountInfo , pkt_rx : flume :: Receiver < wow_packet :: WorldPacket > , send_tx : flume :: Sender < Vec < u8 > > , send_write_fence_like_cpp : wow_network :: SocketWriteFenceLikeCpp , socket_timeouts : SocketTimeoutsLikeCpp , resources : Arc < SessionResources > , session_mgr : Arc < SessionManager > , shared_map : SharedMapManager , canonical_map_manager : SharedCanonicalMapManager , canonical_spawn_metadata : SharedCanonicalSpawnMetadataLikeCpp , loaded_grid_creature_respawn_caches : LoadedGridCreatureRespawnCachesLikeCpp , object_accessor : wow_world :: SharedObjectAccessor , instance_port : u16 , max_expansion : u8 , mmap_runtime_config : MMapRuntimeConfigLikeCpp , mmap_pathfinder : Option < Arc < WorldMMapPathfinderWorkerLikeCpp > > , active_session_registry : Arc < ActiveWorldSessionRegistryLikeCpp > , legacy_creature_aggro_config : wow_world :: session :: LegacyCreatureAggroConfigLikeCpp , world_runtime_state : Arc < WorldRuntimeStateLikeCpp > , battle_pet_account_registry : Arc < BattlePetAccountRegistryLikeCpp > ,)|body=fnv1a64x2:6bb73c764dd8692b01c9b4590921ee88:len=33065|evidence=fnv1a64x2:dd605b9d3e8a9dcc82cdedbf620fbe8f:len=741",
+          "fingerprint": "signature=async fn create_session (account : AccountInfo , pkt_rx : flume :: Receiver < wow_packet :: WorldPacket > , send_tx : flume :: Sender < Vec < u8 > > , send_write_fence_like_cpp : wow_network :: SocketWriteFenceLikeCpp , socket_timeouts : SocketTimeoutsLikeCpp , resources : Arc < SessionResources > , session_mgr : Arc < SessionManager > , shared_map : SharedMapManager , canonical_map_manager : SharedCanonicalMapManager , canonical_spawn_metadata : SharedCanonicalSpawnMetadataLikeCpp , loaded_grid_creature_respawn_caches : LoadedGridCreatureRespawnCachesLikeCpp , object_accessor : wow_world :: SharedObjectAccessor , instance_port : u16 , max_expansion : u8 , mmap_runtime_config : MMapRuntimeConfigLikeCpp , mmap_pathfinder : Option < Arc < WorldMMapPathfinderWorkerLikeCpp > > , active_session_registry : Arc < ActiveWorldSessionRegistryLikeCpp > , legacy_creature_aggro_config : wow_world :: session :: LegacyCreatureAggroConfigLikeCpp , world_runtime_state : Arc < WorldRuntimeStateLikeCpp > , battle_pet_account_registry : Arc < BattlePetAccountRegistryLikeCpp > ,)|body=fnv1a64x2:0dc389e61b002f7253054753c9a142b5:len=33191|evidence=fnv1a64x2:dd605b9d3e8a9dcc82cdedbf620fbe8f:len=741",
           "cfg": [],
           "multiplicity": 1
         },
@@ -73333,7 +73382,7 @@
               "multiplicity": 1
             }
           ],
-          "fingerprint": "signature=struct::WorldSession|surface=fnv1a64x2:db86f4990b23216481dec05654fc6ea7:len=90762|evidence=fnv1a64x2:2e6cfac122e1f70b6b6193924d25bd6c:len=187",
+          "fingerprint": "signature=struct::WorldSession|surface=fnv1a64x2:de9350e795de71ee8f608bee4f1d8095:len=91142|evidence=fnv1a64x2:2e6cfac122e1f70b6b6193924d25bd6c:len=187",
           "cfg": [],
           "multiplicity": 1
         },


### PR DESCRIPTION
Fixes a red `3.4.3` HEAD (`b2451c68`).

## What was broken

Both ratchets failed on a clean checkout of `3.4.3`:

```
session ownership check failed: unreviewed WorldSession field surface: module_registry_like_cpp ...
architecture check failed: runtime ownership WorldSession fields do not match syntax baseline: missing=['module_registry_like_cpp']
```

The module lane (#228 / #229 / #231, merged as #271–#274) added the module-registry
surface to `WorldSession`, `SessionResources` and `create_session` but never recorded
it in `session-ownership-policy.json` or `runtime-ownership-ledger.json`. Because the
ratchet runs against the whole tree, this blocked `./tools/pr-preflight.sh` for every
subsequent PR regardless of what that PR touched.

## Why it merged green

`rust-ci.yml` skips `Format`, `Check core crates` and `Focused library tests` for pull
requests authored by `alseif0x` (the local-first policy in
`docs/operations/local-first-development.md`), and the ownership ratchet lives inside
`Check core crates`. The required checks therefore reported *skipped*, not *passed*,
and the only real gate was local preflight. See the follow-up issue for a second
finding: the workflow has no `push` trigger at all, contradicting the in-file comment
that claims the exhaustive inventory "runs below on every push to 3.4.3".

## Change

Recorded exactly the module-registry surface — reviewed row by row, nothing else:

| Inventory | Change |
|---|---|
| `world_session/fields` | 738 → 739 (`module_registry_like_cpp`, private) |
| `world_session/impl_items` | 3341 → 3343 (`set_module_registry_like_cpp`, `dispatch_module_player_login_like_cpp`) |
| `session_resources/fields` | 243 → 244 (`module_registry`, `pub(super)`) |
| `session_resources/construction_sites` | 243 → 244 arguments |
| `session_factory/setter_call_sites` | 248 → 249 |
| `session_factory/body_fingerprint` | rehashed |
| `bridge_accesses/bridges` | 2 rows rehashed, count stays 65 |

Ledger placement: `module_registry_like_cpp` is a service handle copied from
SessionResources into each session, so it joins
`immutable_catalogs_configuration_and_services`; `module_registry` is a live runtime
handle like `instance_lock_mgr`, so it joins `session_resources_runtime_handles`.

Diff is 53 insertions / 4 deletions in the policy and 13 lines in the ledger — no
blanket regeneration.

## Validation

- `session-ownership-check check --syntax-only` → **PASS** (739 fields / 3343 impl items / 244 SessionResources fields).
- `python3 tools/architecture/check_architecture.py check` → **PASS**.
- `./tools/pr-preflight.sh quick origin/3.4.3` → **exit 0**.

Closes #275.