### PR TITLE
Avoid synthetic world-modules test harness

### DIFF
--- a/crates/world-modules/Cargo.toml
+++ b/crates/world-modules/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [[bin]]
 name = "world-modules"
 path = "src/main.rs"
+test = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/docs/operations/validation-v2.md
+++ b/docs/operations/validation-v2.md
@@ -31,7 +31,10 @@ most once. Neither profile calls a legacy wrapper or uses the network; Cargo is 
 
 `audit` is the explicit global, read-only budget. It does not use changed-path scope: it runs the
 architecture policy checks, handler contract and exhaustive session/persistence ratchets, all
-workspace targets, standalone QA-bot tests, and the required committed capture contracts. Every
+workspace test targets, standalone QA-bot tests, and the required committed capture contracts.
+The generated `world-modules` launcher declares `test = false`: Cargo's explicit `--all-targets`
+override is therefore excluded for that package, and the real launcher is compiled separately
+with `cargo check -p world-modules`. Every
 step has an owner name in the manifest and stops the audit immediately on failure. It never starts
 services, connects to a database, records a fresh capture, regenerates a baseline, invokes Codex,
 or calls either legacy wrapper. Those mutating or live operations require their own explicit QA

--- a/tools/modules/compose.py
+++ b/tools/modules/compose.py
@@ -229,6 +229,7 @@ license.workspace = true
 [[bin]]
 name = "world-modules"
 path = "src/main.rs"
+test = false
 
 [dependencies]
 anyhow = {{ workspace = true }}

--- a/tools/modules/test_rustycore_module.py
+++ b/tools/modules/test_rustycore_module.py
@@ -171,8 +171,14 @@ class ModuleManagerTests(unittest.TestCase):
     def test_zero_modules_and_no_config_keep_the_base_behaviour(self) -> None:
         self.assertEqual(self.ws.run("sync").returncode, 0)
         main = (self.ws.root / "crates/world-modules/src/main.rs").read_text(encoding="utf-8")
+        manifest = (self.ws.root / "crates/world-modules/Cargo.toml").read_text(encoding="utf-8")
         self.assertIn("No modules are installed", main)
         self.assertNotIn("ModuleConfig::new", main)
+        self.assertIn(
+            "test = false",
+            manifest,
+            "the generated launcher has no unit tests and must not link a libtest harness",
+        )
 
 
 if __name__ == "__main__":

--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -250,6 +250,7 @@ def test_planner_contract(repo: Path) -> None:
         "session-persistence-ratchet",
         "qa-bot-tests",
         "workspace-all-target-tests",
+        "world-modules-launcher-check",
         "capture-loot-contract",
         "capture-creature-spell-contract",
     ]

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -381,7 +381,14 @@ def audit_steps(base_commit: str, jobs: int) -> list[dict[str, object]]:
         ),
         (
             "workspace-all-target-tests",
-            ["cargo", "test", "--locked", "--workspace", "--all-targets", "--jobs", str(jobs)],
+            [
+                "cargo", "test", "--locked", "--workspace", "--all-targets",
+                "--exclude", "world-modules", "--jobs", str(jobs),
+            ],
+        ),
+        (
+            "world-modules-launcher-check",
+            ["cargo", "check", "--locked", "-p", "world-modules", "--jobs", str(jobs)],
         ),
         (
             "capture-loot-contract",


### PR DESCRIPTION
Closes #313

Refs #302 and #301.

## Summary
- declare the generated `world-modules` launcher as `test = false` in the generator and generated manifest
- pin the generated contract in module-manager integration tests
- keep audit `--all-targets` coverage for all other packages while excluding only the no-test launcher
- compile the real launcher separately with an owned audit step

## Validation
- `python3 tools/test_validation_v2.py`
- `python3 -m unittest tools.modules.test_rustycore_module` (11 passed)
- `tools/modules/rustycore-module check`
- `cargo test --locked -p world-modules --all-targets --no-run --jobs 2` demonstrated that explicit `--all-targets` overrides `test = false`, motivating the explicit audit exclusion
- `cargo fmt --all --check`
- `git diff --check`

The subsequent exhaustive audit passed all preceding owners, then the independent known host corruption in #301 recurred inside the persistence scanner (SIGSEGV). That host-wide failure is not treated as evidence against this scoped target/configuration fix.