### PR TITLE
Fix four wow-world tests the stack-overflow abort hid

### DIFF
--- a/crates/wow-world/src/handlers/character_tests.rs
+++ b/crates/wow-world/src/handlers/character_tests.rs
@@ -6180,7 +6180,28 @@ fn committed_money_callers_publish_all_runtime_state_before_reopening_admission(
         include_str!("character/visibility.rs"),
         include_str!("character/world_entry.rs"),
     );
-    let session = include_str!("../session/dispatch.rs");
+    // #236 split the former `session.rs` into `session/mod.rs` plus feature
+    // modules, and the committed-money callers stayed in `mod.rs`. Scan the
+    // whole session family so a later move fails on the assertion below
+    // instead of silently scanning a file that no longer holds the segment.
+    let session = concat!(
+        include_str!("../session/mod.rs"),
+        include_str!("../session/admission.rs"),
+        include_str!("../session/connection.rs"),
+        include_str!("../session/directory.rs"),
+        include_str!("../session/dispatch.rs"),
+        include_str!("../session/driver/mod.rs"),
+        include_str!("../session/driver/budget.rs"),
+        include_str!("../session/driver/phases.rs"),
+        include_str!("../session/lifecycle/mod.rs"),
+        include_str!("../session/lifecycle/cleanup.rs"),
+        include_str!("../session/lifecycle/login.rs"),
+        include_str!("../session/lifecycle/logout.rs"),
+        include_str!("../session/mailbox/mod.rs"),
+        include_str!("../session/mailbox/durable.rs"),
+        include_str!("../session/mailbox/protocol.rs"),
+        include_str!("../session/mailbox/pump.rs"),
+    );
     assert_publication_segment(
         character,
         "bank-slot purchase",

--- a/crates/wow-world/src/session_tests.rs
+++ b/crates/wow-world/src/session_tests.rs
@@ -35985,7 +35985,13 @@ fn player_exit_visibility_refresh_uses_same_full_diff_like_cpp() {
     session.set_player_position_like_cpp(Position::ZERO);
 
     let (self_tx, _self_rx) = flume::bounded(1);
-    registry.register_or_replace(guid, broadcast_info(guid, self_tx), Default::default());
+    // Cleanup unregisters through the owning control channel (#243), so this
+    // session's own entry must carry its command sender.
+    registry.register_or_replace(
+        guid,
+        broadcast_info_with_command(guid, self_tx, session.session_command_tx()),
+        Default::default(),
+    );
     registry.register_or_replace(
         nearby_guid,
         broadcast_info_with_command(nearby_guid, nearby_tx, nearby_command_tx),
@@ -36172,7 +36178,13 @@ fn loaded_customizations_refresh_already_registered_player_like_cpp() {
 
     session.set_player_guid(Some(guid));
     session.set_player_registry(Arc::clone(&registry));
-    registry.register_or_replace(guid, broadcast_info(guid, send_tx), Default::default());
+    // The session may only publish into the entry its own control channel
+    // owns (#243); login registers with exactly this sender.
+    registry.register_or_replace(
+        guid,
+        broadcast_info_with_command(guid, send_tx, session.session_command_tx()),
+        Default::default(),
+    );
 
     let customizations = vec![
         wow_packet::packets::update::ChrCustomizationChoiceValuesUpdate {
@@ -46695,7 +46707,7 @@ async fn spell_learn_spell_effect_row_preserves_base_grant_without_richer_author
     ));
     player_registry.register_or_replace(
         player_guid,
-        broadcast_info(player_guid, registry_send_tx),
+        broadcast_info_with_command(player_guid, registry_send_tx, session.session_command_tx()),
         Default::default(),
     );
     observer.set_player_guid(Some(observer_guid));


### PR DESCRIPTION
Closes #323.

All four are **wrong tests, not production defects**. Each broke in a refactor whose test
consequence nobody could see, because one stack overflow aborted the binary before these ran.
Classified individually against the production code and the ownership rules they encode.

## 1. `committed_money_callers_publish_all_runtime_state_before_reopening_admission`

A source-scanning guard: it asserts that after a money COMMIT there is no `.await` before the
runtime publications and the `drop(money_persistence)`. It read
`include_str!("../session/dispatch.rs")`.

#236 (`99626c1e`, 2026-08-21) split the former `session.rs` into `session/mod.rs` plus feature
modules and repointed this include from `../session.rs` to `../session/dispatch.rs` — but the
durability-repair money callers stayed in `session/mod.rs` (`:21482`, `:21637`). The guard has
been scanning a file without its subject ever since, which is exactly what
`missing operation marker "single item durability repair"` was saying.

It now scans the whole session family, so the same class of move fails on the marker assertion
rather than picking an arbitrary file. **With the real source in view the guarded property
holds** — no `.await` in either repair segment, and every required runtime publication precedes
the guard drop. Nothing in production changed.

## 2–4. The three registry tests

- `loaded_customizations_refresh_already_registered_player_like_cpp`
- `player_exit_visibility_refresh_uses_same_full_diff_like_cpp`
- `spell_learn_spell_effect_row_preserves_base_grant_without_richer_authority_like_cpp`

One cause. Each registers **the session's own** entry with `broadcast_info(...)`, and that helper
mints a *fresh, unrelated* command channel (`session_tests.rs:35604`). #243 made the registry
verify the owning control channel before it accepts a write —
`publish_broadcast_info_for_control_channel` (`session/directory.rs:898`) and
`unregister_control_channel` (`:668`) both require `same_channel` — precisely so a stale session
cannot overwrite its replacement, which is this port's stand-in for C++'s single live `Player*`
owner. Production registers with `command_tx: self.session_command_tx.clone()`
(`session/mod.rs:34845`).

So the fixtures asked a session to mutate an entry it does not own, the registry correctly
refused, and the tests asserted a state login cannot produce. They now register through
`session.session_command_tx()`, the same helper the already-passing tests use
(`session_tests.rs:8919`). No production change.

## The fifth, under `--test-threads=1`

`legacy_creature_call_assistance_engages_same_faction_after_delay_like_cpp` **does not reproduce
on a healthy host**: 20/20 in isolation under `--test-threads=1`, plus three full serial suite
runs green. It was measured on the #301 host, whose Cargo results are not authority. No ticket is
warranted; if it returns on a runner it should be filed with that run as evidence.

## Evidence

Host cleared first (#301): `print-path-modules` 12/12, memory triple-hash stable, no swap,
`git fsck --full` clean. aarch64.

- Full `wow-world` lib binary, parallel: **3569 passed; 0 failed; 1 ignored**.
- Same binary, `--test-threads=1`, three consecutive runs: **3569 passed; 0 failed** each time.
- **Mutation check that the fixed tests still bite**: stubbing out
  `sync_player_registry_state_like_cpp`, the customizations publish, or
  `unregister_from_player_registry` makes the corresponding test fail. They assert production
  behavior, not their own fixture.
- `./tools/validation-v2 final --base origin/3.4.3` — **exit 0** (diff hygiene, whitespace,
  `cargo fmt --all --check`, `cargo check --locked --tests` over the reverse closure
  `world-modules`/`world-server`/`wow-world`, `cargo test --locked --lib -p wow-world`).

## Done criteria

- [x] Each of the four is classified: all four are wrong tests, cause named per test.
- [x] Each is fixed with its cause named, not silenced.
- [x] The `--test-threads=1` fifth is shown not to reproduce on a sound host.
- [ ] `cargo test --locked -p wow-world --lib` green in a GitHub audit run — the audit on the
      merge commit is the remaining check, and it is the one #302 needs.