### PR TITLE
Plan a crate removal instead of refusing it

### DIFF
--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -173,10 +173,13 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
 
     # The audit's own budget must outlast its longest step.
     assert runner.DEFAULT_TIMEOUT == 900 and runner.AUDIT_TIMEOUT == 3600
-    audit_locked = invoke("audit", directory / "audit-timeout.json")
-    assert audit_locked.returncode in {0, runner.LOCKED_ERROR}, audit_locked.stderr
-    if audit_locked.returncode == 0:
-        recorded = json.loads((directory / "audit-timeout.json").read_text())
+    # A fixture repository cannot satisfy a real audit, and whether the host
+    # heavy lock is free decides how far it gets. Only the recorded budget is
+    # this test's business.
+    audit_manifest = directory / "audit-timeout.json"
+    invoke("audit", audit_manifest)
+    if audit_manifest.exists():
+        recorded = json.loads(audit_manifest.read_text())
         assert recorded["resources"]["command_timeout_seconds"] == runner.AUDIT_TIMEOUT
     assert (
         json.loads(success_manifest.read_text())["resources"]["command_timeout_seconds"]
@@ -576,9 +579,28 @@ def test_planner_contract(repo: Path) -> None:
     assert any(command[:2] == ["cargo", "fmt"] and "handler-contract-check" in " ".join(command) for command in commands)
     assert any(command[:2] == ["cargo", "fmt"] and "wow-test-bot" in " ".join(command) for command in commands)
 
-    deleted_groups = runner.grouped_paths(["crates/deleted/Cargo.toml"])
+    # A crate that is gone from disk and from the resolved workspace was removed,
+    # and a removal can affect anything: plan it root-wide rather than refuse.
+    removed_paths = ["crates/removed/Cargo.toml"]
+    removed_groups = runner.grouped_paths(removed_paths)
+    removed_workspace = runner.affected_workspace(repo, removed_paths, removed_groups, metadata)
+    assert removed_workspace["root_wide"] is True
+    assert removed_workspace["direct_packages"] == ["a", "b", "c"]
+    removed_commands, _ = runner.validation_commands(
+        repo, "final", 2, "base", removed_groups, removed_workspace
+    )
+    assert any(
+        command[:5] == ["cargo", "check", "--locked", "--workspace", "--all-targets"]
+        for command in removed_commands
+    )
+
+    # A manifest deleted while its package still resolves is an inconsistent
+    # tree, and still fails closed.
+    deleted_paths = ["crates/a/Cargo.toml"]
+    (repo / "crates" / "a" / "Cargo.toml").unlink()
+    deleted_groups = runner.grouped_paths(deleted_paths)
     try:
-        runner.affected_workspace(repo, ["crates/deleted/Cargo.toml"], deleted_groups, metadata)
+        runner.affected_workspace(repo, deleted_paths, deleted_groups, metadata)
     except ValueError as error:
         assert "deleted workspace manifest" in str(error)
     else:

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -487,10 +487,25 @@ def affected_workspace(
     reverse = model["reverse"]
     assert isinstance(by_id, dict) and isinstance(roots, list) and isinstance(reverse, dict)
     root_wide = "workspace-root" in groups
-    direct_ids: set[str] = set(by_id) if root_wide else set()
+    direct_ids: set[str] = set()
     for path in groups.get("workspace-rust", []):
         if path.endswith("Cargo.toml") and not (repo / path).exists():
-            raise ValueError(f"deleted workspace manifest requires explicit recovery: {path}")
+            # A manifest that is gone from disk and from the resolved workspace
+            # is a crate removal, which can affect anything: plan it root-wide.
+            # A manifest that is gone while its package still resolves is an
+            # inconsistent tree, and still fails closed.
+            directory = path.rsplit("/", 1)[0]
+            if any(root == directory for root, _ in roots):
+                raise ValueError(
+                    f"deleted workspace manifest requires explicit recovery: {path}"
+                )
+            root_wide = True
+            continue
+    if root_wide:
+        direct_ids = set(by_id)
+    for path in groups.get("workspace-rust", []):
+        if path.endswith("Cargo.toml") and not (repo / path).exists():
+            continue
         matches = [package_id for root, package_id in roots if path == root or path.startswith(f"{root}/")]
         if len(matches) != 1:
             raise ValueError(f"changed workspace path maps to {len(matches)} packages: {path}")


### PR DESCRIPTION
Closes #353. Unblocks #298, which removes the empty `wow-ecs` crate.

`affected_workspace` maps every changed `crates/**` path to exactly one workspace package, so a
deleted `Cargo.toml` mapped to none and the planner failed closed:

```
validation-v2: deleted workspace manifest requires explicit recovery: crates/wow-ecs/Cargo.toml
```

Correct as a default, but it left crate removal with **no local gate at all** — which is exactly
when a workspace-wide compile matters most.

A manifest gone from disk **and** from the resolved workspace is a removal: it now plans root-wide,
like any other change that can affect anything. A manifest gone while its package still resolves is
an inconsistent tree, and still fails closed.

## A test of mine that only passed by luck

The audit-budget assertion I added in #340 required the fixture audit to return `0` or the lock
error. That only held while some *other* audit happened to hold the host heavy lock — with the lock
free, the fixture audit actually runs, cannot satisfy real architecture tooling, and returns
something else. A fixture repository cannot satisfy a real audit, so the test now asserts only what
it is about: the recorded timeout.

Evidence: `python3 tools/test_validation_v2.py` — passed, including the new root-wide planning case
and the still-fails-closed case; `./tools/validation-v2 final --base origin/3.4.3` — exit 0.