### PR TITLE
Give the audit profile a budget its longest step fits in

### DIFF
--- a/docs/operations/validation-v2.md
+++ b/docs/operations/validation-v2.md
@@ -156,7 +156,10 @@ one host. Lock diagnostics identify the active run id, PID, repository, HEAD, pr
 time. `quick` and `final` never acquire this heavyweight lock. For hermetic tests only, its path
 can be overridden with `VALIDATION_V2_HEAVY_LOCK`.
 
-The conservative defaults are two Cargo jobs and a 900-second per-command timeout. Controlled
+The conservative defaults are two Cargo jobs and a 900-second per-command timeout, except that
+`audit` defaults to 3600 seconds: its exhaustive persistence inventory alone runs 870-900 seconds
+on a four-core host, so the ordinary budget would kill it - correctly reported as
+`failure_kind: timeout`, but for no useful reason. Controlled
 overrides are validated before execution:
 
 ```bash

--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -171,6 +171,18 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     assert child_signal["failure_kind"] == "child-signal"
     assert child_signal["child_signal_reports"] == [{"signal": 6, "name": "SIGABRT"}]
 
+    # The audit's own budget must outlast its longest step.
+    assert runner.DEFAULT_TIMEOUT == 900 and runner.AUDIT_TIMEOUT == 3600
+    audit_locked = invoke("audit", directory / "audit-timeout.json")
+    assert audit_locked.returncode in {0, runner.LOCKED_ERROR}, audit_locked.stderr
+    if audit_locked.returncode == 0:
+        recorded = json.loads((directory / "audit-timeout.json").read_text())
+        assert recorded["resources"]["command_timeout_seconds"] == runner.AUDIT_TIMEOUT
+    assert (
+        json.loads(success_manifest.read_text())["resources"]["command_timeout_seconds"]
+        == runner.DEFAULT_TIMEOUT
+    )
+
     resolved = runner.resolve_protoc(repo, base_env)
     assert resolved is not None and resolved.endswith("protoc")
     assert runner.command_environment(repo, 2)["PROTOC"] == resolved

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -30,6 +30,9 @@ LOCKED_ERROR = 75
 DEFAULT_JOBS = 2
 MAX_JOBS = 8
 DEFAULT_TIMEOUT = 900
+# The exhaustive persistence inventory alone runs 870-900s on a four-core host,
+# so the ordinary per-command budget cannot be the audit's.
+AUDIT_TIMEOUT = 3600
 DEFAULT_BASE = "origin/3.4.3"
 DEFAULT_HEAVY_LOCK = "/tmp/rustycore-validation-v2-heavy.lock"
 CHECKER_MANIFEST = "tools/architecture/handler-contract-check/Cargo.toml"
@@ -1113,7 +1116,12 @@ def main() -> int:
     repo = Path(__file__).resolve().parent.parent
     try:
         jobs = checked_value("VALIDATION_V2_CARGO_JOBS", DEFAULT_JOBS, 1, MAX_JOBS)
-        timeout = checked_value("VALIDATION_V2_TIMEOUT_SECONDS", DEFAULT_TIMEOUT, 30, 3600)
+        timeout = checked_value(
+            "VALIDATION_V2_TIMEOUT_SECONDS",
+            AUDIT_TIMEOUT if args.profile == "audit" else DEFAULT_TIMEOUT,
+            30,
+            3600,
+        )
         details = provenance(repo)
         started_at = utc_now()
         identifier = run_id(repo, str(details["head"]), args.profile, started_at)


### PR DESCRIPTION
Refs #302.

The exhaustive persistence inventory runs **870–900 seconds** on a four-core host, and the
per-command default is **900**. So the local audit killed it at step 9 with SIGTERM. The runner
reported that correctly — `failure_kind: "timeout"`, `signal: 15`, exit 143, status failed, which
is #322 doing its job — but the failure meant nothing except that the budget was too small. CI
never hit it because the workflow passes `3600` explicitly, which is precisely the kind of
divergence between the local and hosted path this epic exists to remove.

`audit` now defaults to 3600 seconds; `quick` and `final` keep 900. The `VALIDATION_V2_TIMEOUT_SECONDS`
override and its 30–3600 bounds are unchanged.

Evidence: `python3 tools/test_validation_v2.py` passes with a new assertion that a `quick`
manifest records 900 and an `audit` manifest records 3600;
`./tools/validation-v2 final --base origin/3.4.3` — exit 0.