### PR TITLE
Refuse a green verdict for timed-out, signalled or OOM runs

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -138,6 +138,12 @@ jobs:
           test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
           ./tools/validation-v2 "$PROFILE" --base "$BASE_SHA"
 
+      - name: Verify Validation V2 manifest verdict
+        if: always()
+        env:
+          VALIDATION_V2_MANIFEST: ${{ runner.temp }}/validation-v2-manifest.json
+        run: ./tools/validation-v2 verify --manifest "$VALIDATION_V2_MANIFEST"
+
       - name: Upload Validation V2 manifest
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/docs/operations/validation-v2.md
+++ b/docs/operations/validation-v2.md
@@ -40,9 +40,43 @@ services, connects to a database, records a fresh capture, regenerates a baselin
 or calls either legacy wrapper. Those mutating or live operations require their own explicit QA
 procedure.
 
+## Verdict rules
+
+A run is green only when every executed command is green. The runner refuses the failure modes
+that used to read as a pass:
+
+- a step that times out is `failed` even when the child traps `SIGTERM` and exits `0`, and
+  `run_steps` stops on the step's status rather than on its exit code;
+- a failed step whose exit code is nevertheless `0` returns exit `70`, never `0`;
+- a terminating signal to the runner itself (`SIGINT`, `SIGTERM`, `SIGHUP`) is raised as an
+  exception, so the child's process group is stopped, the interrupted command is recorded with
+  `failure_kind: "interrupted"`, and the manifest is written with exit `128 + signal`;
+- before writing, the manifest is re-read against the same rules a consumer applies; an
+  inconsistent green is downgraded to exit `70`.
+
+Each command records why it is not green in `failure_kind`: `oom`, `timeout`, `signal`,
+`child-signal`, `exit`, or `interrupted`. `oom_kills` is the kernel OOM-kill delta charged to the
+runner's cgroup for that command (`null` where cgroup v2 is unobservable), which is what separates
+an OOM kill from a plain `kill -9`. `child_signal_reports` preserves a signalled grandchild that
+Cargo hides behind its own exit `101` — for example `(signal: 6, SIGABRT)` from an aborted test
+binary. `resources.memory_limit_kib` records the cgroup or host memory ceiling next to the peak
+child RSS.
+
+A runner killed outright (`SIGKILL`, OOM killer, cancelled job) cannot write anything, so the
+consumer rule is explicit: **a missing manifest is a failed run.** Verify one with
+
+```bash
+./tools/validation-v2 verify --manifest <path>
+```
+
+which exits non-zero for a missing, unreadable, schema-mismatched, signalled, failed, or truncated
+manifest — including a `passed` manifest that executed fewer commands than its plan declared. Rust
+CI runs this step after every profile, before the artifact upload.
+
 Every run acquires a non-blocking, worktree-specific lock and writes a JSON manifest under
-`target/validation-v2/manifests/`. The manifest records repository and toolchain provenance,
-dirty state, kernel, timings, command results, signals, resource limits, and peak child RSS. It
+`target/validation-v2/manifests/`. The manifest (schema 4) records repository and toolchain
+provenance, dirty state, kernel, timings, command results, signals, failure kinds, OOM-kill
+deltas, resource limits, and peak child RSS. It
 also records the resolved base, complete changed-path set, path classes, direct workspace packages,
 reverse-dependent closure, metadata outcome, optional-linter omissions, and exact command plan. It
 does not record the environment or command output. Set `VALIDATION_V2_MANIFEST` to choose a result

--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -15,6 +15,8 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 
 
 RUNNER_PATH = Path(__file__).with_name("validation-v2").resolve()
@@ -97,6 +99,10 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     result = invoke("quick", success_manifest)
     assert result.returncode == 0, result.stderr
     success = json.loads(success_manifest.read_text())
+    assert success["schema"] == runner.MANIFEST_SCHEMA
+    assert success["runner_signal"] is None
+    assert success["resources"]["cargo_jobs"] == 2
+    assert "memory_limit_kib" in success["resources"]
     assert success["profile"] == "quick"
     assert len(success["run_id"]) == 20
     assert success["provenance"]["rust"] == {"active": "1.98.0", "pinned": "1.98.0"}
@@ -126,6 +132,8 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
         repo, [sys.executable, "-c", "raise SystemExit(23)"], base_env, 30
     )
     assert direct_failure["exit_code"] == 23
+    assert direct_failure["failure_kind"] == "exit"
+    assert direct_failure["status"] == "failed"
     direct_signal = runner.run_one(
         repo,
         [sys.executable, "-c", "import os,signal; os.kill(os.getpid(), signal.SIGTERM)"],
@@ -134,11 +142,61 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     )
     assert direct_signal["exit_code"] == 128 + signal.SIGTERM
     assert direct_signal["signal"] == signal.SIGTERM
+    assert direct_signal["failure_kind"] == "signal"
     direct_timeout = runner.run_one(
         repo, [sys.executable, "-c", "import time; time.sleep(10)"], base_env, 1
     )
     assert direct_timeout["timed_out"] is True
     assert direct_timeout["exit_code"] == 128 + signal.SIGTERM
+    assert direct_timeout["failure_kind"] == "timeout"
+
+    # A child that traps SIGTERM and exits zero during the grace window used to
+    # be recorded as {"timed_out": true, "exit_code": 0, "status": "passed"}.
+    trapped_timeout = runner.run_one(
+        repo,
+        [
+            sys.executable,
+            "-c",
+            "import signal,sys,time; signal.signal(signal.SIGTERM, lambda *_: sys.exit(0));"
+            " time.sleep(30)",
+        ],
+        base_env,
+        1,
+    )
+    assert trapped_timeout["timed_out"] is True
+    assert trapped_timeout["exit_code"] == 0
+    assert trapped_timeout["failure_kind"] == "timeout"
+    assert trapped_timeout["status"] == "failed"
+
+    # Cargo hides a signalled test binary behind its own exit 101.
+    child_signal = runner.run_one(
+        repo,
+        [
+            sys.executable,
+            "-c",
+            "import sys; print('error: test failed, to rerun pass `-p wow-world --lib`');"
+            " print('  process didn\\'t exit successfully: wow_world-df42 (signal: 6,"
+            " SIGABRT: process abort signal)'); sys.exit(101)",
+        ],
+        base_env,
+        30,
+    )
+    assert child_signal["exit_code"] == 101
+    assert child_signal["signal"] is None
+    assert child_signal["failure_kind"] == "child-signal"
+    assert child_signal["child_signal_reports"] == [{"signal": 6, "name": "SIGABRT"}]
+
+    # Classification order, including the OOM case a host cannot be forced into.
+    assert runner.classify_failure(0, None, False, 0, []) is None
+    assert runner.classify_failure(0, None, False, None, []) is None
+    assert runner.classify_failure(0, None, False, 1, []) == "oom"
+    assert runner.classify_failure(137, None, True, 1, []) == "oom"
+    assert runner.classify_failure(137, 9, True, 0, []) == "timeout"
+    assert runner.classify_failure(137, 9, False, 0, []) == "signal"
+    assert runner.classify_failure(101, None, False, 0, [{"signal": 6}]) == "child-signal"
+    assert runner.classify_failure(1, None, False, None, []) == "exit"
+    for probe in (runner.oom_kill_count(), runner.memory_limit_kib()):
+        assert probe is None or isinstance(probe, int)
 
     steps = [
         {"section": "pass", "argv": [sys.executable, "-c", "pass"]},
@@ -151,6 +209,36 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     outcomes, exit_code = runner.run_steps(repo, steps, base_env, 30)
     assert exit_code == 19
     assert [outcome["section"] for outcome in outcomes] == ["pass", "fail"]
+
+    zero_exit_timeout = [
+        {
+            "section": "trapped-timeout",
+            "argv": [
+                sys.executable,
+                "-c",
+                "import signal,sys,time; signal.signal(signal.SIGTERM, lambda *_: sys.exit(0));"
+                " time.sleep(30)",
+            ],
+        },
+        {"section": "must-not-run", "argv": [sys.executable, "-c", "pass"]},
+    ]
+    outcomes, exit_code = runner.run_steps(repo, zero_exit_timeout, base_env, 1)
+    assert exit_code == runner.RUNNER_ERROR
+    assert [outcome["section"] for outcome in outcomes] == ["trapped-timeout"]
+
+    # A terminating signal becomes an exception so the manifest is still written.
+    previous = {number: signal.getsignal(number) for number in runner.INTERRUPT_SIGNALS}
+    try:
+        runner.install_interrupt_handlers()
+        try:
+            os.kill(os.getpid(), signal.SIGTERM)
+        except runner.RunnerInterrupted as interrupted:
+            assert interrupted.number == signal.SIGTERM
+        else:
+            raise AssertionError("SIGTERM did not raise RunnerInterrupted")
+    finally:
+        for number, handler in previous.items():
+            signal.signal(number, handler)
 
     result = invoke(
         "final", directory / "invalid.json", {"VALIDATION_V2_CARGO_JOBS": "0"}
@@ -200,6 +288,130 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     assert result.returncode == runner.LOCKED_ERROR
     assert "other-clone-run" in result.stderr
     assert "different-clone" in result.stderr
+
+
+def test_interrupt_and_verdict_contract(
+    repo: Path, tools: Path, base_env: dict[str, str], directory: Path, fake_bin: Path
+) -> None:
+    """A killed run must leave a failed manifest, and a consumer must reject it."""
+    fake_tool(fake_bin / "actionlint", 'echo VALIDATION_V2_CHILD_READY\nsleep 30\n')
+    workflow = repo / ".github" / "workflows" / "slow.yml"
+    workflow.parent.mkdir(parents=True, exist_ok=True)
+    workflow.write_text("name: fixture\n")
+    manifest = directory / "interrupted.json"
+    environment = base_env.copy()
+    environment["VALIDATION_V2_MANIFEST"] = str(manifest)
+    environment["VALIDATION_V2_TIMEOUT_SECONDS"] = "60"
+    process = subprocess.Popen(
+        [str(tools / "validation-v2"), "quick", "--base", "HEAD"],
+        cwd=repo,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    watchdog = threading.Timer(120, process.kill)
+    watchdog.start()
+    try:
+        assert process.stdout is not None
+        for line in process.stdout:
+            if line.strip() == "VALIDATION_V2_CHILD_READY":
+                time.sleep(0.2)
+                process.send_signal(signal.SIGINT)
+                break
+        else:
+            raise AssertionError("the runner never reached the slow command")
+        trailing = process.stdout.read()
+        returncode = process.wait()
+    finally:
+        watchdog.cancel()
+        if process.stdout is not None:
+            process.stdout.close()
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+    assert returncode == 128 + signal.SIGINT, (returncode, trailing)
+    interrupted = json.loads(manifest.read_text())
+    assert interrupted["status"] == "failed"
+    assert interrupted["exit_code"] == 128 + signal.SIGINT
+    assert interrupted["runner_signal"] == signal.SIGINT
+    assert interrupted["commands"], "the interrupted command must still be recorded"
+    last = interrupted["commands"][-1]
+    assert last["failure_kind"] == "interrupted"
+    assert last["status"] == "failed"
+    assert last["argv"][0] == "actionlint"
+    workflow.unlink()
+    (fake_bin / "actionlint").unlink()
+
+    def verify(target: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(tools / "validation-v2"), "verify", "--manifest", str(target)],
+            cwd=repo,
+            env=base_env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    missing = verify(directory / "never-written.json")
+    assert missing.returncode == runner.VERDICT_ERROR
+    assert "is missing" in missing.stderr
+    rejected = verify(manifest)
+    assert rejected.returncode == runner.VERDICT_ERROR
+    assert "runner died by signal" in rejected.stderr
+
+    green_manifest = directory / "verified-green.json"
+    environment["VALIDATION_V2_MANIFEST"] = str(green_manifest)
+    result = subprocess.run(
+        [str(tools / "validation-v2"), "quick", "--base", "HEAD"],
+        cwd=repo,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0, result.stderr
+    accepted = verify(green_manifest)
+    assert accepted.returncode == 0, accepted.stderr
+
+    green = json.loads(green_manifest.read_text())
+    unreadable = directory / "unreadable.json"
+    unreadable.write_text("{not json")
+    assert verify(unreadable).returncode == runner.VERDICT_ERROR
+
+    tampered = directory / "tampered.json"
+    document = json.loads(json.dumps(green))
+    document["commands"][-1]["status"] = "failed"
+    document["commands"][-1]["failure_kind"] = "oom"
+    tampered.write_text(json.dumps(document))
+    tampered_result = verify(tampered)
+    assert tampered_result.returncode == runner.VERDICT_ERROR
+    assert "oom" in tampered_result.stderr
+
+    truncated = directory / "truncated.json"
+    document = json.loads(json.dumps(green))
+    document["commands"] = document["commands"][:-1]
+    truncated.write_text(json.dumps(document))
+    truncated_result = verify(truncated)
+    assert truncated_result.returncode == runner.VERDICT_ERROR
+    assert "planned steps were executed" in truncated_result.stderr
+
+    stale_schema = directory / "stale-schema.json"
+    document = json.loads(json.dumps(green))
+    document["schema"] = runner.MANIFEST_SCHEMA - 1
+    stale_schema.write_text(json.dumps(document))
+    assert verify(stale_schema).returncode == runner.VERDICT_ERROR
+
+    usage = subprocess.run(
+        [str(tools / "validation-v2"), "verify"],
+        cwd=repo,
+        env=base_env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert usage.returncode == runner.USAGE_ERROR
+    assert "requires --manifest" in usage.stderr
 
 
 def test_planner_contract(repo: Path) -> None:
@@ -318,6 +530,7 @@ def main() -> None:
         environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
         environment["VALIDATION_V2_LOCK_DIR"] = str(directory / "locks")
         test_runner_contract(repo, tools, environment, directory)
+        test_interrupt_and_verdict_contract(repo, tools, environment, directory, fake_bin)
         test_planner_contract(repo)
     print("validation-v2 self-test passed")
 

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -11,16 +11,21 @@ import json
 import os
 from pathlib import Path
 import platform
+import re
 import resource
 import shutil
 import signal
 import subprocess
 import sys
+import threading
 import time
 import tomllib
 
 
+MANIFEST_SCHEMA = 4
 USAGE_ERROR = 64
+VERDICT_ERROR = 1
+RUNNER_ERROR = 70
 LOCKED_ERROR = 75
 DEFAULT_JOBS = 2
 MAX_JOBS = 8
@@ -29,6 +34,12 @@ DEFAULT_BASE = "origin/3.4.3"
 DEFAULT_HEAVY_LOCK = "/tmp/rustycore-validation-v2-heavy.lock"
 CHECKER_MANIFEST = "tools/architecture/handler-contract-check/Cargo.toml"
 BOT_MANIFEST = "tools/wow-test-bot/Cargo.toml"
+INTERRUPT_SIGNALS = (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+# Cargo reports a child killed by a signal as its own exit 101, so the signal
+# only survives in the child's own message: "(signal: 6, SIGABRT: ...)".
+CHILD_SIGNAL_PATTERN = re.compile(rb"\(signal:\s*(\d+),\s*(SIG[A-Z0-9]+)")
+MAX_SIGNAL_REPORTS = 5
+TERMINATE_GRACE_SECONDS = 5
 WHITESPACE_CHECK = (
     "from pathlib import Path; import sys; "
     "bad=[f'{path}:{number}' for path in sys.argv[1:] "
@@ -36,6 +47,79 @@ WHITESPACE_CHECK = (
     "if line.endswith((' ', '\\t'))]; "
     "bad and print('\\n'.join(bad), file=sys.stderr); raise SystemExit(bool(bad))"
 )
+
+
+class RunnerInterrupted(Exception):
+    """The runner process itself received a terminating signal."""
+
+    def __init__(self, number: int) -> None:
+        super().__init__(f"runner received {signal_name(number)}")
+        self.number = number
+
+
+def signal_name(number: int) -> str:
+    try:
+        return signal.Signals(number).name
+    except ValueError:
+        return f"SIG{number}"
+
+
+def install_interrupt_handlers() -> None:
+    """Turn a terminating signal into an exception so the manifest is written."""
+
+    def handler(number: int, _frame) -> None:
+        raise RunnerInterrupted(number)
+
+    for number in INTERRUPT_SIGNALS:
+        signal.signal(number, handler)
+
+
+def cgroup_memory_file(name: str) -> Path | None:
+    try:
+        entries = Path("/proc/self/cgroup").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    for entry in entries:
+        fields = entry.split(":", 2)
+        if len(fields) == 3 and fields[1] == "":
+            candidate = Path("/sys/fs/cgroup") / fields[2].lstrip("/") / name
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+def oom_kill_count() -> int | None:
+    """Kernel OOM kills charged to this cgroup, or None when unobservable."""
+    for name in ("memory.events.local", "memory.events"):
+        path = cgroup_memory_file(name)
+        if path is None:
+            continue
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines():
+                key, _, value = line.partition(" ")
+                if key == "oom_kill":
+                    return int(value)
+        except (OSError, ValueError):
+            return None
+    return None
+
+
+def memory_limit_kib() -> int | None:
+    path = cgroup_memory_file("memory.max")
+    if path is not None:
+        try:
+            raw = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            raw = "max"
+        if raw.isdigit():
+            return int(raw) // 1024
+    try:
+        for line in Path("/proc/meminfo").read_text(encoding="utf-8").splitlines():
+            if line.startswith("MemTotal:"):
+                return int(line.split()[1])
+    except (OSError, IndexError, ValueError):
+        return None
+    return None
 
 
 def utc_now() -> str:
@@ -219,6 +303,10 @@ def cargo_metadata(
         "duration_seconds": round(time.monotonic() - started, 3),
         "exit_code": exit_code,
         "signal": signal_number,
+        "timed_out": False,
+        "oom_kills": None,
+        "child_signal_reports": [],
+        "failure_kind": None if exit_code == 0 else "exit",
         "status": "passed" if exit_code == 0 else "failed",
     }
     if exit_code != 0:
@@ -587,26 +675,110 @@ def command_environment(repo: Path, jobs: int) -> dict[str, str]:
     return environment
 
 
-def run_one(repo: Path, command: list[str], environment: dict[str, str], timeout: int) -> dict[str, object]:
+def terminate_group(process: subprocess.Popen) -> int:
+    """Stop the child's whole process group and return its wait status."""
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except (OSError, ProcessLookupError):
+        return process.wait()
+    try:
+        return process.wait(timeout=TERMINATE_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (OSError, ProcessLookupError):
+            pass
+        return process.wait()
+
+
+def tee_output(stream, reports: list[dict[str, object]]) -> None:
+    """Stream child output through unchanged while noting reported signals."""
+    target = sys.stdout.buffer
+    for line in iter(stream.readline, b""):
+        target.write(line)
+        target.flush()
+        if len(reports) >= MAX_SIGNAL_REPORTS:
+            continue
+        match = CHILD_SIGNAL_PATTERN.search(line)
+        if match is None:
+            continue
+        report = {"signal": int(match.group(1)), "name": match.group(2).decode("ascii")}
+        if report not in reports:
+            reports.append(report)
+
+
+def classify_failure(
+    exit_code: int,
+    signal_number: int | None,
+    timed_out: bool,
+    oom_kills: int | None,
+    reports: list[dict[str, object]],
+) -> str | None:
+    """Name why a command is not green, or None when it genuinely passed."""
+    if oom_kills:
+        return "oom"
+    if timed_out:
+        return "timeout"
+    if signal_number is not None:
+        return "signal"
+    if exit_code != 0:
+        # Cargo hides a signalled child behind its own exit 101.
+        return "child-signal" if reports else "exit"
+    return None
+
+
+def run_one(
+    repo: Path,
+    command: list[str],
+    environment: dict[str, str],
+    timeout: int,
+    sink: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
     print("+ " + " ".join(command), flush=True)
     started_at = utc_now()
     started = time.monotonic()
     timed_out = False
-    process = subprocess.Popen(command, cwd=repo, env=environment, start_new_session=True)
+    interrupt: BaseException | None = None
+    reports: list[dict[str, object]] = []
+    oom_before = oom_kill_count()
+    process: subprocess.Popen | None = None
+    pump: threading.Thread | None = None
     try:
+        process = subprocess.Popen(
+            command,
+            cwd=repo,
+            env=environment,
+            start_new_session=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        pump = threading.Thread(target=tee_output, args=(process.stdout, reports), daemon=True)
+        pump.start()
         return_code = process.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         timed_out = True
-        os.killpg(process.pid, signal.SIGTERM)
-        try:
-            return_code = process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            os.killpg(process.pid, signal.SIGKILL)
-            return_code = process.wait()
+        return_code = terminate_group(process)
+    except BaseException as error:  # The runner itself was signalled.
+        if process is None:
+            raise
+        interrupt = error
+        return_code = terminate_group(process)
+    finally:
+        if pump is not None and pump.ident is not None:
+            pump.join(timeout=TERMINATE_GRACE_SECONDS)
+        if process is not None and process.stdout is not None:
+            process.stdout.close()
     duration = round(time.monotonic() - started, 3)
     signal_number = -return_code if return_code < 0 else None
     exit_code = 128 + signal_number if signal_number is not None else return_code
-    return {
+    oom_after = oom_kill_count()
+    oom_kills = (
+        None if oom_before is None or oom_after is None else max(oom_after - oom_before, 0)
+    )
+    failure_kind = classify_failure(exit_code, signal_number, timed_out, oom_kills, reports)
+    if interrupt is not None:
+        failure_kind = "interrupted"
+    outcome = {
         "argv": command,
         "started_at": started_at,
         "ended_at": utc_now(),
@@ -614,8 +786,22 @@ def run_one(repo: Path, command: list[str], environment: dict[str, str], timeout
         "exit_code": exit_code,
         "signal": signal_number,
         "timed_out": timed_out,
-        "status": "passed" if exit_code == 0 else "failed",
+        "oom_kills": oom_kills,
+        "child_signal_reports": reports,
+        "failure_kind": failure_kind,
+        "status": "passed" if failure_kind is None else "failed",
     }
+    if sink is not None:
+        sink.append(outcome)
+    if interrupt is not None:
+        raise interrupt
+    return outcome
+
+
+def failed_exit_code(outcome: dict[str, object]) -> int:
+    """A failed step must never yield a zero runner exit code."""
+    code = int(outcome["exit_code"])
+    return code if code != 0 else RUNNER_ERROR
 
 
 def run_steps(
@@ -623,8 +809,10 @@ def run_steps(
     steps: list[dict[str, object]],
     environment: dict[str, str],
     timeout: int,
+    outcomes: list[dict[str, object]] | None = None,
 ) -> tuple[list[dict[str, object]], int]:
-    outcomes: list[dict[str, object]] = []
+    if outcomes is None:
+        outcomes = []
     for step in steps:
         section = step.get("section")
         command = step.get("argv")
@@ -632,19 +820,94 @@ def run_steps(
             raise ValueError("planned step has an invalid section or argv")
         if not all(isinstance(item, str) for item in command):
             raise ValueError(f"planned step '{section}' contains a non-string argument")
-        outcome = run_one(repo, command, environment, timeout)
+        before = len(outcomes)
+        try:
+            outcome = run_one(repo, command, environment, timeout, sink=outcomes)
+        except BaseException:
+            # An interrupted command is still recorded through the sink.
+            for recorded in outcomes[before:]:
+                recorded["section"] = section
+            raise
         outcome["section"] = section
-        outcomes.append(outcome)
-        if outcome["exit_code"] != 0:
-            return outcomes, int(outcome["exit_code"])
+        if outcome["status"] != "passed":
+            return outcomes, failed_exit_code(outcome)
     return outcomes, 0
+
+
+def manifest_problems(document: object) -> list[str]:
+    """Every reason this manifest may not be read as a green run."""
+    if not isinstance(document, dict):
+        return ["manifest is not a JSON object"]
+    problems: list[str] = []
+    if document.get("schema") != MANIFEST_SCHEMA:
+        problems.append(f"schema is {document.get('schema')!r}, expected {MANIFEST_SCHEMA}")
+    if document.get("runner") != "rustycore-validation-v2":
+        problems.append(f"runner is {document.get('runner')!r}")
+    if document.get("status") != "passed":
+        problems.append(f"status is {document.get('status')!r}")
+    if document.get("exit_code") != 0:
+        problems.append(f"exit code is {document.get('exit_code')!r}")
+    if document.get("runner_error"):
+        problems.append(f"runner error {document.get('runner_error')!r}")
+    if document.get("runner_signal") is not None:
+        problems.append(f"runner died by signal {document.get('runner_signal')!r}")
+    commands = document.get("commands")
+    if not isinstance(commands, list):
+        problems.append("commands are missing")
+        return problems
+    for index, command in enumerate(commands):
+        if not isinstance(command, dict):
+            problems.append(f"command {index} is not an object")
+            continue
+        if command.get("status") != "passed":
+            problems.append(
+                f"command {index} ({command.get('section')}) is {command.get('status')!r}"
+                f" [{command.get('failure_kind')}]"
+            )
+    plan = document.get("plan")
+    if isinstance(plan, dict):
+        planned = plan.get("planned_steps")
+        if isinstance(planned, list) and len(planned) != len(commands):
+            problems.append(
+                f"{len(commands)} of {len(planned)} planned steps were executed"
+            )
+    return problems
+
+
+def verify_manifest(path: Path) -> int:
+    """A missing, unreadable, or non-green manifest is a failed run."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return fail(f"manifest {path} is missing; a run without a manifest is a failure", VERDICT_ERROR)
+    except OSError as error:
+        return fail(f"manifest {path} is unreadable: {error}", VERDICT_ERROR)
+    try:
+        document = json.loads(raw)
+    except json.JSONDecodeError as error:
+        return fail(f"manifest {path} is not valid JSON: {error}", VERDICT_ERROR)
+    problems = manifest_problems(document)
+    if problems:
+        for problem in problems:
+            print(f"validation-v2: {path}: {problem}", file=sys.stderr)
+        return VERDICT_ERROR
+    print(f"validation-v2: manifest {path} verified green")
+    return 0
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(prog="tools/validation-v2")
-    parser.add_argument("profile", choices=("self-test", "quick", "final", "audit"))
+    parser.add_argument("profile", choices=("self-test", "quick", "final", "audit", "verify"))
     parser.add_argument("--base", default=DEFAULT_BASE)
+    parser.add_argument("--manifest", help="manifest to verify with the verify profile")
     args = parser.parse_args()
+    if args.profile == "verify":
+        if not args.manifest:
+            return fail("verify requires --manifest")
+        return verify_manifest(Path(args.manifest))
+    if args.manifest:
+        return fail("--manifest is only valid with the verify profile")
+    install_interrupt_handlers()
     repo = Path(__file__).resolve().parent.parent
     try:
         jobs = checked_value("VALIDATION_V2_CARGO_JOBS", DEFAULT_JOBS, 1, MAX_JOBS)
@@ -674,55 +937,76 @@ def main() -> int:
     started = time.monotonic()
     path = manifest_path(repo, args.profile)
     document: dict[str, object] = {
-        "schema": 3,
+        "schema": MANIFEST_SCHEMA,
         "runner": "rustycore-validation-v2",
         "shadow_only": True,
         "run_id": identifier,
         "profile": args.profile,
         "provenance": details,
-        "resources": {"cargo_jobs": jobs, "command_timeout_seconds": timeout},
+        "resources": {
+            "cargo_jobs": jobs,
+            "command_timeout_seconds": timeout,
+            "memory_limit_kib": memory_limit_kib(),
+        },
         "locks": {
             "repository": str(active_lock),
             "heavy": str(active_heavy_lock) if active_heavy_lock is not None else None,
         },
         "started_at": started_at,
+        "runner_signal": None,
         "plan": None,
         "commands": [],
     }
+    outcomes: list[dict[str, object]] = []
+    document["commands"] = outcomes
     exit_code = 0
     try:
+        environment = command_environment(repo, jobs)
         if args.profile == "self-test":
-            environment = command_environment(repo, jobs)
             outcome = run_one(
                 repo,
                 [sys.executable, str(repo / "tools" / "test_validation_v2.py")],
                 environment,
                 timeout,
+                sink=outcomes,
             )
-            document["commands"] = [outcome]
-            exit_code = int(outcome["exit_code"])
+            exit_code = 0 if outcome["status"] == "passed" else failed_exit_code(outcome)
         else:
-            environment = command_environment(repo, jobs)
             plan = build_plan(repo, args.profile, jobs, args.base, environment, timeout)
             document["plan"] = plan
             steps = plan["planned_steps"]
             assert isinstance(steps, list)
-            outcomes, exit_code = run_steps(repo, steps, environment, timeout)
-            document["commands"] = outcomes
+            _, exit_code = run_steps(repo, steps, environment, timeout, outcomes)
+    except RunnerInterrupted as error:
+        exit_code = 128 + error.number
+        document["runner_signal"] = error.number
+        document["runner_error"] = f"RunnerInterrupted: {error}"
+        print(f"validation-v2: {error}", file=sys.stderr)
     except ValueError as error:
         exit_code = USAGE_ERROR
         document["runner_error"] = f"ValueError: {error}"
         print(f"validation-v2: {error}", file=sys.stderr)
     except Exception as error:  # Manifest unexpected runner failures before returning.
-        exit_code = 70
+        exit_code = RUNNER_ERROR
         document["runner_error"] = f"{type(error).__name__}: {error}"
         print(f"validation-v2: runner failure: {error}", file=sys.stderr)
+    except BaseException as error:  # KeyboardInterrupt and every other escape.
+        exit_code = 128 + signal.SIGINT if isinstance(error, KeyboardInterrupt) else RUNNER_ERROR
+        document["runner_error"] = f"{type(error).__name__}: {error}"
+        print(f"validation-v2: runner aborted: {type(error).__name__}", file=sys.stderr)
     finally:
         document["ended_at"] = utc_now()
         document["duration_seconds"] = round(time.monotonic() - started, 3)
         document["peak_child_rss_kib"] = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
-        document["status"] = "passed" if exit_code == 0 else "failed"
         document["exit_code"] = exit_code
+        document["status"] = "passed" if exit_code == 0 else "failed"
+        # Fail closed: a green verdict must survive its own manifest.
+        problems = manifest_problems(document)
+        if problems and exit_code == 0:
+            document["exit_code"] = exit_code = RUNNER_ERROR
+            document["status"] = "failed"
+            document["runner_error"] = f"inconsistent verdict: {'; '.join(problems)}"
+            print(f"validation-v2: {document['runner_error']}", file=sys.stderr)
         write_manifest(path, document)
         print(f"validation-v2: manifest {path}")
         if heavy_stream is not None:


### PR DESCRIPTION
Closes #322.

## What was wrong

`tools/validation-v2` could report **green for a run that did not finish**:

- `run_one` computed `status` from the exit code alone, so a child that traps `SIGTERM` and
  exits `0` inside the 5s grace window produced `{"timed_out": true, "exit_code": 0,
  "status": "passed"}`, and `run_steps` keyed its stop decision on the exit code, so the run
  continued and could finish green.
- `KeyboardInterrupt` is a `BaseException`, so SIGINT unwound past both `except` clauses into
  the `finally`, which wrote a manifest with the initial `exit_code = 0`.
- A runner killed outright wrote no manifest at all, and nothing said that a missing manifest
  is a failure.
- OOM was indistinguishable from `kill -9`, and a child signalled underneath Cargo disappeared
  behind Cargo's own exit 101 — visible in audit run 32646479042, where `signal: 6, SIGABRT`
  reached the log but not the manifest.

## What changed

- `timed_out` is part of the verdict; `run_steps` stops on `status`, and a failed step whose
  exit code is `0` returns exit `70`.
- Terminating signals (`SIGINT`/`SIGTERM`/`SIGHUP`) are raised as `RunnerInterrupted`: the
  child's process group is stopped, the interrupted command is recorded through a sink that
  survives the exception, and the manifest is written with `128 + signal` and `runner_signal`.
  `BaseException` is caught as a last resort.
- Each command records `failure_kind` (`oom`, `timeout`, `signal`, `child-signal`, `exit`,
  `interrupted`), `oom_kills` (cgroup v2 OOM-kill delta, `null` when unobservable) and
  `child_signal_reports` parsed from the child's own `(signal: N, SIGXXX)` line. Output is
  teed through unchanged; the manifest still records no command output.
  `resources.memory_limit_kib` puts peak child RSS next to a ceiling.
- New consumer verdict: `./tools/validation-v2 verify --manifest <path>` fails on a missing,
  unreadable, schema-mismatched, signalled, failed or truncated manifest (including a `passed`
  manifest that ran fewer commands than its plan declared). Rust CI runs it after every
  profile, before the upload. The runner applies the same rules to its own manifest before
  writing, downgrading an inconsistent green to exit `70`.
- Manifest schema 3 → 4; `docs/operations/validation-v2.md` documents the verdict rules.

## Done criteria

- [x] A step that times out cannot produce `status: passed`, and `run_steps` stops on status.
- [x] `KeyboardInterrupt`/`BaseException` cannot produce a zero exit code or a passed manifest.
- [x] A missing manifest is specified and tested as failure on the consumer side.
- [x] The manifest distinguishes clean non-zero exit, direct signal, signal via Cargo, timeout
      and OOM.
- [x] `tools/test_validation_v2.py` covers each of the above.

## Evidence

Host sanity first (#301): `session-ownership-check print-path-modules` **12/12**, 10× 256 MiB
SHA-256 triple-hash stable, no swap configured. Local Cargo/Python results on this host count.

- `python3 tools/test_validation_v2.py` — passed, including the new end-to-end SIGINT test
  (real runner subprocess interrupted mid-command: exit 130, manifest written, status failed,
  `runner_signal: 2`, last command `failure_kind: "interrupted"`).
- `./tools/validation-v2 self-test` — exit 0.
- `./tools/validation-v2 quick --base origin/3.4.3` — exit 0.
- `./tools/validation-v2 final --base origin/3.4.3` — exit 0, and its own manifest passes
  `verify` (exit 0).
- Workflow YAML parsed locally (`actionlint` is not installed on this host and is recorded as
  an explicit optional skip; GitHub installs the pinned release).

No gameplay, packet, persistence or runtime behavior is touched.