### PR TITLE
Plan every file of a removed crate, not only its manifest

### DIFF
--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -581,7 +581,7 @@ def test_planner_contract(repo: Path) -> None:
 
     # A crate that is gone from disk and from the resolved workspace was removed,
     # and a removal can affect anything: plan it root-wide rather than refuse.
-    removed_paths = ["crates/removed/Cargo.toml"]
+    removed_paths = ["crates/removed/Cargo.toml", "crates/removed/src/lib.rs"]
     removed_groups = runner.grouped_paths(removed_paths)
     removed_workspace = runner.affected_workspace(repo, removed_paths, removed_groups, metadata)
     assert removed_workspace["root_wide"] is True
@@ -596,6 +596,23 @@ def test_planner_contract(repo: Path) -> None:
 
     # A manifest deleted while its package still resolves is an inconsistent
     # tree, and still fails closed.
+    # A source file that resolves to no package but is still on disk stays an
+    # error: that is an unclassified path, not a removal.
+    present_unclassified = repo / "crates" / "stray.rs"
+    present_unclassified.write_text("// not part of any package\n")
+    try:
+        runner.affected_workspace(
+            repo,
+            ["crates/stray.rs"],
+            runner.grouped_paths(["crates/stray.rs"]),
+            metadata,
+        )
+    except ValueError as error:
+        assert "maps to 0 packages" in str(error), error
+    else:
+        raise AssertionError("an unclassified present path did not fail closed")
+    present_unclassified.unlink()
+
     deleted_paths = ["crates/a/Cargo.toml"]
     (repo / "crates" / "a" / "Cargo.toml").unlink()
     deleted_groups = runner.grouped_paths(deleted_paths)

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -487,29 +487,34 @@ def affected_workspace(
     reverse = model["reverse"]
     assert isinstance(by_id, dict) and isinstance(roots, list) and isinstance(reverse, dict)
     root_wide = "workspace-root" in groups
-    direct_ids: set[str] = set()
+    removed: list[str] = []
+    matched: list[tuple[str, str]] = []
     for path in groups.get("workspace-rust", []):
-        if path.endswith("Cargo.toml") and not (repo / path).exists():
-            # A manifest that is gone from disk and from the resolved workspace
-            # is a crate removal, which can affect anything: plan it root-wide.
-            # A manifest that is gone while its package still resolves is an
-            # inconsistent tree, and still fails closed.
-            directory = path.rsplit("/", 1)[0]
-            if any(root == directory for root, _ in roots):
+        matches = [
+            package_id for root, package_id in roots if path == root or path.startswith(f"{root}/")
+        ]
+        if len(matches) == 1:
+            # The package still resolves, so a missing manifest means the tree
+            # disagrees with the lock file rather than that a crate was removed.
+            if path.endswith("Cargo.toml") and not (repo / path).exists():
                 raise ValueError(
                     f"deleted workspace manifest requires explicit recovery: {path}"
                 )
-            root_wide = True
+            matched.append((path, matches[0]))
             continue
-    if root_wide:
-        direct_ids = set(by_id)
-    for path in groups.get("workspace-rust", []):
-        if path.endswith("Cargo.toml") and not (repo / path).exists():
+        # A path that resolves to no package and no longer exists belonged to a
+        # crate that was removed. A removal can affect anything, so it is planned
+        # root-wide. A path that resolves to no package but is still on disk is
+        # genuinely unclassified, and still fails closed.
+        if not matches and not (repo / path).exists():
+            removed.append(path)
             continue
-        matches = [package_id for root, package_id in roots if path == root or path.startswith(f"{root}/")]
-        if len(matches) != 1:
-            raise ValueError(f"changed workspace path maps to {len(matches)} packages: {path}")
-        direct_ids.add(matches[0])
+        raise ValueError(f"changed workspace path maps to {len(matches)} packages: {path}")
+    if removed:
+        root_wide = True
+    direct_ids: set[str] = set(by_id) if root_wide else set()
+    for _, package_id in matched:
+        direct_ids.add(package_id)
     closure = set(direct_ids)
     pending = list(sorted(direct_ids))
     while pending:


### PR DESCRIPTION
Refs #353, completing it. Unblocks #298.

My fix in #354 handled the deleted `Cargo.toml` and left the crate's other files mapping to zero packages, so the gate still refused:

```
validation-v2: changed workspace path maps to 0 packages: crates/wow-ecs/src/lib.rs
```

Now any changed path under `crates/` that resolves to no package **and no longer exists** belonged to a removed crate, and a removal is planned root-wide. Two cases stay errors, with their own tests: a path that resolves to no package but is **still on disk** is genuinely unclassified, and a manifest that is gone while its package **still resolves** is a tree that disagrees with the lock file — not a removal.

Evidence: `python3 tools/test_validation_v2.py` — passed; `./tools/validation-v2 final --base origin/3.4.3` — exit 0.