### PR TITLE
Drive the maintained smoke wrapper instead of the bare bot binary

### DIFF
--- a/tools/qa-runtime.sh
+++ b/tools/qa-runtime.sh
@@ -21,9 +21,14 @@ QA_SERVICE="${QA_SERVICE:-world-server}"
 QA_LIVE_DIR="${QA_LIVE_DIR:-$REPO_ROOT/target/deploy/live}"
 QA_LIVE_NAME="${QA_LIVE_NAME:-world-server}"
 QA_BOT="${QA_BOT:-$REPO_ROOT/tools/wow-test-bot/target/debug/wow-test-bot}"
-# The bot resolves config.json relative to its working directory, so it runs
-# from its own directory exactly as run_rustycore_login_smoke.sh does.
 QA_BOT_DIR="${QA_BOT_DIR:-$REPO_ROOT/tools/wow-test-bot}"
+# The scenario runs through the maintained wrapper, which owns the bot's
+# environment contract - credentials, working directory, mode selection - rather
+# than this script re-deriving it (#349).
+QA_SMOKE="${QA_SMOKE:-$REPO_ROOT/tools/wow-test-bot/run_rustycore_login_smoke.sh}"
+# Fixture recovery journals. The bot requires an absolute path under a real
+# directory, unused by any previous run.
+QA_JOURNAL_DIR="${QA_JOURNAL_DIR:-/tmp/rustycore-loot-race-qa}"
 QA_LOCK="${QA_LOCK:-/tmp/rustycore-qa-runtime.lock}"
 QA_WORLD_PORT="${QA_WORLD_PORT:-8085}"
 QA_INSTANCE_PORT="${QA_INSTANCE_PORT:-8086}"
@@ -255,6 +260,7 @@ run_loot_race() {
   [[ -x "$candidate" ]] || die "candidate build is not executable: $candidate"
   [[ -f "$LIVE_PATH" ]] || die "no live build at $LIVE_PATH"
   [[ -x "$QA_BOT" ]] || die "QA bot is not built: $QA_BOT"
+  [[ -x "$QA_SMOKE" ]] || die "smoke wrapper is missing: $QA_SMOKE"
   require_clean_worktree
   have_bot_credentials || die \
     "no bot credentials: set WOW_BOT_PASSWORD or provide $QA_ENV_FILE before swapping a build"
@@ -266,7 +272,8 @@ run_loot_race() {
     log "Dry run: nothing is stopped, copied or started"
     printf 'would snapshot  %s\n' "$LIVE_PATH"
     printf 'would install   %s (%s)\n' "$candidate" "$candidate_sha"
-    printf 'would run       %s --loot-race-smoke --ack-disposable-overworld-loot-race\n' "$QA_BOT"
+    printf 'would run       %s with WOW_BOT_LOOT_RACE_SMOKE=1\n' "$QA_SMOKE"
+    printf 'would journal   a fresh path under %s\n' "$QA_JOURNAL_DIR"
     printf 'would restore   the snapshot on every exit path\n'
     return 0
   fi
@@ -300,9 +307,26 @@ run_loot_race() {
   local bot_status=0
   load_bot_environment
   [[ -d "$QA_BOT_DIR" ]] || die "bot directory is missing: $QA_BOT_DIR"
+  mkdir -p "$QA_JOURNAL_DIR"
+  [[ -d "$QA_JOURNAL_DIR" && ! -L "$QA_JOURNAL_DIR" ]] \
+    || die "fixture-journal directory must be a real directory: $QA_JOURNAL_DIR"
+  local journal="$QA_JOURNAL_DIR/fixture-$$-$(date -u +%Y%m%dT%H%M%SZ).journal"
+  [[ ! -e "$journal" && ! -e "${journal}.cleanup-complete" ]] \
+    || die "fixture journal path is not fresh: $journal"
+  log "Fixture recovery journal: $journal"
   ( cd "$QA_BOT_DIR" && exec timeout --foreground --signal=TERM --kill-after=30 \
-      "${QA_BOT_TIMEOUT_SECONDS}s" "$QA_BOT" \
-      --loot-race-smoke --ack-disposable-overworld-loot-race ) || bot_status=$?
+      "${QA_BOT_TIMEOUT_SECONDS}s" env \
+      WOW_BOT_LOOT_RACE_SMOKE=1 \
+      WOW_BOT_ACK_DISPOSABLE_OVERWORLD_LOOT_RACE=1 \
+      WOW_BOT_FIXTURE_JOURNAL="$journal" \
+      WOW_BOT_ENSURE_TEST_ACCOUNTS=0 \
+      "$QA_SMOKE" ) || bot_status=$?
+  # A journal that outlives its run means the world fixture is still mutated.
+  if [[ -e "$journal" ]]; then
+    warn "fixture journal $journal survived the run; the world fixture is still mutated"
+    warn "recover it with: cd $QA_BOT_DIR && WOW_BOT_FIXTURE_JOURNAL=$journal ./target/debug/wow-test-bot --recover-loot-fixture"
+    ((bot_status == 0)) && bot_status=75
+  fi
   if ((bot_status == 0)); then
     log "Loot-race smoke passed"
   else

--- a/tools/qa_runtime_self_test.sh
+++ b/tools/qa_runtime_self_test.sh
@@ -69,6 +69,10 @@ cat >"$WORK/bin/bot" <<'FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
 pwd >"${QA_FAKE_STATE:?}.bot-cwd"
+printf '%s\n' "${WOW_BOT_FIXTURE_JOURNAL:-none}" >"${QA_FAKE_STATE:?}.bot-journal"
+printf '%s\n' "${WOW_BOT_LOOT_RACE_SMOKE:-0}" >"${QA_FAKE_STATE:?}.bot-mode"
+# Some runs leave the fixture mutated; the fixture decides which.
+if [[ "${QA_FAKE_LEAVE_JOURNAL:-0}" == "1" ]]; then : >"${WOW_BOT_FIXTURE_JOURNAL:?}"; fi
 cat "${QA_FAKE_LIVE:?}" >"${QA_FAKE_STATE:?}.bot-saw"
 # Record only whether a credential arrived, never its value.
 if [[ -n "${WOW_BOT_PASSWORD_TESTBOT2_BOT_LOCAL:-}" ]]; then
@@ -84,7 +88,18 @@ printf '%s\n' "${QA_FAKE_LIVE:?}"
 FAKE
 chmod +x "$WORK/bin/resolver"
 
+assert_fake() {
+  local name="$1" value="$2"
+  [[ "$value" == "$WORK"/* ]] || {
+    printf 'FAIL: self-test would drive the real %s (%s)\n' "$name" "$value" >&2
+    exit 1
+  }
+}
+
 run_qa() {
+  assert_fake systemctl "$WORK/bin/systemctl"
+  assert_fake smoke "$WORK/bin/bot"
+  assert_fake journals "$WORK/journals"
   env \
     QA_SYSTEMCTL="$WORK/bin/systemctl" \
     QA_SERVICE="fake-world" \
@@ -100,6 +115,8 @@ run_qa() {
     QA_GIT_DIR="$WORK/repo" \
     QA_ENV_FILE="$WORK/env.local" \
     QA_BOT_DIR="$WORK/botdir" \
+    QA_SMOKE="$WORK/bin/bot" \
+    QA_JOURNAL_DIR="$WORK/journals" \
     "${EXTRA_ENV[@]}" \
     "$QA" "$@"
 }
@@ -146,6 +163,12 @@ check "the bot ran against the candidate build" bot_saw_candidate
 check "the original build was restored" live_is_original
 check "the report records a pass" grep -q '"outcome":"passed"' "$WORK/report.json"
 check "the smoke received its credentials" test -f "$WORK/state.bot-env"
+check "the smoke was asked for loot-race mode" \
+  bash -c '[[ "$(cat "'"$WORK"'/state.bot-mode")" == "1" ]]'
+check "the smoke received a fresh absolute journal" \
+  bash -c 'j="$(cat "'"$WORK"'/state.bot-journal")"; [[ "$j" == /* && "$j" == *journals/fixture-* ]]'
+check "a completed run leaves no journal behind" \
+  bash -c '! compgen -G "'"$WORK"'/journals/*.journal" >/dev/null'
 check "the smoke ran from the bot's own directory" \
   bash -c '[[ "$(cat "'"$WORK"'/state.bot-cwd")" == "'"$WORK"'/botdir" ]]'
 check "no credential value reached the report" bash -c '! grep -q fixture-secret "'"$WORK"'/report.json"'
@@ -170,6 +193,18 @@ run_qa --allow-runtime-qa --ack-disposable-overworld-loot-race \
 check "a failing smoke fails the run" test "$status" -eq 3
 check "a failing smoke still restores" live_is_original
 check "the report records the failure" grep -q '"outcome":"failed"' "$WORK/report.json"
+
+# 5b. A run that leaves its journal behind is a pending fixture recovery.
+reset_state
+EXTRA_ENV=(QA_FAKE_LEAVE_JOURNAL=1)
+status=0
+output="$(run_qa --allow-runtime-qa --ack-disposable-overworld-loot-race \
+  --world-exec "$WORK/candidate" loot-race 2>&1)" || status=$?
+check "a surviving journal fails the run" test "$status" -eq 75
+check "a surviving journal is explained" grep -q "still mutated" <<<"$output"
+check "a surviving journal names the recovery command" grep -q -- "--recover-loot-fixture" <<<"$output"
+check "a surviving journal still restored the build" live_is_original
+rm -f "$WORK"/journals/*.journal
 
 # 6. A restore that cannot start the service outranks everything else.
 reset_state


### PR DESCRIPTION
Closes #349.

Three consecutive live runs of #334 failed on three different pieces of the bot's environment
contract — credentials (#345), working directory (#347), and the fixture recovery journal — each
time **after** a correct stop, swap, start and restore cycle. That is one design fault, not three
bugs: `qa-runtime.sh` invoked the binary directly and had to re-derive a contract that
`run_rustycore_login_smoke.sh` already owns, and that the retired `pr-preflight.sh` drove *through*
that script rather than around it.

The wrapper is now invoked with `WOW_BOT_LOOT_RACE_SMOKE=1`, the destructive acknowledgement,
`WOW_BOT_ENSURE_TEST_ACCOUNTS=0`, and a journal path that is **fresh per run** under a directory
verified to be real and not a symlink — the contract `loot_race.rs:394-434` enforces.

A journal that outlives its run means the world fixture is still mutated, so it is treated like a
failed restore: **exit 75**, an explanation, and the exact `--recover-loot-fixture` command.

## Self-test: 30 → 37 checks

New: loot-race mode requested, a fresh absolute journal handed over, no journal left behind by a
clean run, and a surviving journal failing the run *while still restoring the build*.

It also now refuses to start unless every injected tool resolves inside its own temporary
directory. That guard exists because an editing mistake during this work let one self-test run
reach the *real* wrapper — harmless in the event (the fake `systemctl` kept the live service
untouched, and the run bailed before creating a journal), but precisely the accident a fixture
harness must make impossible.

Evidence: `./tools/qa-runtime.sh self-test` — PASS (37 checks);
`./tools/validation-v2 final --base origin/3.4.3` — exit 0.