### PR TITLE
Run the joined purchase test on its own 32 MiB stack

### DIFF
--- a/crates/wow-world/src/battle_pet_purchase.rs
+++ b/crates/wow-world/src/battle_pet_purchase.rs
@@ -2881,6 +2881,7 @@ pub(crate) mod tests {
 #[cfg(test)]
 mod executor_tests {
     use std::collections::HashMap;
+    use std::future::Future;
     use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex as StdMutex};
     use std::time::Duration as StdDuration;
@@ -4296,8 +4297,36 @@ mod executor_tests {
         assert_no_packets(&fixture);
     }
 
-    #[tokio::test]
-    async fn concurrent_sessions_charge_once_grant_once_and_compensate_once_like_cpp() {
+    /// Run one async body on a 32 MiB stack, mirroring `run_player_stack_test`
+    /// in `wow-entities` (`object_accessor.rs`). `#[tokio::test]` runs the body
+    /// on a default 2 MiB thread, which cannot hold two joined debug-profile
+    /// purchase state machines at once.
+    fn run_async_stack_test<F>(test: impl FnOnce() -> F + Send + 'static)
+    where
+        F: Future<Output = ()>,
+    {
+        std::thread::Builder::new()
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("current-thread runtime")
+                    .block_on(test());
+            })
+            .expect("stack test thread")
+            .join()
+            .unwrap_or_else(|payload| std::panic::resume_unwind(payload));
+    }
+
+    #[test]
+    fn concurrent_sessions_charge_once_grant_once_and_compensate_once_like_cpp() {
+        // `tokio::join!` polls both purchase futures inline, so both live on
+        // this stack at once; the pair does not fit the default test thread.
+        run_async_stack_test(concurrent_sessions_charge_once_grant_once_and_compensate_once);
+    }
+
+    async fn concurrent_sessions_charge_once_grant_once_and_compensate_once() {
         let seeded = vec![
             saga_durable_pet_row_like_cpp(1, SAGA_SPECIES, None),
             saga_durable_pet_row_like_cpp(2, SAGA_SPECIES, None),


### PR DESCRIPTION
Closes #321.

## Confirmed on a healthy host first

Per #301, local Cargo results only count on a host that clears the fault check. This host does:
`session-ownership-check print-path-modules` **12/12**, 10× 256 MiB SHA-256 triple-hash stable,
**no swap configured**, and `git fsck --full` clean. Note it is **aarch64**; the CI runner is
x86_64, so the arch-sensitive numbers below are labelled as such.

The overflow reproduces here exactly as on the GitHub runner:

```
thread 'battle_pet_purchase::executor_tests::concurrent_sessions_charge_once_grant_once_and_compensate_once_like_cpp' has overflowed its stack
fatal runtime error: stack overflow, aborting
... (signal: 6, SIGABRT: process abort signal)
```

## The fix

`#[tokio::test]` runs the body on a thread with the default 2 MiB stack, and `tokio::join!` polls
both purchase futures inline, so two debug-profile state machines over a ~729-field `WorldSession`
live on that stack at once.

The body moves unchanged into a plain `async fn`; the `#[test]` drives it through a local
`run_async_stack_test`, which is the existing `run_player_stack_test` idiom
(`crates/wow-entities/src/object_accessor.rs:1532`) adapted to an async body — a thread with a
32 MiB stack owning a current-thread runtime, with the panic payload resumed so assertion
messages survive. Both sessions still race concurrently and every assertion is identical.

Rejected alternatives, both measured rather than assumed:

- **`RUST_MIN_STACK`** — the retired preflight ran at 8 GiB
  (`docs/migration/inventory/r8-entities-miniphase.md:393`), which is why this never surfaced
  locally. Raising it in CI hides the cause the audit exists to find.
- **`Box::pin`** — 2.137 → 2.110 MiB, still over the limit. The cost is poll-frame depth, not the
  root future held as a stack local.

## Evidence

- The named test passes, and still passes under `RUST_MIN_STACK=1048576` (1 MiB), so it no longer
  depends on the ambient thread stack at all.
- `battle_pet_purchase::` module: 55 passed, 0 failed.
- **The whole `wow-world` lib binary now runs to completion**: `3565 passed; 4 failed; 1 ignored`.
  No abort, no SIGABRT. Those four are #323, previously invisible because one overflow killed the
  binary before they ran.
- `cargo fmt --all --check` clean.

### Other tests at the same risk

Swept **every one of the 3570 tests in its own process** at fixed `RUST_MIN_STACK` values
(aarch64, debug):

| Thread stack | Tests that overflow |
|---|---|
| 2 MiB (the default) | **0** |
| 1.9 MiB (90.7 %) | 11 |
| 1 MiB (50 %) | 338 |

So nothing else exceeds the real budget, and the margin is quantified rather than guessed: 11
tests sit between 90.7 % and 100 % of the default — ten in `battle_pet_purchase::executor_tests`
and `handlers::movement::tests::player_movement_loads_active_grid_before_visibility_like_cpp`.
That is a thin margin worth its own ticket, not more 32 MiB wrappers here; any growth in those
chains re-breaks them. aarch64 debug frames are generally no smaller than x86_64's, so these
should have at least as much headroom on the CI runner, and the audit after #323 will confirm it.

## Done criteria

- [x] The test passes without any stack-size override (verified down to a 1 MiB thread).
- [x] It still exercises both sessions concurrently and asserts the same outcomes.
- [x] Any other test at the same risk is fixed or shown not to be at risk (per-test sweep above).
- [ ] A full Validation V2 audit runs green on the merge commit — **blocked by #323**: the four
      deterministic failures this fix uncovers are still red. `validation-v2 final` on this branch
      is red for exactly those four and nothing else.