### PR TITLE
Rebuild the guarded runtime QA orchestration on systemd

### DIFF
--- a/docs/operations/local-first-development.md
+++ b/docs/operations/local-first-development.md
@@ -53,6 +53,11 @@ Validation does not review code and does not start servers.
   required remote gate for external authors is the `Codex Review Gate` workflow.
 - `tools/wow-test-bot/run_rustycore_login_smoke.sh` is the live login smoke. It needs the local
   runtime and MariaDB, and is never part of CI.
+- `tools/qa-runtime.sh` orchestrates QA that needs a *different* build than the one deployed. It
+  snapshots the live build, installs a candidate through `systemctl`, runs the scenario, and
+  restores the original on every exit path; `self-test` exercises that restore against fake
+  services and `snapshot` prints the live identity without touching anything. Destructive
+  scenarios stay behind two explicit flags.
 
 ## What runs remotely
 

--- a/tools/qa-runtime.sh
+++ b/tools/qa-runtime.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# Guarded live runtime QA for RustyCore.
+#
+# #331 retired tools/pr-preflight.sh, and with it the orchestration around the
+# destructive loot-race smoke: it drove PM2, which this host no longer runs.
+# #334 rebuilds it against the real process model - systemd units started from
+# a deploy directory - and keeps the property that made the old wrapper safe:
+# the live build is snapshotted before anything is swapped in, and it is put
+# back afterwards even when the run fails, is interrupted, or the bot hangs.
+#
+# Validation lives in tools/validation-v2; code review in tools/local-review.sh.
+# This starts and stops a live server, so it never runs in CI.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Injection points. Production defaults address the real host; the self-test
+# points them at fakes so the restore path is exercised, not asserted.
+QA_SYSTEMCTL="${QA_SYSTEMCTL:-sudo -n systemctl}"
+QA_SERVICE="${QA_SERVICE:-world-server}"
+QA_LIVE_DIR="${QA_LIVE_DIR:-$REPO_ROOT/target/deploy/live}"
+QA_LIVE_NAME="${QA_LIVE_NAME:-world-server}"
+QA_BOT="${QA_BOT:-$REPO_ROOT/tools/wow-test-bot/target/debug/wow-test-bot}"
+QA_LOCK="${QA_LOCK:-/tmp/rustycore-qa-runtime.lock}"
+QA_WORLD_PORT="${QA_WORLD_PORT:-8085}"
+QA_INSTANCE_PORT="${QA_INSTANCE_PORT:-8086}"
+QA_READY_TIMEOUT_SECONDS="${QA_READY_TIMEOUT_SECONDS:-60}"
+QA_BOT_TIMEOUT_SECONDS="${QA_BOT_TIMEOUT_SECONDS:-600}"
+QA_SKIP_PORT_GUARD="${QA_SKIP_PORT_GUARD:-0}"
+# How the running executable of a PID is resolved. Overridden only by the
+# self-test, which has no /proc entry pointing at its fake build.
+QA_EXE_RESOLVER="${QA_EXE_RESOLVER:-realpath -e --}"
+# Which worktree must be clean for the swapped build to be identifiable. The
+# self-test points this at its own clean fixture repository.
+QA_GIT_DIR="${QA_GIT_DIR:-$REPO_ROOT}"
+
+DRY_RUN=0
+ALLOW_RUNTIME_QA=0
+ACK_LOOT_RACE=0
+WORLD_EXEC=""
+REPORT=""
+
+RESTORE_PENDING=0
+RESTORE_FROM=""
+ORIGINAL_SHA=""
+LIVE_PATH=""
+
+usage() {
+  cat <<'USAGE'
+RustyCore guarded runtime QA
+
+Usage:
+  ./tools/qa-runtime.sh [OPTIONS] <COMMAND>
+
+Commands:
+  self-test     Exercise every guard and the restore path against fake services.
+  snapshot      Print the live world build identity and exit. Touches nothing.
+  loot-race     Swap in a build, run the destructive two-session loot smoke, restore.
+
+Options:
+  --dry-run                              Print the plan; start, stop and copy nothing.
+  --allow-runtime-qa                     Required: this stops and starts a live service.
+  --ack-disposable-overworld-loot-race   Required for loot-race: it mutates a world
+                                         GameObject fixture and two disposable characters.
+  --world-exec PATH                      Build to swap in (default target/release/world-server).
+  --report PATH                          Write a JSON result document.
+  -h, --help                             Show this help.
+
+The live build is snapshotted by path and SHA-256 before the swap and restored
+afterwards on every exit path. A failed restore is reported as the run's outcome
+even when the QA itself passed, because the normal server is then not the build
+it was.
+USAGE
+}
+
+log() { printf '\n==> %s\n' "$*"; }
+warn() { printf 'warning: %s\n' "$*" >&2; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+sha256_of() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+service_property() {
+  # shellcheck disable=SC2086
+  $QA_SYSTEMCTL show "$QA_SERVICE" --property="$1" --value 2>/dev/null || true
+}
+
+service_active() {
+  [[ "$(service_property ActiveState)" == "active" ]]
+}
+
+service_main_pid() {
+  local pid
+  pid="$(service_property MainPID)"
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+  printf '%s' "$pid"
+}
+
+# Verbatim from the retired wrapper: every listening socket on the port must be
+# owned by exactly the process we think is serving it.
+port_owned_exclusively_by_pid() {
+  local port="$1" pid="$2" sockets socket remaining seen_pid matched_pid
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+  sockets="$(ss -H -ltnp "sport = :${port}" 2>/dev/null)" || return 1
+  [[ -n "$sockets" ]] || return 1
+  while IFS= read -r socket; do
+    remaining="$socket"
+    seen_pid=0
+    while [[ "$remaining" =~ pid=([0-9]+), ]]; do
+      matched_pid="${BASH_REMATCH[1]}"
+      [[ "$matched_pid" == "$pid" ]] || return 1
+      seen_pid=1
+      remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+    done
+    ((seen_pid == 1)) || return 1
+  done <<<"$sockets"
+}
+
+ports_ready() {
+  local pid="$1"
+  ((QA_SKIP_PORT_GUARD == 1)) && return 0
+  [[ "$QA_WORLD_PORT" != "$QA_INSTANCE_PORT" ]] || return 1
+  port_owned_exclusively_by_pid "$QA_WORLD_PORT" "$pid" \
+    && port_owned_exclusively_by_pid "$QA_INSTANCE_PORT" "$pid"
+}
+
+# A packet dump would capture the QA traffic to disk; the old wrapper refused to
+# run with one configured, and so does this.
+packet_dump_absent() {
+  local pid environment
+  environment="$(service_property Environment)"
+  [[ "$environment" != *RUSTYCORE_PACKET_DUMP_DIR* ]] || return 1
+  if pid="$(service_main_pid)" && [[ -r "/proc/${pid}/environ" ]]; then
+    ! tr '\0' '\n' <"/proc/${pid}/environ" | grep -q '^RUSTYCORE_PACKET_DUMP_DIR='
+  fi
+}
+
+wait_until_serving() {
+  local deadline=$((SECONDS + QA_READY_TIMEOUT_SECONDS)) pid
+  while ((SECONDS < deadline)); do
+    if service_active && pid="$(service_main_pid)" && ports_ready "$pid"; then
+      printf '%s' "$pid"
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+live_identity() {
+  local pid exec_path live_sha
+  service_active || die "$QA_SERVICE is not active; refusing to touch it"
+  pid="$(service_main_pid)" || die "$QA_SERVICE reports no main PID"
+  # shellcheck disable=SC2086
+  exec_path="$($QA_EXE_RESOLVER "/proc/${pid}/exe" 2>/dev/null)" \
+    || die "cannot resolve the running executable of PID $pid"
+  [[ "$exec_path" == "$LIVE_PATH" ]] \
+    || die "running executable $exec_path is not the deploy path $LIVE_PATH"
+  live_sha="$(sha256_of "$LIVE_PATH")"
+  printf '%s\t%s\t%s\t%s' "$pid" "$exec_path" "$live_sha" "$(service_property NRestarts)"
+}
+
+restore_live_build() {
+  local status=$?
+  trap - EXIT
+  trap '' HUP INT TERM
+  ((RESTORE_PENDING == 1)) || exit "$status"
+  RESTORE_PENDING=0
+  log "Restoring the original live build"
+  local restore_status=0
+  # shellcheck disable=SC2086
+  $QA_SYSTEMCTL stop "$QA_SERVICE" || restore_status=1
+  cp -- "$RESTORE_FROM" "$LIVE_PATH" || restore_status=1
+  # shellcheck disable=SC2086
+  $QA_SYSTEMCTL start "$QA_SERVICE" || restore_status=1
+  if [[ "$(sha256_of "$LIVE_PATH")" != "$ORIGINAL_SHA" ]]; then
+    restore_status=1
+    warn "restored build does not match the snapshot SHA-256"
+  fi
+  if ! wait_until_serving >/dev/null; then
+    restore_status=1
+    warn "$QA_SERVICE did not come back up within ${QA_READY_TIMEOUT_SECONDS}s"
+  fi
+  if ((restore_status != 0)); then
+    printf 'error: THE LIVE BUILD WAS NOT RESTORED CLEANLY. Original kept at %s\n' \
+      "$RESTORE_FROM" >&2
+    exit 70
+  fi
+  log "Original build restored and serving"
+  exit "$status"
+}
+
+write_report() {
+  [[ -n "$REPORT" ]] || return 0
+  printf '{"command":"%s","outcome":"%s","service":"%s","original_sha256":"%s","candidate_sha256":"%s","bot_status":%s}\n' \
+    "$1" "$2" "$QA_SERVICE" "$ORIGINAL_SHA" "${3:-}" "${4:-null}" >"$REPORT"
+}
+
+require_clean_worktree() {
+  [[ -z "$(git -C "$QA_GIT_DIR" status --porcelain=v1 --untracked-files=normal)" ]] \
+    || die "runtime QA requires a clean worktree so the swapped build is identifiable"
+}
+
+run_snapshot() {
+  LIVE_PATH="$QA_LIVE_DIR/$QA_LIVE_NAME"
+  [[ -f "$LIVE_PATH" ]] || die "no live build at $LIVE_PATH"
+  local identity
+  identity="$(live_identity)"
+  printf 'service      %s\n' "$QA_SERVICE"
+  printf 'main pid     %s\n' "$(cut -f1 <<<"$identity")"
+  printf 'executable   %s\n' "$(cut -f2 <<<"$identity")"
+  printf 'sha256       %s\n' "$(cut -f3 <<<"$identity")"
+  printf 'restarts     %s\n' "$(cut -f4 <<<"$identity")"
+  packet_dump_absent || die "a packet dump directory is configured; refusing to run QA"
+  printf 'packet dump  absent\n'
+}
+
+run_loot_race() {
+  ((ALLOW_RUNTIME_QA == 1)) || die \
+    "loot-race stops and starts $QA_SERVICE; rerun with --allow-runtime-qa"
+  ((ACK_LOOT_RACE == 1)) || die \
+    "loot-race mutates a world GameObject fixture and two disposable characters; rerun with --ack-disposable-overworld-loot-race"
+
+  LIVE_PATH="$QA_LIVE_DIR/$QA_LIVE_NAME"
+  local candidate="${WORLD_EXEC:-$REPO_ROOT/target/release/world-server}"
+  [[ -x "$candidate" ]] || die "candidate build is not executable: $candidate"
+  [[ -f "$LIVE_PATH" ]] || die "no live build at $LIVE_PATH"
+  [[ -x "$QA_BOT" ]] || die "QA bot is not built: $QA_BOT"
+  require_clean_worktree
+
+  local candidate_sha
+  candidate_sha="$(sha256_of "$candidate")"
+
+  if ((DRY_RUN == 1)); then
+    log "Dry run: nothing is stopped, copied or started"
+    printf 'would snapshot  %s\n' "$LIVE_PATH"
+    printf 'would install   %s (%s)\n' "$candidate" "$candidate_sha"
+    printf 'would run       %s --loot-race-smoke --ack-disposable-overworld-loot-race\n' "$QA_BOT"
+    printf 'would restore   the snapshot on every exit path\n'
+    return 0
+  fi
+
+  local identity
+  identity="$(live_identity)"
+  packet_dump_absent || die "a packet dump directory is configured; refusing to run QA"
+  ORIGINAL_SHA="$(cut -f3 <<<"$identity")"
+  local pid
+  pid="$(cut -f1 <<<"$identity")"
+  ports_ready "$pid" || die "ports $QA_WORLD_PORT/$QA_INSTANCE_PORT are not owned by PID $pid"
+  log "Live build $ORIGINAL_SHA serving on PID $pid"
+
+  RESTORE_FROM="$(mktemp "${TMPDIR:-/tmp}/rustycore-live-build.XXXXXX")"
+  cp -- "$LIVE_PATH" "$RESTORE_FROM"
+  [[ "$(sha256_of "$RESTORE_FROM")" == "$ORIGINAL_SHA" ]] || die "snapshot copy does not match"
+  RESTORE_PENDING=1
+  trap restore_live_build EXIT
+  trap 'exit 130' HUP INT TERM
+
+  log "Installing the candidate build $candidate_sha"
+  # shellcheck disable=SC2086
+  $QA_SYSTEMCTL stop "$QA_SERVICE"
+  cp -- "$candidate" "$LIVE_PATH"
+  [[ "$(sha256_of "$LIVE_PATH")" == "$candidate_sha" ]] || die "candidate did not install"
+  # shellcheck disable=SC2086
+  $QA_SYSTEMCTL start "$QA_SERVICE"
+  pid="$(wait_until_serving)" || die "the candidate build did not start serving"
+  log "Candidate serving on PID $pid"
+
+  local bot_status=0
+  timeout --foreground --signal=TERM --kill-after=30 "${QA_BOT_TIMEOUT_SECONDS}s" \
+    "$QA_BOT" --loot-race-smoke --ack-disposable-overworld-loot-race || bot_status=$?
+  if ((bot_status == 0)); then
+    log "Loot-race smoke passed"
+  else
+    warn "loot-race smoke failed with status $bot_status"
+  fi
+  write_report loot-race "$([[ $bot_status -eq 0 ]] && echo passed || echo failed)" \
+    "$candidate_sha" "$bot_status"
+  return "$bot_status"
+}
+
+while (($#)); do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --allow-runtime-qa) ALLOW_RUNTIME_QA=1; shift ;;
+    --ack-disposable-overworld-loot-race) ACK_LOOT_RACE=1; shift ;;
+    --world-exec) [[ $# -ge 2 ]] || die "--world-exec needs a path"; WORLD_EXEC="$2"; shift 2 ;;
+    --report) [[ $# -ge 2 ]] || die "--report needs a path"; REPORT="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; break ;;
+    *) break ;;
+  esac
+done
+
+COMMAND="${1:-help}"
+(($# > 0)) && shift || true
+
+case "$COMMAND" in
+  self-test)
+    exec "$REPO_ROOT/tools/qa_runtime_self_test.sh"
+    ;;
+  snapshot)
+    require_command ss
+    run_snapshot
+    ;;
+  loot-race)
+    require_command ss
+    require_command timeout
+    exec 9>"$QA_LOCK"
+    flock -n 9 || die "another runtime QA run holds $QA_LOCK"
+    run_loot_race
+    ;;
+  help) usage ;;
+  *) usage >&2; die "unknown command: $COMMAND" ;;
+esac

--- a/tools/qa_runtime_self_test.sh
+++ b/tools/qa_runtime_self_test.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Contract tests for tools/qa-runtime.sh.
+#
+# The point of the orchestration is that the live build comes back. That cannot
+# be asserted by reading the script, so every case here drives the real script
+# against a fake service and then compares the bytes of the "live" build.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+QA="$REPO_ROOT/tools/qa-runtime.sh"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/qa-runtime-self-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+PASSED=0
+check() {
+  local description="$1"
+  shift
+  if "$@"; then
+    PASSED=$((PASSED + 1))
+  else
+    printf 'FAIL: %s\n' "$description" >&2
+    exit 1
+  fi
+}
+
+mkdir -p "$WORK/live" "$WORK/bin" "$WORK/repo"
+# A clean fixture repository: the guard under test is "the worktree is clean",
+# not "this development checkout happens to be".
+git -C "$WORK/repo" init -q
+git -C "$WORK/repo" config user.email qa@example.invalid
+git -C "$WORK/repo" config user.name "QA Runtime"
+printf 'fixture\n' >"$WORK/repo/README"
+git -C "$WORK/repo" add README
+git -C "$WORK/repo" commit -qm fixture
+printf 'ORIGINAL-BUILD\n' >"$WORK/live/world-server"
+printf 'CANDIDATE-BUILD\n' >"$WORK/candidate"
+chmod +x "$WORK/candidate"
+
+# A fake systemd: it records what it was asked to do and can be told to fail.
+cat >"$WORK/bin/systemctl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+state="${QA_FAKE_STATE:?}"
+printf '%s\n' "$*" >>"${state}.calls"
+case "${1:-}" in
+  show)
+    case "$*" in
+      *ActiveState*) printf 'active\n' ;;
+      *MainPID*) printf '4242\n' ;;
+      *NRestarts*) printf '7\n' ;;
+      *Environment*) printf '%s\n' "${QA_FAKE_ENVIRONMENT:-}" ;;
+      *) printf '\n' ;;
+    esac
+    ;;
+  stop) printf 'stopped\n' >>"${state}.log" ;;
+  start)
+    if [[ "${QA_FAKE_FAIL_START:-0}" == "1" && -f "${state}.swapped" ]]; then
+      printf 'refusing to start\n' >&2
+      exit 1
+    fi
+    printf 'started\n' >>"${state}.log"
+    ;;
+esac
+FAKE
+chmod +x "$WORK/bin/systemctl"
+
+# A fake bot that records which build was live when it ran.
+cat >"$WORK/bin/bot" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+cat "${QA_FAKE_LIVE:?}" >"${QA_FAKE_STATE:?}.bot-saw"
+exit "${QA_FAKE_BOT_STATUS:-0}"
+FAKE
+chmod +x "$WORK/bin/bot"
+
+cat >"$WORK/bin/resolver" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' "${QA_FAKE_LIVE:?}"
+FAKE
+chmod +x "$WORK/bin/resolver"
+
+run_qa() {
+  env \
+    QA_SYSTEMCTL="$WORK/bin/systemctl" \
+    QA_SERVICE="fake-world" \
+    QA_LIVE_DIR="$WORK/live" \
+    QA_LIVE_NAME="world-server" \
+    QA_BOT="$WORK/bin/bot" \
+    QA_LOCK="$WORK/lock" \
+    QA_EXE_RESOLVER="$WORK/bin/resolver" \
+    QA_SKIP_PORT_GUARD=1 \
+    QA_READY_TIMEOUT_SECONDS=5 \
+    QA_FAKE_STATE="$WORK/state" \
+    QA_FAKE_LIVE="$WORK/live/world-server" \
+    QA_GIT_DIR="$WORK/repo" \
+    "${EXTRA_ENV[@]}" \
+    "$QA" "$@"
+}
+
+reset_state() {
+  rm -f "$WORK"/state.* "$WORK/lock"
+  printf 'ORIGINAL-BUILD\n' >"$WORK/live/world-server"
+  EXTRA_ENV=()
+}
+
+live_is_original() { [[ "$(cat "$WORK/live/world-server")" == "ORIGINAL-BUILD" ]]; }
+bot_saw_candidate() { [[ "$(cat "$WORK/state.bot-saw")" == "CANDIDATE-BUILD" ]]; }
+
+# 1. The destructive command refuses without each mandatory flag.
+reset_state
+output="$(run_qa --world-exec "$WORK/candidate" loot-race 2>&1 || true)"
+check "refuses without --allow-runtime-qa" grep -q -- "--allow-runtime-qa" <<<"$output"
+check "nothing was swapped" live_is_original
+
+output="$(run_qa --allow-runtime-qa --world-exec "$WORK/candidate" loot-race 2>&1 || true)"
+check "refuses without the disposable-fixture acknowledgement" \
+  grep -q -- "--ack-disposable-overworld-loot-race" <<<"$output"
+check "still nothing swapped" live_is_original
+
+# 2. A missing candidate is refused before anything stops.
+output="$(run_qa --allow-runtime-qa --ack-disposable-overworld-loot-race \
+  --world-exec "$WORK/absent" loot-race 2>&1 || true)"
+check "refuses a candidate that is not executable" grep -q "not executable" <<<"$output"
+check "nothing stopped" bash -c '[[ ! -f "'"$WORK"'/state.log" ]]'
+
+# 3. A dry run plans without touching anything.
+output="$(run_qa --dry-run --allow-runtime-qa --ack-disposable-overworld-loot-race \
+  --world-exec "$WORK/candidate" loot-race 2>&1)"
+check "dry run explains the plan" grep -q "would restore" <<<"$output"
+check "dry run swapped nothing" live_is_original
+check "dry run started nothing" bash -c '[[ ! -f "'"$WORK"'/state.log" ]]'
+
+# 4. The happy path: the bot sees the candidate, the original comes back.
+reset_state
+run_qa --allow-runtime-qa --ack-disposable-overworld-loot-race \
+  --world-exec "$WORK/candidate" --report "$WORK/report.json" loot-race >/dev/null
+check "the bot ran against the candidate build" bot_saw_candidate
+check "the original build was restored" live_is_original
+check "the report records a pass" grep -q '"outcome":"passed"' "$WORK/report.json"
+
+# 5. A failing smoke still restores, and the failure is the run's status.
+reset_state
+EXTRA_ENV=(QA_FAKE_BOT_STATUS=3)
+status=0
+run_qa --allow-runtime-qa --ack-disposable-overworld-loot-race \
+  --world-exec "$WORK/candidate" --report "$WORK/report.json" loot-race >/dev/null 2>&1 || status=$?
+check "a failing smoke fails the run" test "$status" -eq 3
+check "a failing smoke still restores" live_is_original
+check "the report records the failure" grep -q '"outcome":"failed"' "$WORK/report.json"
+
+# 6. A restore that cannot start the service outranks everything else.
+reset_state
+EXTRA_ENV=(QA_FAKE_FAIL_START=1)
+touch "$WORK/state.swapped"
+status=0
+output="$(run_qa --allow-runtime-qa --ack-disposable-overworld-loot-race \
+  --world-exec "$WORK/candidate" loot-race 2>&1)" || status=$?
+check "a failed restore exits 70" test "$status" -eq 70
+check "a failed restore says so loudly" grep -q "NOT RESTORED CLEANLY" <<<"$output"
+check "a failed restore keeps the original copy" grep -q "Original kept at" <<<"$output"
+
+# 7. A configured packet dump is refused.
+reset_state
+EXTRA_ENV=(QA_FAKE_ENVIRONMENT=RUSTYCORE_PACKET_DUMP_DIR=/tmp/dump)
+output="$(run_qa --allow-runtime-qa --ack-disposable-overworld-loot-race \
+  --world-exec "$WORK/candidate" loot-race 2>&1 || true)"
+check "refuses while a packet dump is configured" grep -q "packet dump" <<<"$output"
+check "packet-dump refusal swapped nothing" live_is_original
+
+# 8. A dirty worktree is refused.
+reset_state
+printf 'uncommitted\n' >"$WORK/repo/scratch"
+output="$(run_qa --allow-runtime-qa --ack-disposable-overworld-loot-race \
+  --world-exec "$WORK/candidate" loot-race 2>&1 || true)"
+rm -f "$WORK/repo/scratch"
+check "refuses a dirty worktree" grep -q "clean worktree" <<<"$output"
+check "the dirty-worktree refusal swapped nothing" live_is_original
+
+# 9. Two runs cannot overlap.
+reset_state
+exec 8>"$WORK/lock"
+flock -n 8
+status=0
+output="$(run_qa --allow-runtime-qa --ack-disposable-overworld-loot-race \
+  --world-exec "$WORK/candidate" loot-race 2>&1)" || status=$?
+exec 8>&-
+check "a second run is refused while the lock is held" grep -q "another runtime QA run" <<<"$output"
+check "the refused run swapped nothing" live_is_original
+
+printf 'qa-runtime self-test: PASS (%d checks)\n' "$PASSED"

--- a/tools/wow-test-bot/README.md
+++ b/tools/wow-test-bot/README.md
@@ -171,17 +171,25 @@ WOW_BOT_DB_CONF=/home/server/trinity-legacy-install/bin/worldserver.conf \
   --loot-race-smoke --ack-disposable-overworld-loot-race
 ```
 
-**Retired orchestration.** Until #331 this smoke was driven by
-`./tools/pr-preflight.sh --allow-runtime-qa --ack-disposable-overworld-loot-race
-qa-loot-race`, which additionally snapshotted the running PM2 world's
-executable, SHA-256 and restart count, swapped in the feature-branch build, and
-restored the original afterwards. That wrapper retired with the rest of the
-legacy validation stack, and its runtime no longer exists on the development
-host: there is no `pm2` and no legacy `worldserver` in
-`/home/server/trinity-legacy-install/bin`. The bot's own guards are unchanged;
-what is gone is the build swap and restore around them. The reference
-implementation is in the git history of `tools/pr-preflight.sh`
-(`run_qa_loot_race` and the `qa_world_*` helpers).
+**Guarded orchestration.** To run it against a feature-branch build without
+leaving that build installed, use `tools/qa-runtime.sh` (#334):
+
+```bash
+./tools/qa-runtime.sh --allow-runtime-qa --ack-disposable-overworld-loot-race \
+  --world-exec target/release/world-server --report /tmp/loot-race.json loot-race
+```
+
+It snapshots the live build by path and SHA-256, refuses to start while a packet
+dump is configured or while the world and instance ports are not owned by the
+service's own process, installs the candidate through `systemctl`, waits until
+it is serving again, runs this smoke, and restores the original build on every
+exit path — including failure, interruption and a hung bot. A restore that does
+not come back clean is reported as the run's outcome even when the smoke passed.
+`./tools/qa-runtime.sh self-test` proves that restore path against fake services;
+`snapshot` prints the live identity without touching anything.
+
+Until #331 this was driven by `pr-preflight.sh qa-loot-race` against PM2, which
+this host no longer runs.
 
 This live mode is never part of normal CI. Both guards are mandatory because it
 temporarily mutates a world GameObject fixture and two disposable characters.


### PR DESCRIPTION
Closes #334.

#331 retired `pr-preflight.sh` and with it `qa-loot-race`, the only orchestration around the bot's
destructive two-session loot smoke. It drove PM2, which this host does not run: `world-server` and
`bnet-server` are **systemd units** started from `target/deploy/live`, and `redeploy-rustycore.sh`
already swaps builds that way.

`tools/qa-runtime.sh` rebuilds the wrapper against that model and keeps the property that made the
old one safe: **the live build is snapshotted by path and SHA-256 before anything is installed, and
put back on every exit path** — success, failure, interruption, or a bot killed on timeout. A
restore that does not come back clean becomes the run's outcome even when the smoke passed, because
the normal server is then not the build it was.

Preconditions carry over from the retired helpers:

| Guard | PM2 original | systemd now |
|---|---|---|
| service identity | `pm2 jlist` name/status/`pm_exec_path` | `ActiveState`, `MainPID`, `NRestarts`, and `/proc/<pid>/exe` resolved against the deploy path |
| build identity | SHA-256 of the pinned executable | unchanged, plus a verified snapshot copy before the swap |
| port ownership | every listening socket on 8085/8086 owned by that PID | unchanged, verbatim |
| packet dump absent | PM2 env scan | unit `Environment` **and** `/proc/<pid>/environ` |

Both flags are unchanged: one for touching the live runtime, one for acknowledging that the smoke
mutates a world GameObject fixture and two disposable characters.

## The self-test is the point

A wrapper whose value is "it puts the build back" cannot be reviewed by reading it.
`tools/qa_runtime_self_test.sh` drives the **real script** against a fake systemd, a fake bot and a
fake deploy directory, then compares the bytes of the live build. **24 checks**, including:

- refuses without each mandatory flag, and swaps nothing;
- refuses a candidate that is not executable, before anything stops;
- a dry run that starts, copies and stops nothing;
- the happy path — the bot demonstrably ran against the *candidate* bytes, the *original* bytes are
  back afterwards;
- a smoke that exits 3: still restored, and 3 is the run's status;
- a restore whose `systemctl start` fails: exit **70**, "NOT RESTORED CLEANLY", and the original
  copy kept on disk with its path printed;
- a configured packet dump, a dirty worktree, and a second run racing for the lock.

The injection points (`QA_SYSTEMCTL`, `QA_LIVE_DIR`, `QA_BOT`, `QA_EXE_RESOLVER`, `QA_GIT_DIR`, …)
exist for that test; production defaults address the real host and no guard has a bypass switch.

Evidence: `./tools/qa-runtime.sh self-test` — PASS (24 checks);
`./tools/validation-v2 final --base origin/3.4.3` — exit 0.

A real run against the live service follows this merge, and its result goes on the issue.