### PR TITLE
Refresh the issue-state mirror after #204

### DIFF
--- a/tools/architecture/architecture-issue-ledger.json
+++ b/tools/architecture/architecture-issue-ledger.json
@@ -657,7 +657,7 @@
     },
     {
       "number": 204,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.DB.1a] Resolve Self constants through the active trait impl",
       "kind": "slice",
       "parents": [


### PR DESCRIPTION
Refs #133, #299.

#204 closed on merge, so the checked-in mirror was one field stale — the condition the weekly `Issue state drift` job exists to catch. Derived with `check_architecture.py refresh-issue-state`, not edited by hand.

Validated with both guards the mirror feeds, per the rule #341 added: `check_architecture.py check` — exit 0, and the **exhaustive** `session-ownership-check check` — PASS. `./tools/validation-v2 final --base origin/3.4.3` — exit 0.