### PR TITLE
[QA] Keep the realm socket open after SMSG_CONNECT_TO in every bot mode

### DIFF
--- a/tools/wow-test-bot/src/main.rs
+++ b/tools/wow-test-bot/src/main.rs
@@ -5500,17 +5500,6 @@ async fn run_bot_with_void_storage(
             || std::env::var("WOW_BOT_LOGIN_REQUIRE_KNOWN_SPELLS")
                 .is_ok_and(|value| is_truthy(&value)));
     let mut known_spells_seen = false;
-    let preserve_realm_connection = stand_state_options.is_some()
-        || homebind_options.is_some()
-        || inventory_swap_options.is_some()
-        || vendor_options.is_some()
-        || rested_xp_options.is_some()
-        || detour_chase_options.is_some()
-        || creature_spell_options.is_some()
-        || loot_race_options.is_some()
-        || group_capacity_options.is_some()
-        || equipment_set_options.is_some()
-        || void_storage_options.is_some();
     let mut loot_race_target_seen = false;
     let mut vendor_target_seen: Option<DiscoveredCreatureGuid> = None;
     let mut void_storage_target_seen: Option<DiscoveredCreatureGuid> = None;
@@ -5730,7 +5719,7 @@ async fn run_bot_with_void_storage(
                         .as_ref()
                         .is_none_or(|_| result.inventory_swap_item_create_sha256.is_some());
                     if login_known_spells_ready(login_ok, require_known_spells, known_spells_seen)
-                        && (!preserve_realm_connection || realm_connection.is_some())
+                        && realm_connection.is_some()
                         && equipment_set_login_ready
                         && void_storage_login_ready
                         && inventory_swap_login_ready
@@ -5757,23 +5746,22 @@ async fn run_bot_with_void_storage(
                     );
                     let (instance_stream, instance_crypt) =
                         connect_to_instance(bot_index, &connect_to, &derived_session_key).await?;
-                    if preserve_realm_connection {
-                        if realm_connection.is_some() {
-                            bail!("Routing smoke received more than one SMSG_CONNECT_TO");
-                        }
-                        let realm_stream = std::mem::replace(&mut stream, instance_stream);
-                        let realm_crypt = std::mem::replace(&mut crypt, instance_crypt);
-                        let realm_inflater = std::mem::take(&mut server_inflater);
-                        realm_connection = Some(EncryptedWorldConnection {
-                            stream: realm_stream,
-                            crypt: realm_crypt,
-                            inflater: realm_inflater,
-                        });
-                    } else {
-                        stream = instance_stream;
-                        crypt = instance_crypt;
-                        server_inflater = ServerPacketInflater::default();
+                    // The server keeps cross-socket ordering fences alive after
+                    // SMSG_CONNECT_TO, so the realm socket must stay open on every
+                    // mode: closing it makes the realm writer disappear before it
+                    // acknowledges the fence and the session is kicked with
+                    // "login packet sequence failed".
+                    if realm_connection.is_some() {
+                        bail!("Routing smoke received more than one SMSG_CONNECT_TO");
                     }
+                    let realm_stream = std::mem::replace(&mut stream, instance_stream);
+                    let realm_crypt = std::mem::replace(&mut crypt, instance_crypt);
+                    let realm_inflater = std::mem::take(&mut server_inflater);
+                    realm_connection = Some(EncryptedWorldConnection {
+                        stream: realm_stream,
+                        crypt: realm_crypt,
+                        inflater: realm_inflater,
+                    });
                     info!("[Bot {}] ✅ Instance socket authenticated", bot_index);
                     let void_storage_login_ready =
                         void_storage_options.as_ref().is_none_or(|options| {
@@ -5785,11 +5773,7 @@ async fn run_bot_with_void_storage(
                     let inventory_swap_login_ready = inventory_swap_options
                         .as_ref()
                         .is_none_or(|_| result.inventory_swap_item_create_sha256.is_some());
-                    if login_ok
-                        && preserve_realm_connection
-                        && void_storage_login_ready
-                        && inventory_swap_login_ready
-                    {
+                    if login_ok && void_storage_login_ready && inventory_swap_login_ready {
                         break;
                     }
                 } else if op == 0x304B {
@@ -5799,14 +5783,14 @@ async fn run_bot_with_void_storage(
                 if equipment_set_options.is_some()
                     && login_ok
                     && result.equipment_set_load_seen
-                    && (!preserve_realm_connection || realm_connection.is_some())
+                    && realm_connection.is_some()
                 {
                     break;
                 }
                 if inventory_swap_options.is_some()
                     && login_ok
                     && result.inventory_swap_item_create_sha256.is_some()
-                    && (!preserve_realm_connection || realm_connection.is_some())
+                    && realm_connection.is_some()
                 {
                     break;
                 }


### PR DESCRIPTION
## Defect

After `SMSG_CONNECT_TO`, the server keeps cross-socket ordering fences alive and expects
the realm writer to acknowledge one. The bot only parked the realm connection when
`preserve_realm_connection` was set — stand-state, homebind, vendor, loot-race and the
other routing-sensitive smokes. Plain `--login-only` took the `else` branch and replaced
the realm stream with the instance stream, closing the realm socket:

```rust
} else {
    stream = instance_stream;
    crypt = instance_crypt;
    server_inflater = ServerPacketInflater::default();
}
```

The server then logged `realm writer closed before acknowledging the ordering fence` and
kicked the session with `WorldSession::HandlePlayerLogin login packet sequence failed`,
so login verification failed 100% of the time in that mode.

## Change

Park the realm connection unconditionally, exactly as the modes that already pass
end-to-end do, and drop the four now-tautological `preserve_realm_connection` guards.
Bot-only; nothing in the Cargo workspace is touched.

This is option 3 of the three the issue proposed ("enable it unconditionally"). The
server-side alternative — treating a closed realm writer as non-fatal — was not taken:
the fence is the server's real ordering contract and a single-socket client is not what
this server's `ConnectTo` flow negotiates, so relaxing it would hide regressions rather
than fix the harness.

## Live validation

Run against the running local runtime (`bnet-server` 1119/8081, `world-server`
8085/8086) with the same account, back to back.

Before (`3.4.3` bot, `results[0]` never recorded — the run aborts):

```
✅ SMSG_ENUM_CHARACTERS_RESULT received
✅ CMSG_PLAYER_LOGIN sent
✅ Instance socket authenticated
✅ SMSG_RESUME_COMMS received
❌ Bot run ERROR: Login verification failed      (30s budget exhausted)
exit 1
```

After (this branch):

```
✅ Login-only smoke passed: world_auth=true enum_characters=true player_login=true
exit 0
```

Report fields, `results[0]`:

| field | before | after |
|---|---|---|
| `world_auth` | *(no result row)* | `true` |
| `enum_characters` | *(no result row)* | `true` |
| `player_login_verified` | *(no result row)* | `true` |
| `join_result` | *(no result row)* | `null` |

Login now completes in ~0.5 s instead of exhausting the 30 s verification budget.

## Other checks

- `cargo fmt -- --check` and `cargo check` clean in `tools/wow-test-bot`.
- `cargo test` in `tools/wow-test-bot`: 141 passed, 0 failed.
- `./tools/pr-preflight.sh quick origin/3.4.3`: exit 0.

## Note for the operator

The local `TESTBOT1@bot.local` fixture's BNet verifier did not match the password in the
ignored `.env.local`, which blocked provisioning before the smoke could reach this
defect. A fresh password was generated for that disposable test account, its verifier
rewritten for the existing salt, and the password stored back in the machine-local
`.env.local` (gitignored, mode 600). No credential is committed here. See the follow-up
issue about making that rotation a supported, reproducible operation instead of a manual
one.

Closes #177.