### PR TITLE
Run the QA bot from its own directory

### DIFF
--- a/tools/qa-runtime.sh
+++ b/tools/qa-runtime.sh
@@ -21,6 +21,9 @@ QA_SERVICE="${QA_SERVICE:-world-server}"
 QA_LIVE_DIR="${QA_LIVE_DIR:-$REPO_ROOT/target/deploy/live}"
 QA_LIVE_NAME="${QA_LIVE_NAME:-world-server}"
 QA_BOT="${QA_BOT:-$REPO_ROOT/tools/wow-test-bot/target/debug/wow-test-bot}"
+# The bot resolves config.json relative to its working directory, so it runs
+# from its own directory exactly as run_rustycore_login_smoke.sh does.
+QA_BOT_DIR="${QA_BOT_DIR:-$REPO_ROOT/tools/wow-test-bot}"
 QA_LOCK="${QA_LOCK:-/tmp/rustycore-qa-runtime.lock}"
 QA_WORLD_PORT="${QA_WORLD_PORT:-8085}"
 QA_INSTANCE_PORT="${QA_INSTANCE_PORT:-8086}"
@@ -296,8 +299,10 @@ run_loot_race() {
 
   local bot_status=0
   load_bot_environment
-  timeout --foreground --signal=TERM --kill-after=30 "${QA_BOT_TIMEOUT_SECONDS}s" \
-    "$QA_BOT" --loot-race-smoke --ack-disposable-overworld-loot-race || bot_status=$?
+  [[ -d "$QA_BOT_DIR" ]] || die "bot directory is missing: $QA_BOT_DIR"
+  ( cd "$QA_BOT_DIR" && exec timeout --foreground --signal=TERM --kill-after=30 \
+      "${QA_BOT_TIMEOUT_SECONDS}s" "$QA_BOT" \
+      --loot-race-smoke --ack-disposable-overworld-loot-race ) || bot_status=$?
   if ((bot_status == 0)); then
     log "Loot-race smoke passed"
   else

--- a/tools/qa_runtime_self_test.sh
+++ b/tools/qa_runtime_self_test.sh
@@ -23,7 +23,7 @@ check() {
   fi
 }
 
-mkdir -p "$WORK/live" "$WORK/bin" "$WORK/repo"
+mkdir -p "$WORK/live" "$WORK/bin" "$WORK/repo" "$WORK/botdir"
 # A clean fixture repository: the guard under test is "the worktree is clean",
 # not "this development checkout happens to be".
 git -C "$WORK/repo" init -q
@@ -68,6 +68,7 @@ chmod +x "$WORK/bin/systemctl"
 cat >"$WORK/bin/bot" <<'FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
+pwd >"${QA_FAKE_STATE:?}.bot-cwd"
 cat "${QA_FAKE_LIVE:?}" >"${QA_FAKE_STATE:?}.bot-saw"
 # Record only whether a credential arrived, never its value.
 if [[ -n "${WOW_BOT_PASSWORD_TESTBOT2_BOT_LOCAL:-}" ]]; then
@@ -98,6 +99,7 @@ run_qa() {
     QA_FAKE_LIVE="$WORK/live/world-server" \
     QA_GIT_DIR="$WORK/repo" \
     QA_ENV_FILE="$WORK/env.local" \
+    QA_BOT_DIR="$WORK/botdir" \
     "${EXTRA_ENV[@]}" \
     "$QA" "$@"
 }
@@ -144,6 +146,8 @@ check "the bot ran against the candidate build" bot_saw_candidate
 check "the original build was restored" live_is_original
 check "the report records a pass" grep -q '"outcome":"passed"' "$WORK/report.json"
 check "the smoke received its credentials" test -f "$WORK/state.bot-env"
+check "the smoke ran from the bot's own directory" \
+  bash -c '[[ "$(cat "'"$WORK"'/state.bot-cwd")" == "'"$WORK"'/botdir" ]]'
 check "no credential value reached the report" bash -c '! grep -q fixture-secret "'"$WORK"'/report.json"'
 
 # 4b. Without any credential source the run refuses before touching the service.


### PR DESCRIPTION
Closes #347. Third finding from running #334 against the live service, and the one that actually
stopped the smoke.

The bot resolves `config.json` **relative to the current directory** (`main.rs:1266`), which is why
`run_rustycore_login_smoke.sh` does `cd "$(dirname "$0")"` before launching it (`:14`).
`qa-runtime.sh` did not, so the bot read whatever `config.json` sat in the caller's cwd. Run from
the repository root on this host it found a stray untracked one left by an earlier session and
failed with `No enabled bots matched the current config/filter` — **after** a full stop, swap,
start and restore cycle that behaved correctly and put the original build back.

The bot now runs from an injectable `QA_BOT_DIR` defaulting to `tools/wow-test-bot`, and the fake
bot in the self-test records its working directory, so the assertion is on observed behaviour
rather than on the code reading right. **30 checks**, up from 29.

Evidence: `./tools/qa-runtime.sh self-test` — PASS (30 checks);
`./tools/validation-v2 final --base origin/3.4.3` — exit 0. The first attempt at that gate failed
on trailing whitespace in the new assertion, which is what the gate is for.