### PR TITLE
Document the branch protection contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,9 +423,15 @@ git push origin <feature-branch>        # NO push unless asked
 
 Only do this after the slice is genuinely validated. If the tree contains changes from another agent, audit them before building on top of them.
 
-Branch protection on `3.4.3` keeps linear history and conversation resolution. Remote validation
-jobs are author-gated: they skip for the exact trusted login `alseif0x` and remain required for
-external authors. Never broaden trust to an author-association role.
+Branch protection on `3.4.3` requires strict status checks, linear history, conversation
+resolution, and exactly two contexts: **`Validation V2`** and **`Codex reviewer verdict`**. Both
+are author-gated jobs: they report `skipped` for the exact trusted login `alseif0x`, which
+satisfies protection, and they run for every other author. Never broaden trust to an
+author-association role.
+
+The validation job's name is deliberately static. A skipped job publishes its check under the raw,
+unexpanded expression, so a templated name cannot be a required context (#336); the profile it ran
+is in the run summary instead.
 
 ## Local Context Files
 

--- a/docs/operations/local-first-development.md
+++ b/docs/operations/local-first-development.md
@@ -73,6 +73,17 @@ job; what runs at merge is the enforcement nobody was performing. A failure ther
 already on `3.4.3`, so it should produce a focused issue and a fix on top, not a retroactive review
 cycle over intermediate commits — the same rule the scheduled audit follows.
 
+## Branch protection
+
+`3.4.3` requires strict status checks, linear history, conversation resolution, and two contexts:
+`Validation V2` and `Codex reviewer verdict`. Both skip for the trusted author and run for
+everyone else, and a skipped required check satisfies protection — which is exactly why the
+merge-cadence audit above exists.
+
+The validation job carries a static name on purpose: GitHub publishes a skipped job's check under
+the raw, unexpanded name expression, so a templated name can never be satisfied as a required
+context.
+
 ## Trust boundary
 
 Do not broaden the trusted condition to `COLLABORATOR`, `MEMBER`, or an author-association class.


### PR DESCRIPTION
Closes #336.

Protection on `3.4.3` now requires strict status checks, linear history, conversation resolution,
and exactly two contexts: **`Validation V2`** and **`Codex reviewer verdict`**.

The three contexts from the workflow #316 replaced — `Format`, `Check core crates`,
`Focused library tests` — are removed. Nothing had reported them since that replacement, so every
pull request sat permanently `BLOCKED` and merged only by administrator override. `AGENTS.md` and
`docs/operations/local-first-development.md` now describe what is actually enforced, including why
the validation job's name has to be static.

**This pull request is the test of the change**: it is merged with the normal button, with no
administrator override. If the required contexts were still wrong it could not be.

Before / after, from the API:

```
before: ["Format", "Check core crates", "Focused library tests", "Codex reviewer verdict"]
after:  ["Codex reviewer verdict", "Validation V2"]
strict: true | linear: true | conversation: true | force-push: false | deletions: false
```

Evidence: `./tools/validation-v2 final --base origin/3.4.3` — exit 0.