### PR TITLE
Derive the mirrored issue state instead of maintaining it

### DIFF
--- a/.github/workflows/issue-state-drift.yml
+++ b/.github/workflows/issue-state-drift.yml
@@ -1,0 +1,37 @@
+name: Issue state drift
+
+# The architecture ledgers mirror GitHub issue state, and two guards read it:
+# a dependency exception owned by a completed issue, and a PlayerBroadcastInfo
+# field whose cutover issue has closed. A stale mirror silently disarms both,
+# which is what #258 and #299 each had to repair by hand. This job is the third
+# repair: it fails as soon as the mirror drifts, and the fix is one command.
+on:
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  drift:
+    name: Issue state drift
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out the default branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Compare the mirrored state against live issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if ! python3 tools/architecture/check_architecture.py refresh-issue-state --check; then
+            echo "::error::The architecture ledgers no longer match live issue state. Run: python3 tools/architecture/check_architecture.py refresh-issue-state"
+            exit 1
+          fi

--- a/docs/architecture/ownership-and-boundaries.md
+++ b/docs/architecture/ownership-and-boundaries.md
@@ -320,14 +320,24 @@ owner, public API, mirror, dependency, or direct storage operation.
 | `handler-module-policy.json` | handler logical-module ownership | `check_architecture.py check` and the handler contract check | reviewed by hand |
 | `world-handler-contract.tsv` | the exact world handler contract rows | the handler contract check | its own checker run |
 | `runtime-clock-phase-trace.json` | the traced runtime clock phases | `check_architecture.py check` | reviewed by hand |
-| `architecture-issue-ledger.json` | issue numbers, kinds, parents, dependencies **and mirrored open/closed state** | `check_architecture.py check` and the Session ownership check | hand-maintained |
+| `architecture-issue-ledger.json` | issue numbers, kinds, parents, dependencies and the mirrored open/closed state | `check_architecture.py check` and the Session ownership check | structure by hand; `state`/`title` by `check_architecture.py refresh-issue-state` |
 
-The last row is the one exception to "one producer": its `state` field mirrors GitHub, which
-[#302](https://github.com/alseif0x/rustycore/issues/302) names as something not to keep, and
-[#299](https://github.com/alseif0x/rustycore/issues/299) reports as drifted. Ten guard sites read
-that field (`check_architecture.py:171`, `:636`, `:640`, `:656`, `:1087`, `:1409`, `:1440` among
-them), so removing the mirror is a redesign of those guards rather than a validation change. #299
-owns that decision.
+### Issue state is derived, not maintained
+
+Two guards read mirrored issue state: a dependency exception owned by a completed issue must fail,
+and a `PlayerBroadcastInfo` field whose cutover issue has closed must fail. A stale mirror disarms
+both silently, which is how #258 and then #299 each had to repair the same class of drift by hand.
+
+The mirror is no longer hand-maintained. `check_architecture.py refresh-issue-state` derives every
+`state` and `title` from the live repository and rewrites both ledgers; `--check` reports drift and
+fails without writing, and the weekly `Issue state drift` workflow runs exactly that. The guards
+keep reading the checked-in file.
+
+Deriving beats reading issue state at check time, which was the other option #299 named: `check`
+runs inside `audit`, which is offline and hermetic by contract, and a validator that needs GitHub
+to answer would make every architecture check depend on network and API availability. The refresh
+is the only networked command in this tool, it is never called by `check`, and drift can no longer
+survive a week unnoticed.
 
 ## Audited ownership and hotspot evidence
 
@@ -647,7 +657,8 @@ display is checked against the JSON ledger:
 62. #229 — deterministic external Cargo composition;
 63. #230 — agent-neutral module CLI and skeleton;
 64. #231 — typed module configuration/fixtures;
-65. #153 — terminal architecture audit.
+65. #270 — retire the four PlayerBroadcastInfo transport endpoints;
+66. #153 — terminal architecture audit.
 
 A slice may start once its declared prerequisites are merged and its branch is current. Independent
 physical work remains parallel to semantic authority cuts. Mechanical moves use focused compile and

--- a/docs/architecture/player-broadcast-info-retirement.tsv
+++ b/docs/architecture/player-broadcast-info-retirement.tsv
@@ -10,7 +10,7 @@ base_mana	canonical Player/Unit powers	#252	query immutable CREATE power facts
 class	canonical Player identity	#252	query immutable character identity
 client_visible_guids_like_cpp	canonical Player visibility membership	#252	query versioned receiver visibility membership
 combat_reach	canonical Player/Unit combat geometry	#252	query immutable target geometry
-command_tx	Session mailbox	#140	store only an opaque incarnation-checked mailbox address
+command_tx	Session mailbox	#270	store only an opaque incarnation-checked mailbox address
 completed_achievements	canonical Player achievements	#252	query immutable achievement membership
 current_health	canonical Player/Unit vitals	#252	query immutable party/runtime vitals
 current_power	canonical Player/Unit powers	#252	query immutable party/runtime power
@@ -19,7 +19,7 @@ daily_quests_completed	canonical Player quest log	#252	query immutable daily que
 df_quests	canonical Player quest log	#252	query immutable dungeon-finder quest history
 display_id	canonical Player/Unit presentation	#252	query immutable CREATE display
 dungeon_difficulty_id	canonical Player difficulty selection	#252	query immutable difficulty selection
-durable_creature_runtime_commands_like_cpp	Session durable mailbox rail	#140	move durable rail storage and pump to Session mailbox
+durable_creature_runtime_commands_like_cpp	Session durable mailbox rail	#270	move durable rail storage and pump to Session mailbox
 enchanting_skill	canonical Player skills	#252	query immutable effective skill value
 faction_template_id	canonical Player/Unit faction	#252	query immutable faction identity
 forced_reputation_faction_ids	canonical Player reputation	#252	query immutable forced-reaction membership
@@ -59,12 +59,12 @@ player_name	canonical Player identity	#252	query immutable character identity
 position	canonical Player location under MapRuntime	#252	query immutable spatial position
 power_type	canonical Player/Unit powers	#252	query immutable active power type
 race	canonical Player identity	#252	query immutable character identity
-realm_send_tx	Session connection/mailbox	#140	store only an opaque realm-delivery endpoint
+realm_send_tx	Session connection/mailbox	#270	store only an opaque realm-delivery endpoint
 recruiter_id	Session account relationship	#252	query immutable admitted account relationship
 reputation_standings	canonical Player reputation	#252	query immutable standing
 reputation_state_flags	canonical Player reputation	#252	query immutable reputation flags
 rewarded_quests	canonical Player quest log	#252	query immutable rewarded membership
-send_tx	Session connection/mailbox	#140	store only an opaque instance-delivery endpoint
+send_tx	Session connection/mailbox	#270	store only an opaque instance-delivery endpoint
 sex	canonical Player identity	#252	query immutable character identity
 spec_id	canonical Player specialization	#252	query immutable active specialization
 this_week_contribution	canonical Player PvP progression	#252	query immutable inspect honor facts

--- a/tools/architecture/architecture-issue-ledger.json
+++ b/tools/architecture/architecture-issue-ledger.json
@@ -5,7 +5,7 @@
   "external_prerequisites": [
     {
       "number": 177,
-      "state": "open",
+      "state": "closed",
       "title": "[QA] wow-test-bot --login-only incompatible with mandatory ConnectTo flow: realm socket dropped, cross-socket fence kicks session",
       "kind": "external-prerequisite"
     }
@@ -75,6 +75,7 @@
     229,
     230,
     231,
+    270,
     153
   ],
   "issues": [
@@ -188,7 +189,7 @@
     },
     {
       "number": 140,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.MOD.MAILBOX] Extract Session mailbox protocol, durable rails and pump",
       "kind": "slice",
       "parents": [
@@ -405,7 +406,7 @@
     },
     {
       "number": 182,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.2.7c] Extract logical realm/instance connection routing",
       "kind": "slice",
       "parents": [
@@ -418,7 +419,7 @@
     },
     {
       "number": 183,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.2.7d] Extract the Session-only phase driver",
       "kind": "slice",
       "parents": [
@@ -431,7 +432,7 @@
     },
     {
       "number": 184,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.MOD.LIFECYCLE] Extract Session login and logout lifecycle modules",
       "kind": "slice",
       "parents": [
@@ -484,7 +485,7 @@
     },
     {
       "number": 188,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.RUNTIME.1] Trace current world/map clocks and phase ownership before convergence",
       "kind": "slice",
       "parents": [
@@ -496,7 +497,7 @@
     },
     {
       "number": 189,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.DB.3] Move durable loot persistence coordination out of wow-network",
       "kind": "slice",
       "parents": [
@@ -505,6 +506,19 @@
       ],
       "depends_on": [
         187
+      ]
+    },
+    {
+      "number": 270,
+      "state": "open",
+      "title": "[ARCH.RUNTIME.PLAYER.A] Retire the four transport endpoints #140 left in PlayerBroadcastInfo",
+      "kind": "slice",
+      "parents": [
+        133
+      ],
+      "depends_on": [
+        140,
+        189
       ]
     },
     {
@@ -535,7 +549,9 @@
       "parents": [
         133
       ],
-      "depends_on": [150]
+      "depends_on": [
+        150
+      ]
     },
     {
       "number": 193,
@@ -545,7 +561,9 @@
       "parents": [
         133
       ],
-      "depends_on": [150]
+      "depends_on": [
+        150
+      ]
     },
     {
       "number": 194,
@@ -555,7 +573,9 @@
       "parents": [
         133
       ],
-      "depends_on": [150]
+      "depends_on": [
+        150
+      ]
     },
     {
       "number": 195,
@@ -617,11 +637,13 @@
       "parents": [
         133
       ],
-      "depends_on": [198]
+      "depends_on": [
+        198
+      ]
     },
     {
       "number": 200,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.DB.4] Earn wow-persistence with the Player lifecycle port",
       "kind": "slice",
       "parents": [
@@ -638,152 +660,228 @@
       "state": "open",
       "title": "[ARCH.DB.1a] Resolve Self constants through the active trait impl",
       "kind": "slice",
-      "parents": [133, 169],
-      "depends_on": [186]
+      "parents": [
+        133,
+        169
+      ],
+      "depends_on": [
+        186
+      ]
     },
     {
       "number": 205,
       "state": "closed",
       "title": "[ARCH.DB.1b] Respect cfg attributes on trait associated constants",
       "kind": "slice",
-      "parents": [133, 169],
-      "depends_on": [186]
+      "parents": [
+        133,
+        169
+      ],
+      "depends_on": [
+        186
+      ]
     },
     {
       "number": 206,
       "state": "closed",
       "title": "[ARCH.PERF] Make the architecture gate fast: release profile, one scan, incremental caches",
       "kind": "slice",
-      "parents": [133],
-      "depends_on": [185]
+      "parents": [
+        133
+      ],
+      "depends_on": [
+        185
+      ]
     },
     {
       "number": 208,
       "state": "closed",
       "title": "[ARCH.PERF.1] Cut the gate's dead weight: redundant check, decorative clippy, unused scan",
       "kind": "slice",
-      "parents": [133],
-      "depends_on": [206]
+      "parents": [
+        133
+      ],
+      "depends_on": [
+        206
+      ]
     },
     {
       "number": 210,
       "state": "closed",
       "title": "[ARCH.PERF.2] Take the exact persistence scan off the PR path",
       "kind": "slice",
-      "parents": [133],
-      "depends_on": [208]
+      "parents": [
+        133
+      ],
+      "depends_on": [
+        208
+      ]
     },
     {
       "number": 213,
       "state": "closed",
       "title": "[ARCH.DB.2a] Close the persistence-trace gaps Codex found on #212",
       "kind": "slice",
-      "parents": [133, 169],
-      "depends_on": [186]
+      "parents": [
+        133,
+        169
+      ],
+      "depends_on": [
+        186
+      ]
     },
     {
       "number": 214,
       "state": "closed",
       "title": "[ARCH.2.0] Extract the test modules that make the hotspots monstrous",
       "kind": "slice",
-      "parents": [133],
-      "depends_on": [181]
+      "parents": [
+        133
+      ],
+      "depends_on": [
+        181
+      ]
     },
     {
       "number": 218,
       "state": "closed",
       "title": "[ARCH.DB.2a] Scope the persistence recorder to a workflow and correlate its transactions",
       "kind": "slice",
-      "parents": [133, 169],
-      "depends_on": [186]
+      "parents": [
+        133,
+        169
+      ],
+      "depends_on": [
+        186
+      ]
     },
     {
       "number": 220,
       "state": "closed",
       "title": "[ARCH] Charge ordinary external modules to their parent in the hotspot ratchet",
       "kind": "slice",
-      "parents": [133],
-      "depends_on": [214]
+      "parents": [
+        133
+      ],
+      "depends_on": [
+        214
+      ]
     },
     {
       "number": 223,
       "state": "closed",
       "title": "[ARCH.PLAN] Align the modular roadmap, physical metrics and local-first policy",
       "kind": "slice",
-      "parents": [133],
-      "depends_on": [220]
+      "parents": [
+        133
+      ],
+      "depends_on": [
+        220
+      ]
     },
     {
       "number": 224,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.MOD.HANDLERS] Split character, loot and quest into private feature modules",
       "kind": "slice",
-      "parents": [133],
+      "parents": [
+        133
+      ],
       "depends_on": []
     },
     {
       "number": 225,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.MOD.MAP] Split Map and MapManager into private runtime modules",
       "kind": "slice",
-      "parents": [133],
+      "parents": [
+        133
+      ],
       "depends_on": []
     },
     {
       "number": 226,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.MOD.ENTITIES] Split Player and Unit subsystems into private domain modules",
       "kind": "slice",
-      "parents": [133],
+      "parents": [
+        133
+      ],
       "depends_on": []
     },
     {
       "number": 227,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.MOD.PROTOCOL] Split packet and spell-data hotspots by protocol domain",
       "kind": "slice",
-      "parents": [133],
+      "parents": [
+        133
+      ],
       "depends_on": []
     },
     {
       "number": 228,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.MODULES.1] Land the trusted linked module API with player.login to message",
       "kind": "slice",
-      "parents": [133, 99],
+      "parents": [
+        133,
+        99
+      ],
       "depends_on": []
     },
     {
       "number": 229,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.MODULES.2] Compose external Cargo modules deterministically",
       "kind": "slice",
-      "parents": [133, 99],
-      "depends_on": [228]
+      "parents": [
+        133,
+        99
+      ],
+      "depends_on": [
+        228
+      ]
     },
     {
       "number": 230,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.MODULES.3] Ship the agent-neutral module manager and official skeleton",
       "kind": "slice",
-      "parents": [133, 99],
-      "depends_on": [229]
+      "parents": [
+        133,
+        99
+      ],
+      "depends_on": [
+        229
+      ]
     },
     {
       "number": 231,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.MODULES.4] Add typed module configuration and compatibility fixtures",
       "kind": "slice",
-      "parents": [133, 99],
-      "depends_on": [230]
+      "parents": [
+        133,
+        99
+      ],
+      "depends_on": [
+        230
+      ]
     },
     {
       "number": 252,
       "state": "open",
       "title": "[ARCH.RUNTIME.PLAYER] Retire the temporary PlayerBroadcastInfo gameplay mirror",
       "kind": "slice",
-      "parents": [133],
-      "depends_on": [138, 140, 189]
+      "parents": [
+        133
+      ],
+      "depends_on": [
+        138,
+        140,
+        189
+      ]
     }
   ]
 }

--- a/tools/architecture/check_architecture.py
+++ b/tools/architecture/check_architecture.py
@@ -3635,6 +3635,88 @@ def run_debt_ownership_fixture_tests() -> int:
     return len(fixtures)
 
 
+def github_issue_facts(repository: str | None = None) -> dict[int, tuple[str, str]]:
+    """Live issue state and title. Explicitly networked; never called by `check`."""
+    if repository is None:
+        try:
+            repository = subprocess.run(
+                ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=60,
+            ).stdout.strip()
+        except (OSError, subprocess.SubprocessError) as error:
+            raise ArchitectureError(f"cannot resolve the GitHub repository: {error}") from error
+    try:
+        listing = subprocess.run(
+            [
+                "gh", "api", "--paginate",
+                f"repos/{repository}/issues?state=all&per_page=100",
+                "--jq", r'.[] | "\(.number)\t\(.state)\t\(.title)"',
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=300,
+        ).stdout
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ArchitectureError(f"cannot read live issue state: {error}") from error
+    facts: dict[int, tuple[str, str]] = {}
+    for line in listing.splitlines():
+        number, _, rest = line.partition("\t")
+        state, _, title = rest.partition("\t")
+        if number.isdigit() and state:
+            facts[int(number)] = (state.lower(), title)
+    if not facts:
+        raise ArchitectureError("live issue listing returned nothing")
+    return facts
+
+
+def refresh_issue_state(
+    issue_ledger_path: pathlib.Path,
+    runtime_ledger_path: pathlib.Path,
+    write: bool,
+) -> int:
+    """Derive the mirrored state/title fields instead of maintaining them by hand."""
+    issue_ledger = load_json(issue_ledger_path)
+    runtime_ledger = load_json(runtime_ledger_path)
+    tracked: list[dict[str, Any]] = []
+    tracked.extend(issue_ledger.get("issues", []))
+    tracked.extend(issue_ledger.get("external_prerequisites", []))
+    tracked.extend(runtime_ledger.get("external_tracking_issues", []))
+    facts = github_issue_facts()
+    unknown = sorted(
+        entry["number"] for entry in tracked if entry.get("number") not in facts
+    )
+    if unknown:
+        raise ArchitectureError(f"tracked issues absent from the repository: {unknown}")
+    drift: list[str] = []
+    for entry in tracked:
+        state, title = facts[entry["number"]]
+        for field, value in (("state", state), ("title", title)):
+            if field in entry and entry[field] != value:
+                drift.append(f"#{entry['number']} {field}: {entry[field]!r} -> {value!r}")
+                entry[field] = value
+    for line in drift:
+        print(line)
+    if not drift:
+        print("issue state mirror is current")
+        return 0
+    if not write:
+        print(f"{len(drift)} mirrored field(s) are stale", file=sys.stderr)
+        return 1
+    for path, document in (
+        (issue_ledger_path, issue_ledger),
+        (runtime_ledger_path, runtime_ledger),
+    ):
+        path.write_text(
+            json.dumps(document, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+    print(f"refreshed {len(drift)} mirrored field(s)")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -3676,6 +3758,15 @@ def main() -> int:
         "hotspot-ratchet",
         help="enforce only the curated hotspot LOC ceilings",
     )
+    refresh_parser = subparsers.add_parser(
+        "refresh-issue-state",
+        help="derive the mirrored issue state/title fields from GitHub (networked)",
+    )
+    refresh_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report drift and fail instead of rewriting the ledgers",
+    )
     hotspots_parser = subparsers.add_parser(
         "hotspots", help="report source hotspots without enforcing a line limit"
     )
@@ -3683,6 +3774,8 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
+        if args.command == "refresh-issue-state":
+            return refresh_issue_state(args.ledger, args.runtime_ledger, not args.check)
         policy = validate_policy(load_json(args.policy))
         if args.command == "hotspot-ratchet":
             # The one ceiling an ordinary Rust diff can move. Kept separate from

--- a/tools/architecture/runtime-ownership-ledger.json
+++ b/tools/architecture/runtime-ownership-ledger.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "baseline_commit": "2d94ee51254ea4628c54ad15fa20d5342d1f2be7",
-  "curated_at": "2026-08-12",
+  "baseline_commit": "6e1299e4f16ac156fc95d90d1b340ecaab0be90c",
+  "curated_at": "2026-08-23",
   "purpose": "Offline semantic ownership, mirror, clock, retirement, and exact persistence-boundary baseline through architecture issue #186.",
   "authorities": {
     "behavior": "C++ under /home/server/woltk-trinity-legacy and committed packet/runtime traces",
@@ -99,10 +99,7 @@
         "mirror_direction": "Logical connection selection in Session points to opaque physical handles in wow-network; no gameplay state may flow back into transport.",
         "target_owner": "wow-network for physical transport and fences; transitional wow_world::session::connection, terminal wow-session, for logical routing.",
         "cutover_issues": [
-          153,
-          177,
-          182,
-          184
+          153
         ],
         "rollback_condition": "Restore the previous logical router while retaining both physical sockets if connection choice, packet bytes, FIFO fences, or stale-incarnation rejection changes.",
         "retirement_condition": "WorldSession stores only opaque transport handles and logical route state; no socket task, writer implementation, or raw network registry is owned by gameplay code."
@@ -129,8 +126,7 @@
         "mirror_direction": "No gameplay mirror is authorized; status and counters are Session-owned protocol state.",
         "target_owner": "transitional wow_world::session::{admission,dispatch}, terminal wow-session with wow-handler metadata contracts.",
         "cutover_issues": [
-          153,
-          183
+          153
         ],
         "rollback_condition": "Restore the prior private module/re-export if opcode metadata, status gates, processing mode, wildcard behavior, budgets, or packet order differs.",
         "retirement_condition": "Admission and dispatch compile as private cohesive modules, retain one concrete dispatcher, and expose no gameplay service locator."
@@ -155,9 +151,7 @@
         "mirror_direction": "Typed owner outcome to Session delivery only. Delayed payloads must not write stale gameplay values back to Player or Map.",
         "target_owner": "transitional wow_world::session::mailbox, terminal wow-session mailbox; durable map outcomes originate in wow-map.",
         "cutover_issues": [
-          140,
-          153,
-          188
+          153
         ],
         "rollback_condition": "Restore the prior protocol location without changing the queue if FIFO, capacity, acknowledgement, incarnation, overload-disconnect, or shutdown behavior changes.",
         "retirement_condition": "wow-network owns no application command payload; gameplay variants are replaced by bounded owner outcomes and Session retains only control/delivery protocol."
@@ -226,10 +220,7 @@
         "target_owner": "wow-session lifecycle orchestration over SQLx-free wow-persistence ports; wow-database remains the sole concrete SQLx/dialect adapter.",
         "cutover_issues": [
           153,
-          169,
-          184,
-          189,
-          200
+          169
         ],
         "rollback_condition": "Revert the port adapter, not the durable data, if statement/transaction/fence/publication traces differ or unknown-commit recovery is weaker.",
         "retirement_condition": "WorldSession imports no pool, row, SQLx transaction/error, raw SQL, or concrete database aggregate; lifecycle uses typed ports with equivalent failure semantics."
@@ -474,9 +465,7 @@
         "target_owner": "wow-map runtime/storage for live map entities and clocks; wow-entities for entity state; Session retains only PlayerHandle and delivery adaptation.",
         "cutover_issues": [
           28,
-          140,
-          153,
-          188
+          153
         ],
         "rollback_condition": "Flip the bounded method back to its previous authoritative implementation if phase trace, recipient set, packet order, or single-tick evidence differs; never enable both writers.",
         "retirement_condition": "Every transition has one canonical Map/Entity writer and clock, its legacy bridge is deleted, and no delivery/await/persistence occurs under Map guards."
@@ -559,9 +548,7 @@
         "mirror_direction": "Character DB loads into represented state; narrow directory snapshots publish outward. Directory or packet payloads may not become a mutable inventory/loot owner.",
         "target_owner": "wow-entities::Player inventory/economy, wow-loot for loot rules/authority, wow-persistence ports for durability, thin wow-world handlers for adaptation.",
         "cutover_issues": [
-          153,
-          189,
-          200
+          153
         ],
         "rollback_condition": "Restore the prior capability adapter if item identity, money, loot eligibility, roll order, transaction order, or packet bytes differ; do not restore raw directory access.",
         "retirement_condition": "Player/loot owners hold one mutable copy, directory projections are bounded and versioned or removed, and SQL/pool types are absent from handlers and Session."
@@ -744,8 +731,7 @@
         "target_owner": "canonical wow-entities::Player submodules and populated domain capabilities such as wow-spell; durability through wow-persistence; handlers remain adapters.",
         "cutover_issues": [
           153,
-          169,
-          200
+          169
         ],
         "rollback_condition": "Restore the previous per-capability adapter if spell/quest criteria, order, persistence, or packets differ; retain completed atomic acquisition/saga boundaries.",
         "retirement_condition": "Each complete responsibility has one Player/domain owner, one durable port, and no duplicate Session/directory mutable mirror."
@@ -841,9 +827,7 @@
         "mirror_direction": "WorldSession currently builds canonical Player snapshots and consumes selected Map outcomes. PlayerBroadcastInfo is an outward temporary projection, never a writer.",
         "target_owner": "wow-entities::Player for mutable player state and per-client visibility membership; wow-map for spatial traversal, scheduling and in-world mutation; Session for routing/delivery only.",
         "cutover_issues": [
-          153,
-          183,
-          188
+          153
         ],
         "rollback_condition": "Re-enable only the previous single owner for the bounded method if phase order, movement ACKs, visibility recipients, combat outcome, or packet order differs.",
         "retirement_condition": "Player/Map are the only mutable owners, Session retains an opaque generation-checked PlayerHandle, and all Session/directory gameplay mirrors for the migrated family are removed."
@@ -928,9 +912,7 @@
         "mirror_direction": "Auth/realm snapshots flow into Session; Player gameplay state must not flow back into identity fields.",
         "target_owner": "terminal wow-session::identity plus typed immutable realm/account policy supplied by world-server composition.",
         "cutover_issues": [
-          153,
-          182,
-          184
+          153
         ],
         "rollback_condition": "Restore the prior private constructor mapping if authentication identity, feature flags, locale/build gates, or character claims differ.",
         "retirement_condition": "Identity is a cohesive Session value with required construction fields and no gameplay/database/catalog ownership."
@@ -955,12 +937,7 @@
         "mirror_direction": "No generic mirror is authorized; any pending gameplay item belongs to a named capability and must leave this family during cutover.",
         "target_owner": "transitional wow_world::session::driver/lifecycle, terminal wow-session driver with explicit phase inputs and outputs.",
         "cutover_issues": [
-          140,
-          153,
-          182,
-          183,
-          184,
-          188
+          153
         ],
         "rollback_condition": "Restore the previous phase driver if command budgets, timer behavior, save/logout order, tick ownership, or packet order differs.",
         "retirement_condition": "The Session driver advances only Session protocol/lifecycle clocks and invokes typed owner capabilities without hidden gameplay mutation."
@@ -1118,8 +1095,7 @@
           ],
           "owner": "world-server composition currently stores concrete adapters; wow-database owns their implementation.",
           "open_retirement_issues": [
-            169,
-            200
+            169
           ],
           "retirement_condition": "Session construction supplies typed wow-persistence capability ports rather than concrete database/pool aggregates."
         },
@@ -1133,7 +1109,7 @@
           ],
           "owner": "world-server composition holds handles; the player directory owner is wow_world::session::directory, the Group owner is wow_social::group, and the Session mailbox is wow_world::session::mailbox.",
           "open_retirement_issues": [
-            140
+            153
           ],
           "retirement_condition": "Only opaque directory, mailbox and Group capability handles are composed; raw storage/payload types are absent."
         },
@@ -1147,9 +1123,7 @@
           ],
           "owner": "world-server composition stores handles; legacy and canonical runtime owners remain distinct and audited by #188.",
           "open_retirement_issues": [
-            140,
-            153,
-            188
+            153
           ],
           "retirement_condition": "Session receives only the minimal typed runtime ports/PlayerHandle and cannot select or tick duplicate map authorities."
         },
@@ -1448,7 +1422,6 @@
           ],
           "owner": "Session directory owns incarnation/addressing; canonical Player or admitted Session identity owns identity facts as assigned by the field ledger.",
           "open_retirement_issues": [
-            140,
             252
           ],
           "retirement_condition": "The directory stores only generation-checked identity/addressing handles; raw senders and broad entries do not escape."
@@ -1465,8 +1438,6 @@
           ],
           "owner": "Player/session publishes receiver-local delivery state into PlayerRegistry; Map selects spatial candidates and Player owns client-visible membership.",
           "open_retirement_issues": [
-            140,
-            188,
             252
           ],
           "retirement_condition": "Only bounded generation/versioned delivery handles remain; visibility membership is Player-owned and spatial traversal is Map-owned."
@@ -1480,7 +1451,6 @@
           ],
           "owner": "PlayerRegistry currently exposes loot snapshots and a durable persistence tracker; loot and persistence owners are separate.",
           "open_retirement_issues": [
-            189,
             252
           ],
           "retirement_condition": "No durable tracker or mutable loot authority is stored in the directory; addressing consumes typed committed outcomes."
@@ -1608,8 +1578,7 @@
           ],
           "owner": "wow-network currently defines the enum; the owning Session task is the sole consumer and logical routing owner.",
           "open_retirement_issues": [
-            140,
-            182
+            153
           ],
           "retirement_condition": "Variants live in the Session mailbox protocol and depend only on opaque transport/control contracts."
         },
@@ -1635,9 +1604,7 @@
           ],
           "owner": "wow-network currently defines payloads; canonical/legacy Map owners commit transitions and Session applies receiver-local delivery/presentation.",
           "open_retirement_issues": [
-            140,
-            153,
-            188
+            153
           ],
           "retirement_condition": "Map-owned typed outcomes replace gameplay payload variants; Session protocol retains only bounded delivery facts and never rewrites stale gameplay state."
         },
@@ -1653,9 +1620,7 @@
           ],
           "owner": "wow-network currently defines payloads; wow-loot and durable persistence coordination own decisions and commit ordering.",
           "open_retirement_issues": [
-            140,
-            153,
-            189
+            153
           ],
           "retirement_condition": "Loot owner outcomes and persistence outcomes cross the Session boundary without embedding mutable loot authority or trackers."
         },
@@ -1669,7 +1634,6 @@
           ],
           "owner": "wow-network currently defines payloads; represented Player/quest capability owns state and Session owns recipient delivery.",
           "open_retirement_issues": [
-            140,
             153
           ],
           "retirement_condition": "Quest capability returns typed outcomes and Session mailbox contains only addressing/delivery data."
@@ -1692,7 +1656,6 @@
           ],
           "owner": "wow_world::session::mailbox defines the payloads; wow_social::group owns Group transitions and Session applies receiver-local facts.",
           "open_retirement_issues": [
-            140,
             153
           ],
           "retirement_condition": "Group/social/Player outcomes are typed at their owner; Session mailbox performs generation-checked delivery without reimplementing invariants."
@@ -1721,8 +1684,7 @@
           "owner": "canonical load/spawn path supplies the source; world-server bridge performs the compatibility insertion.",
           "open_retirement_issues": [
             28,
-            153,
-            188
+            153
           ],
           "retirement_condition": "Legacy creature storage is no longer read for the complete migrated load/spawn/runtime transition."
         },
@@ -1739,9 +1701,7 @@
           "owner": "GlobalLegacy is the production transition writer; named bridge code applies only explicitly modeled outcomes to canonical state.",
           "open_retirement_issues": [
             28,
-            140,
-            153,
-            188
+            153
           ],
           "retirement_condition": "Each method executes directly under canonical Map authority and the corresponding legacy function, write-back, and delivery compatibility rail are deleted."
         },
@@ -1766,9 +1726,7 @@
           "direction": "loot release/state decisions reconcile explicit legacy and canonical creature/GameObject state without shared storage",
           "owner": "current loot handler coordinates both managers; underlying loot and map authorities remain distinct.",
           "open_retirement_issues": [
-            153,
-            188,
-            189
+            153
           ],
           "retirement_condition": "Loot reads and mutations use one canonical entity/view owner and no dual-manager reconciliation remains."
         },
@@ -1778,8 +1736,7 @@
           "direction": "unclassified; no direction or ownership may be inferred",
           "owner": "Current containing function until #188 classifies the writer and phase.",
           "open_retirement_issues": [
-            153,
-            188
+            153
           ],
           "retirement_condition": "Every discovered bridge site is assigned to a named direction/owner and a concrete method cut, or removed."
         }
@@ -1799,9 +1756,7 @@
           "id": "exact_persistence_semantic_policy",
           "owner": "persistence-boundary-workflows.json is the reviewed semantic authority; persistence-boundary-policy.json is its canonical generated projection over the exact snapshot.",
           "open_retirement_issues": [
-            153,
-            189,
-            200
+            153
           ],
           "retirement_condition": "Each non-stable group disappears with its typed capability migration; wow-database remains the sole stable concrete adapter boundary."
         }
@@ -1867,7 +1822,7 @@
         "command": "python3 tools/architecture/check_architecture.py hotspots --limit 20",
         "measurement": "two independent views: every real Rust file is reported physically, while each checked-in row is a logical owner ceiling including its reviewed private descendants; production/test/total remain independent non-growth ceilings",
         "physical_review_signals": "review a productive file around 2,000 lines; above 4,000 lines require a split plan or explicit cohesive exception; these are review signals, not daily blocking limits",
-        "baseline_commit": "c2bb8a8511ed1db170bc56230d6efd35e910b091"
+        "baseline_commit": "6e1299e4f16ac156fc95d90d1b340ecaab0be90c"
       },
       "entries": [
         {
@@ -1877,11 +1832,7 @@
           "total_lines": 170235,
           "owner": "wow-world WorldSession/application monolith.",
           "open_retirement_issues": [
-            140,
-            153,
-            182,
-            183,
-            184
+            153
           ],
           "retirement_condition": "Session is a thin protocol/lifecycle shell with no mutable Player/Map gameplay, concrete DB/catalog bag, or external impl growth; LOC alone does not close it."
         },
@@ -1893,9 +1844,7 @@
           "owner": "wow-map canonical MapManager/runtime.",
           "open_retirement_issues": [
             28,
-            153,
-            188,
-            225
+            153
           ],
           "retirement_condition": "Map runtime/storage/visibility/respawn submodules have one writer and clock per transition; physical splitting is not combined with authority flips."
         },
@@ -1906,9 +1855,7 @@
           "total_lines": 31197,
           "owner": "wow-world character handler adapter plus mixed gameplay/persistence logic.",
           "open_retirement_issues": [
-            153,
-            200,
-            224
+            153
           ],
           "retirement_condition": "Character verticals are thin capability adapters with typed owners/ports and no raw directory or concrete persistence access."
         },
@@ -1919,9 +1866,7 @@
           "total_lines": 29928,
           "owner": "wow-world loot handler plus transitional loot/map/persistence coordination.",
           "open_retirement_issues": [
-            153,
-            189,
-            224
+            153
           ],
           "retirement_condition": "Loot handlers adapt typed wow-loot/Player/Map/persistence outcomes and no longer coordinate dual authorities or durable trackers."
         },
@@ -1933,8 +1878,7 @@
           "total_lines": 46568,
           "owner": "world-server crate composition root, bootstrap/loaders and runtime orchestration.",
           "open_retirement_issues": [
-            153,
-            188
+            153
           ],
           "retirement_condition": "The crate keeps main as a thin entry point and distributes bootstrap/loaders/runtime by cohesive private modules; gameplay algorithms and hidden mutable clocks are absent."
         },
@@ -1945,9 +1889,7 @@
           "total_lines": 18546,
           "owner": "wow-world quest handler plus represented Player/persistence logic.",
           "open_retirement_issues": [
-            153,
-            200,
-            224
+            153
           ],
           "retirement_condition": "Quest handler is a thin adapter over canonical Player/quest/persistence capabilities with exact outcome and packet order."
         },
@@ -1958,8 +1900,7 @@
           "total_lines": 18300,
           "owner": "wow-entities partial canonical Player model.",
           "open_retirement_issues": [
-            153,
-            226
+            153
           ],
           "retirement_condition": "Player submodules own one mutable representation per responsibility with colocated tests; Session and directory mirrors for migrated families are removed."
         },
@@ -1970,7 +1911,6 @@
           "total_lines": 5291,
           "owner": "wow-social atomic Group/PendingInvites authority relocated from wow-network by #137.",
           "open_retirement_issues": [
-            140,
             153
           ],
           "retirement_condition": "Group state, invariants and outcomes stay behind the narrow named service boundary; no transport, SQL or packet type enters wow-social and the transitional wow-network mailbox edge is gone."


### PR DESCRIPTION
Closes #299.

The ledger claimed **sixteen** issues were open that had merged — #140, #177, #182–#184, #188,
#189, #200, #224–#231 — which silently disarmed both guards keyed on issue state. #258 repaired
this class once and it returned within ~25 commits, so the resync alone was never the fix.

## The mirror is now derived

`python3 tools/architecture/check_architecture.py refresh-issue-state` reads the live repository
and rewrites every mirrored `state`/`title` in both ledgers. `--check` reports drift and fails
without writing, and the new weekly **`Issue state drift`** workflow runs exactly that, with the
repair command in its error message.

#299 named two options. Deriving beats reading issue state at check time because `check` runs
inside `audit`, which is offline and hermetic by contract; making every architecture check depend
on the GitHub API to answer is a worse trade than one file refreshed by one command. The refresh
is the only networked command in this tool, and `check` never calls it.

## What the re-armed guards found

Both had something real to say, and both are now true rather than silenced.

**The four `PlayerBroadcastInfo` transport rows named #140**, which merged on 2026-08-22 without
retiring them. They are retargeted to **#270**, the live slice that exists to retire exactly those
four endpoints and whose own scope asked for this reassignment. The fields stay listed as
un-retired — only their owner is now an issue that can actually remove them. #270 joins the ledger
as a slice under #133 depending on #140 and #189, sequenced immediately before the terminal audit
in the JSON and in the documented sequence.

**Twenty-four retirement and cutover lists named closed slices.** Each is pruned to its live
owners; where that emptied a list it falls to #153, the standing terminal audit that owns leftover
debt by definition. #28 is kept — it is open and lives only in the runtime ledger's external
tracking entry, which is the bug I had to fix in my own first pass.

`runtime-ownership-ledger.json` provenance moves from `2d94ee51` / 2026-08-12 to the current HEAD,
and its hotspot coverage baseline with it.

## The exact semantic delta

Verified by parsing both revisions rather than reading the diff:

```
added issues:            [270]
removed issues:          []
state corrections:       15  [140,182,183,184,188,189,200,224,225,226,227,228,229,230,231]
external prerequisites:  #177 open -> closed
non-state field changes: none
sequence:                +270 only, existing order preserved
```

Formatting is now the refresh command's canonical form, which reflows single-element arrays once;
that is the bulk of the line count.

## Evidence

- `refresh-issue-state --check` — exit 0, "issue state mirror is current".
- `check_architecture.py check` — exit 0.
- `check_architecture.py self-test` — PASS (20 fixtures, 11 debt-ownership rejections, 9
  runtime-ownership rejections, 4 hotspot-ratchet rejections, 6 handler-module-policy rejections).
- `./tools/validation-v2 final --base origin/3.4.3` — exit 0.
- The drift workflow parses and pins its action by SHA.