### PR TITLE
Give the validation job a static check name

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -28,7 +28,10 @@ env:
 
 jobs:
   validation:
-    name: Validation V2 ${{ github.event_name == 'pull_request' && 'final' || github.event.inputs.profile || 'audit' }}
+    # A static name on purpose: a skipped job publishes its check under the raw,
+    # unexpanded expression, so a templated name cannot be a required context.
+    # The profile is reported inside the run instead.
+    name: Validation V2
     # First-party pull requests use explicit local evidence and must not wait
     # for hosted validation. Push/audit enforcement still validates the merged
     # exact SHA on an independent host. External pull requests retain the
@@ -136,6 +139,7 @@ jobs:
           RUSTYCORE_CPP_REFERENCE_ROOT: ${{ runner.temp }}/trinity-reference
         run: |
           test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
+          echo "Profile: ${PROFILE}" >> "$GITHUB_STEP_SUMMARY"
           ./tools/validation-v2 "$PROFILE" --base "$BASE_SHA"
 
       - name: Verify Validation V2 manifest verdict


### PR DESCRIPTION
Part of #336. The protection change itself follows once this is on `3.4.3` and the new context has
reported at least once.

Branch protection cannot require a templated job name. When the job is skipped before evaluation —
which is every first-party pull request — GitHub publishes the check under the **raw, unexpanded**
expression. On PR #324 the reported name was literally:

```
Validation V2 ${{ (((github.event_name == 'pull_request') && 'final') || github.event.inputs.profile || 'audit') }}
```

So requiring `Validation V2 final` would leave protection exactly as broken as the three dead
contexts leave it today, only for a subtler reason.

The job is now named `Validation V2` in every event, and the profile it ran is written to the run
summary instead of into the check name. The artifact name keeps the profile, since it is not a
required context.

Evidence: `./tools/validation-v2 final --base origin/3.4.3` — exit 0; the workflow parses and the
job name resolves to the literal `Validation V2`.