### PR TITLE
[00] Run Rust CI at merge cadence on 3.4.3

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -4,6 +4,17 @@ on:
   pull_request:
     branches:
       - "3.4.3"
+  # Merge-cadence enforcement. Every required check is skipped for first-party
+  # pull requests (see the author conditions below and
+  # docs/operations/local-first-development.md), and a skipped check satisfies
+  # branch protection, so without this trigger nothing in CI ever runs against
+  # a first-party change — not at review time and not at merge. Two regressions
+  # reached 3.4.3 through that gap: #275 left both ownership ratchets red on
+  # HEAD, and #277 hid ~985 production persistence accesses from the inventory.
+  # Both are exactly what the steps below detect.
+  push:
+    branches:
+      - "3.4.3"
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:
@@ -11,9 +22,13 @@ on:
 permissions:
   contents: read
 
+# Pull requests supersede themselves: a newer push to the same PR makes the
+# older run worthless. Merges do not — each merge is a distinct commit whose
+# result nobody else will recompute, so keying pushes on the shared branch ref
+# would let a busy day cancel the only enforcement this repository gets.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -57,9 +72,12 @@ jobs:
     runs-on: ubuntu-24.04
     # The exact persistence inventory is intentionally scanned both by its
     # repository test and by the boundary command before the core build. A
-    # single full scan measures ~36 minutes locally, so the two scans plus the
-    # core build and clippy steps exhausted a 60-minute budget exactly; keep
-    # every intentional validation and give the job room instead.
+    # single full scan was measured at ~36 minutes locally when this budget was
+    # set; repeated local runs in August 2026 measured ~11 minutes, and the one
+    # CI run that reached this step took 11m24s. The budget is deliberately not
+    # retuned to the faster figure: two scans plus the core build and clippy
+    # exhausted a 60-minute budget exactly, and one machine's numbers are not
+    # enough to narrow it again.
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -100,12 +118,13 @@ jobs:
           cargo run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml -- check
 
       # Pull requests ratchet the session surface only — seconds. The exact
-      # persistence inventory is an 11-minute scan that was 72% of this job,
-      # and it is a change detector on source text: on a branch where 55% of
-      # commits touch session.rs, most of what it reports mid-development is
-      # regeneration churn. It still runs below on every push to 3.4.3 and on
-      # the cron, so a leak is caught at merge rather than at review time —
-      # deferred, not dropped.
+      # persistence inventory is a long scan that was 72% of this job, and it
+      # is a change detector on source text: on a branch where 55% of commits
+      # touch session.rs, most of what it reports mid-development is
+      # regeneration churn. It runs below on every push to 3.4.3 and on the
+      # cron, so a leak is caught at merge rather than at review time —
+      # deferred, not dropped. That claim was false between #222 (which removed
+      # the push trigger) and the change that restored it; it is true again.
       - name: Ratchet the session ownership surface
         if: github.event_name == 'pull_request'
         run: |

--- a/docs/operations/local-first-development.md
+++ b/docs/operations/local-first-development.md
@@ -123,11 +123,21 @@ its local Codex review is optional.
 Broad remote validation runs only in these cases:
 
 - a pull request whose author is not `alseif0x`;
+- **a push to `3.4.3`, which is every merge**;
 - the scheduled Rust CI audit;
 - an explicit `workflow_dispatch` run.
 
-A failure in a scheduled audit should produce a focused issue. It does not retroactively turn
-every intermediate first-party commit into a review cycle.
+The merge-cadence case exists because the first three bullets alone left first-party work with no
+remote enforcement at all. A skipped required check satisfies branch protection, so a first-party
+pull request merged with every check reporting *skipped* — which reads as green. Two regressions
+reached `3.4.3` that way: #275 left both ownership ratchets red on HEAD, blocking every subsequent
+local preflight, and #277 hid roughly 985 production persistence accesses from the inventory. Both
+are detected by steps that already existed and simply never ran.
+
+This does not weaken the trust boundary. Review-time validation stays local and stays the author's
+job; what runs at merge is the enforcement nobody was performing. A failure there names a commit
+already on `3.4.3`, so it should produce a focused issue and a fix on top, not a retroactive review
+cycle over intermediate commits — the same rule the scheduled audit follows.
 
 ## Trust boundary
 


### PR DESCRIPTION
`rust-ci.yml` had no `push` trigger while a comment above the exhaustive ratchet step claimed
the inventory "still runs below on every push to 3.4.3 and on the cron". #211 added that path
on 2026-08-19; #222 removed it two days later and added the first-party author gate without
touching the comment.

## The gap is larger than a stale comment

Every required check — `Format`, `Check core crates`, `Focused library tests`,
`Codex reviewer verdict` — is skipped for pull requests authored by `alseif0x`, and **a
skipped check satisfies branch protection**. With no push trigger, a first-party change is
verified by nothing remote at any point: not at review, not at merge.

Measured on this repository:

- the last Actions run that executed a job was #217, 2026-08-19;
- the **45 pull requests merged since** all report every check `skipped`;
- the exhaustive persistence scan has run in CI **once in its history**.

I diagnosed the skip before touching the trigger, because if the cause had been elsewhere
this change would have fixed nothing. It is not: `gh api .../jobs` on the most recent run
shows `Format`, `Check core crates` and `Focused library tests` skipped by the author
condition, and `Clippy` / `Latest stable` skipped because they only run on
`schedule`/`workflow_dispatch`. Actor is `alseif0x`. Actions itself is healthy.

## Two regressions reached 3.4.3 through this gap

Both are caught by steps that already existed and simply never ran:

- **#275** left both ownership ratchets red on HEAD, which blocked every subsequent local
  preflight regardless of what that PR touched.
- **#277** hid roughly 985 production persistence accesses from the inventory, where a naive
  rebaseline would have deleted them permanently.

## The change

`push: branches: ["3.4.3"]`. The job conditions already read
`github.event_name != 'pull_request'`, so the existing steps — including the exhaustive
`session-ownership-check check` at line 121 — start firing at merge cadence with no further
change.

**Concurrency also had to change.** It grouped on `github.ref`, the shared branch for every
push, with `cancel-in-progress: true`: on a busy day most merges would have cancelled each
other and the enforcement would have been theatre. Pull requests still supersede themselves —
a newer push to the same PR makes the older run worthless — but merges are distinct commits
nobody else recomputes, so they key on `github.sha` and do not cancel.

`docs/operations/local-first-development.md` gains the merge-cadence case and says plainly
why. **The trust boundary is unchanged**: review-time validation stays local and stays the
author's job; what runs at merge is the enforcement nobody was performing.

## Two stale figures corrected

The comment asserting a "~36 minute" local scan now records that repeated August 2026 runs
measured ~11 minutes and the one CI run took 11m24s. `timeout-minutes` is deliberately left
at 120 — one machine's numbers are not enough to narrow a budget that two scans plus the core
build once exhausted exactly.

## Validation

- `check_architecture.py check` → PASS.
- `./tools/pr-preflight.sh quick origin/3.4.3` → exit 0.
- YAML parses with all four triggers.

Closes #284. Refs #133, #153, #275, #277.