### PR TITLE
Discover protoc instead of naming a retired host

### DIFF
--- a/.agents/skills/refactor-rustycore-safely/SKILL.md
+++ b/.agents/skills/refactor-rustycore-safely/SKILL.md
@@ -111,7 +111,7 @@ explicitly for protobuf-dependent crates. Run:
 ```bash
 cargo fmt --all -- --check
 git diff --check
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p <affected-crate>
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo check -p <affected-crate>
 ./tools/pr-preflight.sh quick origin/3.4.3
 ```
 
@@ -120,11 +120,11 @@ library:
 
 ```bash
 # Library target:
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p <package> <focused-test> --lib
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test -p <package> <focused-test> --lib
 # Binary target such as world-server or bnet-server:
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p <package> <focused-test> --bin <binary>
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test -p <package> <focused-test> --bin <binary>
 # Integration-test target:
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p <package> <focused-test> --test <target>
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test -p <package> <focused-test> --test <target>
 ```
 
 After committing to a clean HEAD and before an authorized push, run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,10 @@ RustyCore is a Rust port of a TrinityCore-derived World of Warcraft Wrath/Cata-c
 - `main` is retained as an optional stable pointer (ff-advanced at release checkpoints); it is no
   longer the default and not used for day-to-day work. A pre-rebrand backup is `backup/pre-3.4.3-rebrand`.
 - Rust toolchain: Rust 1.98.0, edition 2024.
-- `protoc`: `/home/cdmonio/.local/protoc/bin/protoc`
+- `protoc`: `/home/ubuntu/.local/protoc/bin/protoc` (it is on `PATH`; the harnesses discover it
+  rather than hard-coding a home, so a different machine needs no edit here)
+- Development host: **aarch64**. GitHub runners are x86_64, so any measurement that depends on the
+  machine — stack budgets, timings, perf numbers — must say which of the two produced it.
 
 Do not trust existing Rust, old AI summaries, or migration docs as correctness proof. Always contrast behavior against the C++ source before implementing or approving a change.
 
@@ -132,9 +135,9 @@ Do not mark anything `manual-test-ready` unless it has actually been installed/r
 Use `PROTOC` explicitly for any command that may compile protobuf-dependent crates:
 
 ```bash
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p world-server
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-world --lib
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-map --lib
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo check -p world-server
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test -p wow-world --lib
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test -p wow-map --lib
 ```
 
 Fast iteration commands:

--- a/MIGRATION_STATUS.md
+++ b/MIGRATION_STATUS.md
@@ -241,4 +241,4 @@
 ---
 
 **Última actualización**: 2026-02-27
-**Build**: `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo build --workspace` → ✅ 0 errores, 138 handlers
+**Build**: `PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo build --workspace` → ✅ 0 errores, 138 handlers

--- a/crates/capture-diff/flows/loot-single-item-claim/README.md
+++ b/crates/capture-diff/flows/loot-single-item-claim/README.md
@@ -146,7 +146,7 @@ its descendant.
 REPO_ROOT=/absolute/path/to/your/rustycore-worktree
 cd "$REPO_ROOT"
 test -z "$(git status --porcelain=v1 --untracked-files=normal)"
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc \
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc \
   cargo build --locked -p world-server
 cargo build --locked \
   --manifest-path tools/wow-test-bot/Cargo.toml

--- a/docs/migration/claude-porting-instructions.md
+++ b/docs/migration/claude-porting-instructions.md
@@ -156,8 +156,8 @@ rg -n "can_take_quest|satisfy_quest|represented_.*like_cpp|ConditionType" crates
 
 ```bash
 cargo fmt --check
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-world --lib
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p world-server
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test -p wow-world --lib
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo check -p world-server
 git diff --check
 awk -F '\t' 'NF != 9 { print FNR ":" NF ":" $0; bad=1 } END { if (bad) exit 1; print "TSV_OK" }' docs/migration/inventory/r8-entities-miniphase.tsv
 ```

--- a/docs/migration/creature-port-no-gaps-plan.md
+++ b/docs/migration/creature-port-no-gaps-plan.md
@@ -451,9 +451,9 @@ A Creature slice is done only when all of this is true:
 - `rg -n "C#|c#|RUSTYCORE_LOGIN_UPDATEOBJECT_DIAGNOSTIC|diagnostic" crates/wow-world crates/world-server crates/wow-entities` has no Creature production behavior dependency.
 - No Creature packet, movement, runtime or NPC-service code relies on a diagnostic flag.
 - Tests pass:
-  - `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-world`
-  - `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p world-server`
-  - `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test -p wow-map`
+  - `PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test -p wow-world`
+  - `PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test -p world-server`
+  - `PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test -p wow-map`
   - targeted tests for `wow-entities`, `wow-data`, `wow-ai`, `wow-loot` if touched.
 - Real-client verification passes:
   - login to a creature-dense area,

--- a/docs/migration/login-world-load-cpp-parity-plan.md
+++ b/docs/migration/login-world-load-cpp-parity-plan.md
@@ -344,7 +344,7 @@ Acceptance:
 
 - No diagnostic behavior flags.
 - `cargo fmt --all`.
-- `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p wow-map -p wow-world -p world-server`.
+- `PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo check -p wow-map -p wow-world -p world-server`.
 - Targeted tests for touched modules.
 - Server restarted from the built binary.
 - Real client enters world, can move/control/select/interact, and no Error #132 or

--- a/docs/migration/migration-perf-strategy.md
+++ b/docs/migration/migration-perf-strategy.md
@@ -241,7 +241,7 @@ Each regression "test" is enforced by `#PERF.15` (CI perf-regression job).
 5. **`tracing` overhead is non-zero even when filtered out.** A `log_network!(trace, ...)` macro call still constructs the format args. For sub-µs hot paths, gate trace-level calls with `if tracing::enabled!(Level::TRACE)`.
 6. **Compare against C++ on the same host with the same libc, same kernel, same MariaDB build.** A C++ build with `-O3 -flto` against a Rust `Release` build with `lto = "thin"` is fair. A C++ build with `-O0` is not, and a Rust `dev` build is not.
 7. **`MapManager` is not yet wired into the live tick path** (AGENTS.md "Creature storage" section). Bench numbers for it today reflect the standalone module, not the in-flight game state. Re-bench after the migration is complete.
-8. **`PROTOC=/home/cdmonio/.local/protoc/bin/protoc`** is required to build the workspace, hence required to run benches. CI configs for perf must set it.
+8. **`PROTOC=/home/ubuntu/.local/protoc/bin/protoc`** is required to build the workspace, hence required to run benches. CI configs for perf must set it.
 9. **Prefer `samply` over `perf` on hosts where `perf_event_paranoid > 1`** and you can't change it. Same flamegraph output, different permissions model.
 10. **The C# legacy at `/home/server/woltk-server-core/Source/`** (the original C# port that this Rust project replaces) is **not** the comparison baseline. The C++ TC at `/home/server/woltk-trinity-legacy/` is. The C# numbers are uninteresting except as a "must-beat-this" floor.
 

--- a/docs/migration/migration-test-strategy.md
+++ b/docs/migration/migration-test-strategy.md
@@ -17,7 +17,7 @@ Consolidate the `[ ] Test:` items and audit-flagged "no golden vectors" findings
 
 ## 2. Current state (consolidated from §11/§13 of every per-module doc)
 
-- **Baseline.** `PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test --workspace` → **395 passed** (AGENTS.md, "Build / test"). Per-crate: `wow-crypto` 46, `wow-world` ~120 (incl. 12 `MapManager`), `wow-packet` ~50, `wow-database` ~30, rest distributed.
+- **Baseline.** `PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test --workspace` → **395 passed** (AGENTS.md, "Build / test"). Per-crate: `wow-crypto` 46, `wow-world` ~120 (incl. 12 `MapManager`), `wow-packet` ~50, `wow-database` ~30, rest distributed.
 - **Test categories present.**
   - Round-trip serialization tests (most `wow-packet` modules).
   - Internal consistency tests (`wow-crypto`: encrypt-then-decrypt matches plaintext, but with no C++ reference output).
@@ -223,7 +223,7 @@ These are the **invariants** the test suite must protect; per-module audits list
 4. **The C++ legacy at `/home/server/woltk-trinity-legacy/` is the canonical reference per AGENTS.md.** Treat it as the test-oracle. Any time a test asks "what should this byte be?", the answer comes from running the corresponding C++ function, not from inspection of the Rust output.
 5. **`_attic/` content is not a vector source.** Per AGENTS.md, `_attic/` is failed integration scaffolding. Do not bake `_attic/` outputs into golden tests; capture from C++ or the running official client only.
 6. **Tests that allocate a `MapManager` need it `Arc<RwLock<…>>` shaped per AGENTS.md** "WorldSession and creature storage" section. The legacy `WorldSession.creatures` field is `#[deprecated]`. New tests should use `MapManager` directly to avoid being rewritten when the migration finishes.
-7. **`PROTOC=/home/cdmonio/.local/protoc/bin/protoc` must be set even for `cargo test`** because `wow-proto` invokes `prost-build` in `build.rs`. CI configs that forget this fail at compile, not at test.
+7. **`PROTOC=/home/ubuntu/.local/protoc/bin/protoc` must be set even for `cargo test`** because `wow-proto` invokes `prost-build` in `build.rs`. CI configs that forget this fail at compile, not at test.
 8. **Per-crate testing is fast** — use `cargo test -p <crate> --lib` for tight loops; `--workspace` is for green-bar verification only.
 
 ---

--- a/docs/operations/db-bootstrap.md
+++ b/docs/operations/db-bootstrap.md
@@ -182,7 +182,7 @@ is ready for manual client testing.
 Preferred smoke harness:
 
 ```bash
-/home/cdmonio/projects/wow-test-bot/rust-bot/run_rustycore_login_smoke.sh
+tools/wow-test-bot/run_rustycore_login_smoke.sh
 ```
 
 Minimum expected gate:

--- a/docs/operations/local-first-development.md
+++ b/docs/operations/local-first-development.md
@@ -52,7 +52,7 @@ monolithic library suite merely because a file moved or a branch was rebased. Ru
 explicitly when behavior changes, for example:
 
 ```bash
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc \
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc \
   cargo test --locked -p wow-world exact_test_name --lib
 ```
 

--- a/docs/world-entry-implementation.md
+++ b/docs/world-entry-implementation.md
@@ -1035,9 +1035,9 @@ assert_eq!(last4, &[0x00, 0x00, 0xFF, 0xFF]);
 ### Build and Test Commands
 
 ```bash
-export PATH="/home/cdmonio/.cargo/bin:/usr/bin:/usr/local/bin:/bin:$PATH"
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo test --workspace
-PROTOC=/home/cdmonio/.local/protoc/bin/protoc cargo check -p world-server
+export PATH="$HOME/.cargo/bin:/usr/bin:/usr/local/bin:/bin:$PATH"
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test --workspace
+PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo check -p world-server
 ```
 
 ### Debugging Checklist

--- a/tools/local-harness.sh
+++ b/tools/local-harness.sh
@@ -218,10 +218,10 @@ if ((workflow_changed == 1)); then
 fi
 
 if ((workspace_rust == 1 || architecture_checker == 1 || wow_test_bot == 1)); then
-  if [[ -x /home/cdmonio/.local/protoc/bin/protoc ]]; then
-    export PROTOC=/home/cdmonio/.local/protoc/bin/protoc
-  elif command -v protoc >/dev/null 2>&1; then
+  if command -v protoc >/dev/null 2>&1; then
     export PROTOC="$(command -v protoc)"
+  elif [[ -x "$HOME/.local/protoc/bin/protoc" ]]; then
+    export PROTOC="$HOME/.local/protoc/bin/protoc"
   fi
 fi
 

--- a/tools/pr-preflight.sh
+++ b/tools/pr-preflight.sh
@@ -373,7 +373,6 @@ resolve_protoc() {
     if command -v protoc >/dev/null 2>&1; then
       candidates+=("$(command -v protoc)")
     fi
-    candidates+=(/home/cdmonio/.local/protoc/bin/protoc)
   fi
 
   if ((DRY_RUN)); then


### PR DESCRIPTION
Closes #326.

Development moved to a new server; the repository still encoded the old one.

- `tools/local-harness.sh:221` guarded on `-x /home/cdmonio/.local/protoc/bin/protoc`, so on this
  host the guard simply failed and `PROTOC` was never exported. It now prefers
  `command -v protoc` and falls back to `$HOME/.local/protoc/bin/protoc`, which needs no edit on
  the next machine. `tools/pr-preflight.sh` drops the same absolute candidate; it already had both
  portable ones.
- `AGENTS.md`, the operations docs, the agent skill and the plan/README command examples name this
  host's path (`/home/ubuntu/.local/protoc/bin/protoc`, `libprotoc 28.3`, matching
  `.protoc-version`).
- Two other examples that would fail as written: the login smoke script is
  `tools/wow-test-bot/run_rustycore_login_smoke.sh` in-repo, not an external `rust-bot` copy, and
  the PATH export uses `$HOME/.cargo/bin`.
- `AGENTS.md` records that this host is **aarch64** while GitHub runners are x86_64, so
  machine-shaped measurements (stack budgets, timings) always say which one produced them — see
  #321.

**Left as recorded, deliberately:** the frozen `current-session-handoff.md` append-log and the two
r8-entities inventories hold 1331 of the 1362 occurrences, all inside historical "checks run"
entries. Rewriting them would claim past commands ran against a path that did not exist then.
Capture provenance was checked and contains no stale-host reference at all.

The #301 re-validation named in the issue is evidence, not a code change, and is posted on #301
itself: `print-path-modules` 12/12, ten 256 MiB SHA-256 triple-hashes stable, no swap configured,
`git fsck --full` clean.

## Evidence

`./tools/validation-v2 final --base origin/3.4.3` — exit 0: diff hygiene, whitespace over all 14
changed files, `bash -n` on both harnesses, `cargo fmt --all --check`, and the capture-diff
package check plus its lib tests (the README lives in that crate).