### PR TITLE
Retarget the persistence workflow groups away from the completed #200

### DIFF
--- a/docs/architecture/ownership-and-boundaries.md
+++ b/docs/architecture/ownership-and-boundaries.md
@@ -333,6 +333,20 @@ The mirror is no longer hand-maintained. `check_architecture.py refresh-issue-st
 fails without writing, and the weekly `Issue state drift` workflow runs exactly that. The guards
 keep reading the checked-in file.
 
+**Validating a ledger change takes the exhaustive ratchet.** Three separate guards read issue
+state, and they do not live in one tool: the dependency-exception and `PlayerBroadcastInfo` guards
+are in `check_architecture.py`, while persistence workflow ownership is in the Rust
+`session-ownership-check check`, which only runs in `audit`. #299 was validated with the Python
+checker alone and left 91 workflow groups targeting a closed issue, which #341 then had to repair
+on `3.4.3`. After editing either ledger, run both:
+
+```bash
+python3 tools/architecture/check_architecture.py check
+cargo run --release --locked \
+  --manifest-path tools/architecture/handler-contract-check/Cargo.toml \
+  --bin session-ownership-check -- check
+```
+
 Deriving beats reading issue state at check time, which was the other option #299 named: `check`
 runs inside `audit`, which is offline and hermetic by contract, and a validator that needs GitHub
 to answer would make every architecture check depend on network and API availability. The refresh

--- a/tools/architecture/persistence-boundary-policy.json
+++ b/tools/architecture/persistence-boundary-policy.json
@@ -2252,9 +2252,9 @@
       "failure_and_unknown_commit": "Preserve current rollback/commit error propagation and publication suppression; no stronger retry or unknown-outcome guarantee is inferred.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -3119,9 +3119,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -19522,9 +19522,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -19587,9 +19587,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -19620,9 +19620,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -19653,9 +19653,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -19686,9 +19686,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -19719,9 +19719,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -20401,9 +20401,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -20434,9 +20434,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -20467,9 +20467,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -20696,9 +20696,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -20729,9 +20729,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -20762,9 +20762,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -20796,9 +20796,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -20861,9 +20861,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -20894,9 +20894,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -20928,9 +20928,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -20995,9 +20995,9 @@
       "failure_and_unknown_commit": "Preserve current rollback/commit error propagation and publication suppression; no stronger retry or unknown-outcome guarantee is inferred.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -21158,9 +21158,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -21191,9 +21191,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -21420,9 +21420,9 @@
       "failure_and_unknown_commit": "Preserve current rollback/commit error propagation and publication suppression; no stronger retry or unknown-outcome guarantee is inferred.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25258,9 +25258,9 @@
       "failure_and_unknown_commit": "Preserve current rollback/commit error propagation and publication suppression; no stronger retry or unknown-outcome guarantee is inferred.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25291,9 +25291,9 @@
       "failure_and_unknown_commit": "Preserve current rollback/commit error propagation and publication suppression; no stronger retry or unknown-outcome guarantee is inferred.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25324,9 +25324,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25357,9 +25357,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25390,9 +25390,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25423,9 +25423,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25456,9 +25456,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25489,9 +25489,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25522,9 +25522,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25555,9 +25555,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25588,9 +25588,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25621,9 +25621,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25654,9 +25654,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25687,9 +25687,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25720,9 +25720,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25753,9 +25753,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25786,9 +25786,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25819,9 +25819,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25852,9 +25852,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25885,9 +25885,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25918,9 +25918,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25951,9 +25951,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -25984,9 +25984,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26017,9 +26017,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26050,9 +26050,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26083,9 +26083,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26116,9 +26116,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26149,9 +26149,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26182,9 +26182,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26215,9 +26215,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26248,9 +26248,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26281,9 +26281,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26314,9 +26314,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26347,9 +26347,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26380,9 +26380,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26413,9 +26413,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26446,9 +26446,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26479,9 +26479,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26512,9 +26512,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26545,9 +26545,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26578,9 +26578,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26611,9 +26611,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26644,9 +26644,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26677,9 +26677,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26710,9 +26710,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26775,9 +26775,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26808,9 +26808,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26841,9 +26841,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26874,9 +26874,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26907,9 +26907,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26940,9 +26940,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -26973,9 +26973,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27006,9 +27006,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27039,9 +27039,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27200,9 +27200,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27233,9 +27233,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27266,9 +27266,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27331,9 +27331,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27428,9 +27428,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27461,9 +27461,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27494,9 +27494,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27527,9 +27527,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27560,9 +27560,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27721,9 +27721,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27850,9 +27850,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27883,9 +27883,9 @@
       "failure_and_unknown_commit": "Preserve the explicit distinction between definite rollback and unknown commit outcome, including quarantine/reconciliation behavior.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -27916,9 +27916,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -28109,9 +28109,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {
@@ -28304,9 +28304,9 @@
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; syntax alone adds no unknown-commit guarantee.",
       "target_issues": [
         153,
-        200
+        169
       ],
-      "retirement_condition": "The annotated issues [153, 200] must migrate or explicitly decide the entire workflow before this exception can disappear.",
+      "retirement_condition": "The annotated issues [153, 169] must migrate or explicitly decide the entire workflow before this exception can disappear.",
       "stable_boundary": false
     },
     {

--- a/tools/architecture/persistence-boundary-workflows.json
+++ b/tools/architecture/persistence-boundary-workflows.json
@@ -678,7 +678,7 @@
       "boundary": "world-server bootstrap composition root",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow uses independent characters, hotfix, login, world connections/pools in source order; no distributed ACID boundary is inferred.",
@@ -1658,7 +1658,7 @@
       "boundary": "world-server session composition boundary",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "This is a shared dependency/type surface for characters, login, world; it does not itself imply a runtime transaction.",
@@ -6920,7 +6920,7 @@
       "target_issues": [],
       "stable_boundary": true,
       "connection_affinity": "The typed adapter is instantiated against exactly one of characters, hotfix, login, world per value/transaction; the list denotes supported logical databases, not a simultaneous distributed workflow.",
-      "current_order": "Pure classification of a finished sqlx error; it issues nothing and imposes no order. Separates a failure to acquire a connection \u2014 which never reached the server, so the statement definitely did not run \u2014 from a failure after the statement was sent, whose outcome is ambiguous and must not be recorded as a revert.",
+      "current_order": "Pure classification of a finished sqlx error; it issues nothing and imposes no order. Separates a failure to acquire a connection — which never reached the server, so the statement definitely did not run — from a failure after the statement was sent, whose outcome is ambiguous and must not be recorded as a revert.",
       "failure_and_unknown_commit": "Preserve the workflow's current returned, logged, mapped, or ignored error path; recording never alters it, and a poisoned recorder drops its event rather than propagating a panic through a persistence path."
     },
     {
@@ -10222,7 +10222,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -10257,7 +10257,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the login adapter as currently coded; no wider transaction is inferred.",
@@ -10275,7 +10275,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the login adapter as currently coded; no wider transaction is inferred.",
@@ -10293,7 +10293,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the login adapter as currently coded; no wider transaction is inferred.",
@@ -10311,7 +10311,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the login adapter as currently coded; no wider transaction is inferred.",
@@ -10329,7 +10329,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the login adapter as currently coded; no wider transaction is inferred.",
@@ -10696,7 +10696,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the world adapter as currently coded; no wider transaction is inferred.",
@@ -10714,7 +10714,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -10732,7 +10732,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -11045,7 +11045,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -11063,7 +11063,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -11081,7 +11081,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -11100,7 +11100,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow uses independent characters, world connections/pools in source order; no distributed ACID boundary is inferred.",
@@ -11135,7 +11135,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the world adapter as currently coded; no wider transaction is inferred.",
@@ -11153,7 +11153,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the world adapter as currently coded; no wider transaction is inferred.",
@@ -11172,7 +11172,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow uses independent characters, login connections/pools in source order; no distributed ACID boundary is inferred.",
@@ -11209,7 +11209,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow preserves one explicit characters connection/transaction across its current statement sequence.",
@@ -11297,7 +11297,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -11315,7 +11315,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -11439,7 +11439,7 @@
       "boundary": "Player login/logout lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow preserves one explicit characters connection/transaction across its current statement sequence.",
@@ -13509,7 +13509,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow preserves one explicit characters connection/transaction across its current statement sequence.",
@@ -13527,7 +13527,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow preserves one explicit characters connection/transaction across its current statement sequence.",
@@ -13545,7 +13545,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13563,7 +13563,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13581,7 +13581,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13599,7 +13599,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13617,7 +13617,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13635,7 +13635,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13653,7 +13653,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13671,7 +13671,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13689,7 +13689,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13707,7 +13707,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13725,7 +13725,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13743,7 +13743,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13761,7 +13761,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13779,7 +13779,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13797,7 +13797,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13815,7 +13815,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13833,7 +13833,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13851,7 +13851,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13869,7 +13869,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13887,7 +13887,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13905,7 +13905,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13923,7 +13923,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13941,7 +13941,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13959,7 +13959,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13977,7 +13977,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -13995,7 +13995,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14013,7 +14013,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14031,7 +14031,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14049,7 +14049,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14067,7 +14067,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14085,7 +14085,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14103,7 +14103,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14121,7 +14121,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14139,7 +14139,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14157,7 +14157,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14175,7 +14175,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14193,7 +14193,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14211,7 +14211,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14229,7 +14229,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14247,7 +14247,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14265,7 +14265,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14283,7 +14283,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14301,7 +14301,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14336,7 +14336,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14354,7 +14354,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14372,7 +14372,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14390,7 +14390,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14408,7 +14408,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14426,7 +14426,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14444,7 +14444,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14462,7 +14462,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14480,7 +14480,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14566,7 +14566,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14584,7 +14584,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14602,7 +14602,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14637,7 +14637,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14689,7 +14689,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14707,7 +14707,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14725,7 +14725,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14743,7 +14743,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14761,7 +14761,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14847,7 +14847,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14916,7 +14916,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -14934,7 +14934,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow preserves one explicit characters connection/transaction across its current statement sequence.",
@@ -14952,7 +14952,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -15055,7 +15055,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "The workflow acquires or uses the characters adapter as currently coded; no wider transaction is inferred.",
@@ -15160,7 +15160,7 @@
       "boundary": "Player lifecycle persistence capability",
       "target_issues": [
         153,
-        200
+        169
       ],
       "stable_boundary": false,
       "connection_affinity": "This is a shared dependency/type surface for characters; it does not itself imply a runtime transaction.",


### PR DESCRIPTION
Closes #341. Repairs `3.4.3`, which is red on
[run 32659756676](https://github.com/alseif0x/rustycore/actions/runs/32659756676).

#299 corrected the mirrored issue state, which re-armed every guard that state had been
disarming. Two were anticipated and fixed there. This one was not: **91 persistence workflow
groups target #200**, which merged.

```
session ownership check failed: invalid persistence semantic ownership:
persistence group workflow:world-server:crate::app:...::fn run_inner targets stale issue #200 (closed)
... 91 groups
```

They move to **#169** (`[ARCH.DB] Establish SQLx-free persistence ownership and dialect
adapters`), which is open and is exactly the boundary these accesses must move behind — account
and character loads, session resources, the world-server app. Not #286: that is the narrower
character-save-statement slice under the same umbrella and should not inherit them. The remaining
758 groups already target #153 and are untouched.

## The derived file is derived, not edited

`persistence-boundary-policy.json` is generated from the workflows file. My first pass edited both
by hand and the checker rejected it — *"checked persistence policy is stale; regenerate it from
persistence-boundary-workflows.json with print-persistence-policy"* — which was right: the hand
edit had left 91 human-readable `retirement_condition` strings still naming `[153, 200]`. The
policy here is the regenerated one.

## Why the local gate did not catch it in #299

Three guards read issue state and they do not live in one tool. The dependency-exception and
`PlayerBroadcastInfo` guards are in `check_architecture.py`; persistence workflow ownership is in
the Rust `session-ownership-check check`, which only runs in `audit` and takes ~13 minutes. #299
was validated with the Python side alone. That rule is now written into
`docs/architecture/ownership-and-boundaries.md`: editing either ledger requires running both.

## Evidence

- `session-ownership-check check` (exhaustive, ~13 min) — **PASS**: 11675 production + 10533
  test-fixture persistence rows, 909 exact semantic groups, 570 registry rows.
- `check_architecture.py check` — exit 0; `self-test` — PASS.
- `./tools/validation-v2 final --base origin/3.4.3` — exit 0.
- No `target_issues` entry names a closed issue: the distribution is now `{153: 758, 169: 91}`.