### PR TITLE
Stop pinning world-server re-export spelling

### DIFF
--- a/crates/world-server/src/main_tests.rs
+++ b/crates/world-server/src/main_tests.rs
@@ -3426,11 +3426,8 @@ fn world_server_binary_delegates_to_the_library_composition_root() {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let binary_source = fs::read_to_string(manifest_dir.join("src/main.rs"))
         .expect("world-server binary source should be readable");
-    let library_source = fs::read_to_string(manifest_dir.join("src/lib.rs"))
-        .expect("world-server library source should be readable");
 
     assert!(binary_source.contains("world_server::run("));
-    assert!(library_source.contains("pub use app::run;"));
     assert!(!binary_source.contains("start_world_listener"));
     assert!(!binary_source.contains("create_session"));
 }


### PR DESCRIPTION
Closes #317

Refs #302 and #315.

## Summary
- retain the source-contract assertions that the binary delegates to `world_server::run`
- retain the negative assertions that listener/session bootstrap does not return to the binary
- remove the obsolete exact spelling assertion for `pub use app::run;`; the current grouped public re-export and binary compilation already establish the contract

## Evidence
- hosted Validation V2 audit run 32643848870: 448 tests passed; this sole test failed because current source is `pub use app::{run, run_with_modules};`
- audit manifest: persistence ratchet and QA bot passed; workspace owner exited 101 with no signal/timeout
- `git diff --check`: passed

Local Cargo evidence is intentionally excluded: #301 recurred while compiling the focused test (rustc ICE followed by SIGSEGV). The post-merge GitHub audit is the trusted verification.