### PR TITLE
Provision pinned C++ SQL parity inputs

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -103,6 +103,22 @@ jobs:
           tar -xzf "${RUNNER_TEMP}/${actionlint_archive}" -C "${RUNNER_TEMP}" actionlint
           install -m 0755 "${RUNNER_TEMP}/actionlint" "$HOME/.local/bin/actionlint"
 
+          cpp_commit="92796557f9b0ba3d2d1c7c770f535153154cf83e"
+          cpp_relative="src/server/database/Database/Implementation"
+          cpp_root="${RUNNER_TEMP}/trinity-reference"
+          mkdir -p "${cpp_root}/${cpp_relative}"
+          curl --fail --show-error --location --retry 3 --retry-all-errors \
+            -o "${cpp_root}/${cpp_relative}/CharacterDatabase.cpp" \
+            "https://raw.githubusercontent.com/TrinityCoreLegacy/TrinityCore/${cpp_commit}/${cpp_relative}/CharacterDatabase.cpp"
+          curl --fail --show-error --location --retry 3 --retry-all-errors \
+            -o "${cpp_root}/${cpp_relative}/HotfixDatabase.cpp" \
+            "https://raw.githubusercontent.com/TrinityCoreLegacy/TrinityCore/${cpp_commit}/${cpp_relative}/HotfixDatabase.cpp"
+          printf '%s  %s\n' \
+            "1bc7a3647d8cf5646ad9e0a7ed2a6d9e88f6a6de21bd3b329cc52725b40c89f9" \
+            "${cpp_root}/${cpp_relative}/CharacterDatabase.cpp" \
+            "7c224e902a3a11743d60432f0975e86994eabe521dd1d49708db5ad17cb52097" \
+            "${cpp_root}/${cpp_relative}/HotfixDatabase.cpp" | sha256sum --check --strict
+
       - name: Prepare locked offline inputs
         run: |
           cargo fetch --locked
@@ -117,6 +133,7 @@ jobs:
           VALIDATION_V2_CARGO_JOBS: "2"
           VALIDATION_V2_TIMEOUT_SECONDS: "3600"
           VALIDATION_V2_MANIFEST: ${{ runner.temp }}/validation-v2-manifest.json
+          RUSTYCORE_CPP_REFERENCE_ROOT: ${{ runner.temp }}/trinity-reference
         run: |
           test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
           ./tools/validation-v2 "$PROFILE" --base "$BASE_SHA"

--- a/crates/wow-database/src/statements/character_tests.rs
+++ b/crates/wow-database/src/statements/character_tests.rs
@@ -8,6 +8,8 @@
 
 #![cfg(test)]
 
+use std::path::PathBuf;
+
 // Explicit database imports: this module reaches its parent through
 // `use super::*`, and the persistence inventory cannot resolve a glob, so
 // without these every database access in the file is invisible to the
@@ -16,8 +18,11 @@ use crate::{CharStatements, CharacterDatabase, Database};
 
 use super::*;
 
-fn cpp_character_database_cpp() -> &'static str {
-    "/home/server/woltk-trinity-legacy/src/server/database/Database/Implementation/CharacterDatabase.cpp"
+fn cpp_character_database_cpp() -> PathBuf {
+    let root = std::env::var_os("RUSTYCORE_CPP_REFERENCE_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/home/server/woltk-trinity-legacy"));
+    root.join("src/server/database/Database/Implementation/CharacterDatabase.cpp")
 }
 
 fn cpp_string_literals(block: &str) -> String {

--- a/crates/wow-database/src/statements/hotfix.rs
+++ b/crates/wow-database/src/statements/hotfix.rs
@@ -315,13 +315,18 @@ impl StatementDef for HotfixStatements {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::{
         HOTFIX_STATEMENT_STRATEGY_LIKE_CPP, HotfixStatementStrategyLikeCpp, HotfixStatements,
     };
     use crate::statements::StatementDef;
 
-    fn cpp_hotfix_database_cpp() -> &'static str {
-        "/home/server/woltk-trinity-legacy/src/server/database/Database/Implementation/HotfixDatabase.cpp"
+    fn cpp_hotfix_database_cpp() -> PathBuf {
+        let root = std::env::var_os("RUSTYCORE_CPP_REFERENCE_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/home/server/woltk-trinity-legacy"));
+        root.join("src/server/database/Database/Implementation/HotfixDatabase.cpp")
     }
 
     fn cpp_max_id_tables() -> Vec<String> {


### PR DESCRIPTION
Closes #319

Refs #302 and #315.

## Summary
- accept `RUSTYCORE_CPP_REFERENCE_ROOT` in character/hotfix parity tests while retaining the authoritative local fallback
- pin the public TrinityCoreLegacy reference to exact commit `92796557f9b0ba3d2d1c7c770f535153154cf83e`
- download only CharacterDatabase.cpp and HotfixDatabase.cpp on hosted runners
- verify both files against SHA-256 values matched to `/home/server/woltk-trinity-legacy`
- keep all parity tests executing; no missing-reference skip and no private token

## Validation
- actionlint 1.7.12: clean
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p wow-database --lib generated_`: 6 passed (four relevant parity tests plus two matching generated-statement tests)
- `character_select_item_instance_content_aliases_match_cpp_expansion_exactly`: passed
- public pinned files match local C++ authority byte-for-byte

The post-merge hosted audit verifies the clean-runner path.