### PR TITLE
Own the determinism contract in the runner as an allowlist

### DIFF
--- a/.github/workflows/validation-determinism.yml
+++ b/.github/workflows/validation-determinism.yml
@@ -1,0 +1,114 @@
+name: Validation determinism
+
+# Twenty isolated runs of one profile on twenty independent hosts, compared
+# through the runner's own normalised manifest form. Manual only: this is
+# evidence for #302, not a gate.
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: Profile repeated in every job
+        required: true
+        default: self-test
+        type: choice
+        options:
+          - self-test
+          - quick
+          - final
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  repeat:
+    name: Determinism run ${{ matrix.run }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        run:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+          - 13
+          - 14
+          - 15
+          - 16
+          - 17
+          - 18
+          - 19
+          - 20
+    steps:
+      - name: Check out exact SHA
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install pinned Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+          rustflags: ""
+
+      - name: Run the profile and normalise its manifest
+        env:
+          PROFILE: ${{ inputs.profile }}
+          VALIDATION_V2_MANIFEST: ${{ runner.temp }}/manifest.json
+        run: |
+          set -euo pipefail
+          base="$(git rev-parse HEAD~1)"
+          ./tools/validation-v2 "$PROFILE" --base "$base"
+          ./tools/validation-v2 verify --manifest "$VALIDATION_V2_MANIFEST"
+          ./tools/validation-v2 normalize --manifest "$VALIDATION_V2_MANIFEST" \
+            > "${RUNNER_TEMP}/normalised.json"
+
+      - name: Upload the normalised manifest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: determinism-${{ matrix.run }}
+          path: ${{ runner.temp }}/normalised.json
+          if-no-files-found: error
+          retention-days: 14
+
+  compare:
+    name: Compare the twenty runs
+    needs: repeat
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Download every normalised manifest
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: determinism-*
+          path: normalised
+
+      - name: One form, or name the difference
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find normalised -name normalised.json | sort)
+          test "${#files[@]}" -eq 20
+          sha256sum "${files[@]}"
+          unique="$(sha256sum "${files[@]}" | awk '{print $1}' | sort -u | wc -l)"
+          if [ "$unique" -ne 1 ]; then
+            echo "::error::${unique} distinct normalised manifests across 20 runs"
+            for file in "${files[@]:1}"; do
+              diff -u "${files[0]}" "$file" || true
+            done
+            exit 1
+          fi
+          echo "20 runs, one normalised form"

--- a/docs/operations/validation-v2.md
+++ b/docs/operations/validation-v2.md
@@ -90,6 +90,57 @@ path. Timestamps, durations, peak RSS, PIDs, and explicitly selected result path
 the profile, provenance, resource policy, routing, command declarations, statuses, and exit
 semantics are stable for an unchanged checkout.
 
+## Determinism
+
+Two runs of the same profile on the same commit must produce the same manifest once the fields
+that cannot repeat are removed. The runner owns that comparison form:
+
+```bash
+./tools/validation-v2 normalize --manifest <path>
+```
+
+The contract is an **allowlist**, not a denylist: every field a manifest may carry is named in the
+runner, so a field added later fails the comparison instead of slipping through it. Dropped:
+`run_id`, `started_at`, `ended_at`, `duration_seconds`, `peak_child_rss_kib`, and the three
+timestamps inside each command. Replaced with a placeholder because they describe the host, not
+the run: `provenance.repository_root`, `provenance.kernel`, `resources.memory_limit_kib`,
+`locks.repository`, `locks.heavy`. Everything else — profile, status, exit code, runner error and
+signal, HEAD, dirty state, both Rust versions, the entire plan, and every command's argv, section,
+status, failure kind, OOM delta and signal reports — is compared exactly.
+
+Twenty local runs, keeping every manifest:
+
+```bash
+dir=$(mktemp -d)
+for run in $(seq 1 20); do
+  VALIDATION_V2_MANIFEST="$dir/$run.json" ./tools/validation-v2 self-test > /dev/null
+  ./tools/validation-v2 normalize --manifest "$dir/$run.json" > "$dir/$run.norm"
+done
+sha256sum "$dir"/*.norm | awk '{print $1}' | sort -u | wc -l   # must print 1
+```
+
+Twenty isolated GitHub runs are the `Validation determinism` workflow: a 20-job matrix on
+independent hosts, each running one profile, verifying its manifest and uploading the normalised
+form, followed by a job that fails with a diff unless all twenty hash identically. It is
+`workflow_dispatch` only — evidence, not a gate.
+
+## Fresh clone
+
+The documented path must work with no state from an older worktree, target directory or generated
+artifact. Cargo is forced offline, so the procedure is the one CI uses:
+
+```bash
+git clone https://github.com/alseif0x/rustycore.git fresh && cd fresh
+cargo fetch --locked
+cargo fetch --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml
+cargo fetch --locked --manifest-path tools/wow-test-bot/Cargo.toml
+./tools/validation-v2 self-test
+./tools/validation-v2 quick --base HEAD~1
+```
+
+`--base HEAD~1` is deliberate: at `origin/3.4.3` a fresh clone has no changed paths, so the
+profiles would plan nothing and prove nothing.
+
 An `audit` also acquires `/tmp/rustycore-validation-v2-heavy.lock`. That lock is deliberately not
 derived from the checkout path, so audits in independent clones and worktrees cannot overlap on
 one host. Lock diagnostics identify the active run id, PID, repository, HEAD, profile and start

--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -58,23 +58,8 @@ def synthetic_metadata(repo: Path) -> dict[str, object]:
 
 
 def stable_manifest(value: object) -> object:
-    """Remove fields that are expected to vary between otherwise identical runs."""
-    volatile = {
-        "run_id",
-        "started_at",
-        "ended_at",
-        "duration_seconds",
-        "peak_child_rss_kib",
-    }
-    if isinstance(value, dict):
-        return {
-            key: stable_manifest(item)
-            for key, item in value.items()
-            if key not in volatile
-        }
-    if isinstance(value, list):
-        return [stable_manifest(item) for item in value]
-    return value
+    """The runner owns the comparison form; the fixture must not keep a rival copy."""
+    return runner.normalise_manifest(value)
 
 
 def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], directory: Path) -> None:
@@ -185,6 +170,56 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     assert child_signal["signal"] is None
     assert child_signal["failure_kind"] == "child-signal"
     assert child_signal["child_signal_reports"] == [{"signal": 6, "name": "SIGABRT"}]
+
+    # The comparison form is an allowlist: a new field cannot slip through it.
+    for mutation, expected in (
+        ({"invented_at_top": 1}, "manifest carries unknown field(s): invented_at_top"),
+        (
+            {"provenance": {**success["provenance"], "hostname": "x"}},
+            "provenance carries unknown field(s): hostname",
+        ),
+        (
+            {"resources": {**success["resources"], "swap_kib": 0}},
+            "resources carries unknown field(s): swap_kib",
+        ),
+        (
+            {"plan": {**success["plan"], "future_field": []}},
+            "plan carries unknown field(s): future_field",
+        ),
+        (
+            {"commands": [{**success["commands"][0], "cpu_seconds": 1}]},
+            "command 0 carries unknown field(s): cpu_seconds",
+        ),
+    ):
+        try:
+            runner.normalise_manifest({**success, **mutation})
+        except ValueError as error:
+            assert str(error) == expected, (str(error), expected)
+        else:
+            raise AssertionError(f"the contract accepted {sorted(mutation)}")
+
+    # Host-shaped values are placeheld, never compared literally.
+    comparison = runner.normalise_manifest(success)
+    assert comparison["provenance"]["repository_root"] == runner.PLACEHOLDER
+    assert comparison["provenance"]["kernel"] == runner.PLACEHOLDER
+    assert comparison["locks"]["repository"] == runner.PLACEHOLDER
+    assert comparison["locks"]["heavy"] is None
+    assert comparison["provenance"]["head"] == success["provenance"]["head"]
+    assert "run_id" not in comparison and "started_at" not in comparison
+    assert all(
+        "duration_seconds" not in command for command in comparison["commands"]
+    )
+
+    normalised = subprocess.run(
+        [str(tools / "validation-v2"), "normalize", "--manifest", str(success_manifest)],
+        cwd=repo,
+        env=base_env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert normalised.returncode == 0, normalised.stderr
+    assert json.loads(normalised.stdout) == comparison
 
     # Classification order, including the OOM case a host cannot be forced into.
     assert runner.classify_failure(0, None, False, 0, []) is None

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -214,6 +214,115 @@ def write_manifest(path: Path, document: dict[str, object]) -> None:
     os.replace(temporary, path)
 
 
+# The determinism contract. Every key a manifest may carry is named here, so a
+# field added later fails the comparison instead of escaping a denylist.
+DROPPED_FIELDS = frozenset(
+    {"run_id", "started_at", "ended_at", "duration_seconds", "peak_child_rss_kib"}
+)
+DROPPED_COMMAND_FIELDS = frozenset({"started_at", "ended_at", "duration_seconds"})
+NORMALISED_FIELDS = {
+    ("provenance", "repository_root"),
+    ("provenance", "kernel"),
+    ("resources", "memory_limit_kib"),
+    ("locks", "repository"),
+    ("locks", "heavy"),
+}
+COMPARED_SHAPE: dict[str, frozenset[str]] = {
+    "": frozenset(
+        {
+            "schema", "runner", "shadow_only", "profile", "status", "exit_code",
+            "runner_signal", "runner_error", "provenance", "resources", "locks",
+            "plan", "commands",
+        }
+    ),
+    "provenance": frozenset({"head", "dirty", "rust", "repository_root", "kernel"}),
+    "provenance.rust": frozenset({"pinned", "active"}),
+    "resources": frozenset({"cargo_jobs", "command_timeout_seconds", "memory_limit_kib"}),
+    "locks": frozenset({"repository", "heavy"}),
+    "plan": frozenset(
+        {
+            "base_input", "base_commit", "changed_paths", "path_classes", "workspace",
+            "metadata", "optional_skips", "planned_steps", "planned_commands",
+        }
+    ),
+    "command": frozenset(
+        {
+            "argv", "section", "exit_code", "signal", "timed_out", "oom_kills",
+            "child_signal_reports", "failure_kind", "status",
+        }
+    ),
+}
+PLACEHOLDER = "<normalised>"
+
+
+def normalise_command(command: object, where: str) -> dict[str, object]:
+    if not isinstance(command, dict):
+        raise ValueError(f"{where} is not an object")
+    unknown = sorted(set(command) - COMPARED_SHAPE["command"] - DROPPED_COMMAND_FIELDS)
+    if unknown:
+        raise ValueError(f"{where} carries unknown field(s): {', '.join(unknown)}")
+    return {
+        key: value for key, value in command.items() if key not in DROPPED_COMMAND_FIELDS
+    }
+
+
+def normalise_manifest(document: object) -> dict[str, object]:
+    """The exact comparison form: volatile dropped, host-shaped placeheld, rest exact."""
+    if not isinstance(document, dict):
+        raise ValueError("manifest is not an object")
+    unknown = sorted(set(document) - COMPARED_SHAPE[""] - DROPPED_FIELDS)
+    if unknown:
+        raise ValueError(f"manifest carries unknown field(s): {', '.join(unknown)}")
+    result: dict[str, object] = {}
+    for key, value in document.items():
+        if key in DROPPED_FIELDS:
+            continue
+        if key in {"provenance", "resources", "locks"}:
+            if not isinstance(value, dict):
+                raise ValueError(f"{key} is not an object")
+            section_unknown = sorted(set(value) - COMPARED_SHAPE[key])
+            if section_unknown:
+                raise ValueError(
+                    f"{key} carries unknown field(s): {', '.join(section_unknown)}"
+                )
+            section = {}
+            for name, item in value.items():
+                if (key, name) in NORMALISED_FIELDS:
+                    section[name] = None if item is None else PLACEHOLDER
+                elif key == "provenance" and name == "rust":
+                    if not isinstance(item, dict) or set(item) != COMPARED_SHAPE[
+                        "provenance.rust"
+                    ]:
+                        raise ValueError("provenance.rust does not match its shape")
+                    section[name] = item
+                else:
+                    section[name] = item
+            result[key] = section
+        elif key == "plan":
+            if value is None:
+                result[key] = None
+                continue
+            if not isinstance(value, dict):
+                raise ValueError("plan is not an object")
+            plan_unknown = sorted(set(value) - COMPARED_SHAPE["plan"])
+            if plan_unknown:
+                raise ValueError(f"plan carries unknown field(s): {', '.join(plan_unknown)}")
+            plan = dict(value)
+            if plan.get("metadata") is not None:
+                plan["metadata"] = normalise_command(plan["metadata"], "plan.metadata")
+            result[key] = plan
+        elif key == "commands":
+            if not isinstance(value, list):
+                raise ValueError("commands is not a list")
+            result[key] = [
+                normalise_command(command, f"command {index}")
+                for index, command in enumerate(value)
+            ]
+        else:
+            result[key] = value
+    return result
+
+
 def nul_paths(repo: Path, *command: str) -> list[str]:
     data = subprocess.check_output(command, cwd=repo)
     try:
@@ -903,18 +1012,41 @@ def verify_manifest(path: Path) -> int:
     return 0
 
 
+def normalise_to_stdout(path: Path) -> int:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as error:
+        return fail(f"manifest {path} is unreadable: {error}", VERDICT_ERROR)
+    try:
+        document = json.loads(raw)
+    except json.JSONDecodeError as error:
+        return fail(f"manifest {path} is not valid JSON: {error}", VERDICT_ERROR)
+    try:
+        normalised = normalise_manifest(document)
+    except ValueError as error:
+        return fail(f"manifest {path}: {error}", VERDICT_ERROR)
+    print(json.dumps(normalised, indent=2, sort_keys=True))
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(prog="tools/validation-v2")
-    parser.add_argument("profile", choices=("self-test", "quick", "final", "audit", "verify"))
+    parser.add_argument(
+        "profile", choices=("self-test", "quick", "final", "audit", "verify", "normalize")
+    )
     parser.add_argument("--base", default=DEFAULT_BASE)
-    parser.add_argument("--manifest", help="manifest to verify with the verify profile")
+    parser.add_argument(
+        "--manifest", help="manifest for the verify and normalize profiles"
+    )
     args = parser.parse_args()
-    if args.profile == "verify":
+    if args.profile in {"verify", "normalize"}:
         if not args.manifest:
-            return fail("verify requires --manifest")
-        return verify_manifest(Path(args.manifest))
+            return fail(f"{args.profile} requires --manifest")
+        if args.profile == "verify":
+            return verify_manifest(Path(args.manifest))
+        return normalise_to_stdout(Path(args.manifest))
     if args.manifest:
-        return fail("--manifest is only valid with the verify profile")
+        return fail("--manifest is only valid with the verify and normalize profiles")
     install_interrupt_handlers()
     repo = Path(__file__).resolve().parent.parent
     try:


### PR DESCRIPTION
Refs #330. Closes the contract, local-determinism, fresh-clone and heavy-lock lines of that issue;
the twenty GitHub runs are dispatched once this is on `3.4.3`, since `workflow_dispatch` only sees
workflows that exist on the default branch.

## The contract was a denylist

`tools/test_validation_v2.py:58-75` stripped five key names at any depth. Every field #322 added —
`runner_signal`, `failure_kind`, `oom_kills`, `child_signal_reports`, `memory_limit_kib` — would
have escaped it silently, and so would the next one.

`normalise_manifest` now names every field a manifest may carry and **rejects anything else**:

- **dropped**: `run_id`, `started_at`, `ended_at`, `duration_seconds`, `peak_child_rss_kib`, and
  the three timestamps inside each command;
- **placeheld** (host, not run): `provenance.repository_root`, `provenance.kernel`,
  `resources.memory_limit_kib`, `locks.repository`, `locks.heavy`;
- **compared exactly**: everything else — profile, status, exit code, runner error and signal,
  HEAD, dirty, both Rust versions, the entire plan, and each command's argv, section, status,
  failure kind, OOM delta and signal reports.

`validation-v2 normalize --manifest <path>` prints that form, so local runs and CI compare through
one implementation. `stable_manifest` in the fixture becomes a one-line call to it.

## Evidence

- **Twenty sequential local runs → one form.** 20× `self-test` with separate manifests, each
  normalised: `sha256` of all twenty is `33d0ffe152308bfc4293bce679732ef1d2d278929503f1fd082ae6dd214fb945`,
  one unique hash.
- **The allowlist bites.** New focused tests assert a rejection with the exact message for an
  unknown field at the top level and inside `provenance`, `resources`, `plan` and a command, plus
  that host fields are placeheld, volatile fields are gone, HEAD survives, and the CLI output
  equals the in-process form.
- **Fresh clone, no prior state.** Cloned from the remote into a new directory,
  `cargo fetch --locked` ×3 as CI does, then `self-test` (exit 0) and `quick --base HEAD~1`
  (exit 0, cold `cargo check --locked --tests -p wow-world`). `--base HEAD~1` is deliberate: at
  `origin/3.4.3` a fresh clone has no changed paths and would prove nothing.
- **Heavy jobs cannot overlap, and the refusal names the owner.** With an `audit` running in
  `/home/server/rustycore`, a second `audit` in the same worktree exited **75** on
  `rustycore-validation-v2-<digest>.lock`, and an `audit` from the independent fresh clone exited
  **75** on `/tmp/rustycore-validation-v2-heavy.lock`. Both named the active `run_id`, PID,
  repository, HEAD, profile and start time.
- `python3 tools/test_validation_v2.py` — passed. `./tools/validation-v2 final --base origin/3.4.3`
  — exit 0.
- Both pinned action SHAs verified against the upstream tags.

## The twenty GitHub runs

`Validation determinism` is `workflow_dispatch` only — evidence, not a gate. Twenty independent
hosts each run one profile, verify the manifest, and upload the normalised form; a final job fails
with a diff unless all twenty hash identically. The result will be posted to #330 and #302.