### PR TITLE
Give the runtime QA wrapper the credentials the bot needs

### DIFF
--- a/tools/qa-runtime.sh
+++ b/tools/qa-runtime.sh
@@ -33,6 +33,9 @@ QA_EXE_RESOLVER="${QA_EXE_RESOLVER:-realpath -e --}"
 # Which worktree must be clean for the swapped build to be identifiable. The
 # self-test points this at its own clean fixture repository.
 QA_GIT_DIR="${QA_GIT_DIR:-$REPO_ROOT}"
+# Per-account bot passwords. The login-smoke wrapper loads this file; the bot
+# binary does not, so a run that invokes the binary directly must.
+QA_ENV_FILE="${QA_ENV_FILE:-$REPO_ROOT/tools/wow-test-bot/.env.local}"
 
 DRY_RUN=0
 ALLOW_RUNTIME_QA=0
@@ -201,6 +204,24 @@ write_report() {
     "$1" "$2" "$QA_SERVICE" "$ORIGINAL_SHA" "${3:-}" "${4:-null}" >"$REPORT"
 }
 
+# Values are exported, never echoed: this file holds passwords.
+load_bot_environment() {
+  [[ -f "$QA_ENV_FILE" ]] || return 0
+  set -a
+  # shellcheck disable=SC1090
+  source "$QA_ENV_FILE"
+  set +a
+}
+
+have_bot_credentials() {
+  local name
+  for name in $(compgen -v | grep '^WOW_BOT_PASSWORD' || true); do
+    [[ -n "${!name}" ]] && return 0
+  done
+  # A declared-but-empty password is not a credential.
+  [[ -f "$QA_ENV_FILE" ]] && grep -qE '^WOW_BOT_PASSWORD[A-Z0-9_]*=.' "$QA_ENV_FILE"
+}
+
 require_clean_worktree() {
   [[ -z "$(git -C "$QA_GIT_DIR" status --porcelain=v1 --untracked-files=normal)" ]] \
     || die "runtime QA requires a clean worktree so the swapped build is identifiable"
@@ -232,6 +253,8 @@ run_loot_race() {
   [[ -f "$LIVE_PATH" ]] || die "no live build at $LIVE_PATH"
   [[ -x "$QA_BOT" ]] || die "QA bot is not built: $QA_BOT"
   require_clean_worktree
+  have_bot_credentials || die \
+    "no bot credentials: set WOW_BOT_PASSWORD or provide $QA_ENV_FILE before swapping a build"
 
   local candidate_sha
   candidate_sha="$(sha256_of "$candidate")"
@@ -272,6 +295,7 @@ run_loot_race() {
   log "Candidate serving on PID $pid"
 
   local bot_status=0
+  load_bot_environment
   timeout --foreground --signal=TERM --kill-after=30 "${QA_BOT_TIMEOUT_SECONDS}s" \
     "$QA_BOT" --loot-race-smoke --ack-disposable-overworld-loot-race || bot_status=$?
   if ((bot_status == 0)); then

--- a/tools/qa_runtime_self_test.sh
+++ b/tools/qa_runtime_self_test.sh
@@ -69,6 +69,10 @@ cat >"$WORK/bin/bot" <<'FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
 cat "${QA_FAKE_LIVE:?}" >"${QA_FAKE_STATE:?}.bot-saw"
+# Record only whether a credential arrived, never its value.
+if [[ -n "${WOW_BOT_PASSWORD_TESTBOT2_BOT_LOCAL:-}" ]]; then
+  printf 'credentials-present\n' >"${QA_FAKE_STATE:?}.bot-env"
+fi
 exit "${QA_FAKE_BOT_STATUS:-0}"
 FAKE
 chmod +x "$WORK/bin/bot"
@@ -93,12 +97,14 @@ run_qa() {
     QA_FAKE_STATE="$WORK/state" \
     QA_FAKE_LIVE="$WORK/live/world-server" \
     QA_GIT_DIR="$WORK/repo" \
+    QA_ENV_FILE="$WORK/env.local" \
     "${EXTRA_ENV[@]}" \
     "$QA" "$@"
 }
 
 reset_state() {
   rm -f "$WORK"/state.* "$WORK/lock"
+  printf 'WOW_BOT_PASSWORD_TESTBOT2_BOT_LOCAL=fixture-secret\n' >"$WORK/env.local"
   printf 'ORIGINAL-BUILD\n' >"$WORK/live/world-server"
   EXTRA_ENV=()
 }
@@ -137,6 +143,19 @@ run_qa --allow-runtime-qa --ack-disposable-overworld-loot-race \
 check "the bot ran against the candidate build" bot_saw_candidate
 check "the original build was restored" live_is_original
 check "the report records a pass" grep -q '"outcome":"passed"' "$WORK/report.json"
+check "the smoke received its credentials" test -f "$WORK/state.bot-env"
+check "no credential value reached the report" bash -c '! grep -q fixture-secret "'"$WORK"'/report.json"'
+
+# 4b. Without any credential source the run refuses before touching the service.
+reset_state
+rm -f "$WORK/env.local"
+status=0
+EXTRA_ENV=(WOW_BOT_PASSWORD= WOW_BOT_PASSWORD_TESTBOT2_BOT_LOCAL=)
+output="$(run_qa --allow-runtime-qa \
+  --ack-disposable-overworld-loot-race --world-exec "$WORK/candidate" loot-race 2>&1)" || status=$?
+check "refuses without credentials" grep -q "no bot credentials" <<<"$output"
+check "the credential refusal stopped nothing" bash -c '[[ ! -f "'"$WORK"'/state.log" ]]'
+check "the credential refusal swapped nothing" live_is_original
 
 # 5. A failing smoke still restores, and the failure is the run's status.
 reset_state


### PR DESCRIPTION
Closes #345. Found by running #334's orchestration against the live service for the first time.

The per-account passwords live in the ignored `tools/wow-test-bot/.env.local`, which
`run_rustycore_login_smoke.sh` sources (`:30`) and the **bot binary does not read**.
`qa-runtime.sh` invokes the binary directly, so the destructive smoke would have started with no
credentials — after stopping the service, installing the candidate and restarting it. Safe, since
the restore path puts the original build back, but an entire swap cycle spent discovering a
missing environment variable.

- The env file is sourced immediately before the bot runs, exported and never echoed.
- The run refuses **up front**, before anything is stopped, when neither a `WOW_BOT_PASSWORD*`
  variable nor a password line in that file exists.
- A declared-but-empty password does not count as a credential.

The self-test covers both directions: the fake bot records *that* a credential arrived without
recording its value, the report is checked for the absence of that value, and the refusal case
asserts nothing was stopped or swapped. **29 checks**, up from 24.

Evidence: `./tools/qa-runtime.sh self-test` — PASS (29 checks);
`./tools/validation-v2 final --base origin/3.4.3` — exit 0.