### PR TITLE
Give the session hotspot an owner that can actually reduce it

### DIFF
--- a/docs/architecture/ownership-and-boundaries.md
+++ b/docs/architecture/ownership-and-boundaries.md
@@ -672,7 +672,9 @@ display is checked against the JSON ledger:
 63. #230 — agent-neutral module CLI and skeleton;
 64. #231 — typed module configuration/fixtures;
 65. #270 — retire the four PlayerBroadcastInfo transport endpoints;
-66. #153 — terminal architecture audit.
+66. #359 — single dispatch mechanism for every opcode;
+67. #297 — promote the Session kernel to `wow-session`;
+68. #153 — terminal architecture audit.
 
 A slice may start once its declared prerequisites are merged and its branch is current. Independent
 physical work remains parallel to semantic authority cuts. Mechanical moves use focused compile and

--- a/tools/architecture/architecture-issue-ledger.json
+++ b/tools/architecture/architecture-issue-ledger.json
@@ -76,6 +76,8 @@
     230,
     231,
     270,
+    359,
+    297,
     153
   ],
   "issues": [
@@ -443,6 +445,30 @@
         183,
         187,
         200
+      ]
+    },
+    {
+      "number": 359,
+      "state": "open",
+      "title": "[ARCH.P4.1a] Retire the dispatcher's 479 match arms in favour of the registration that already exists",
+      "kind": "slice",
+      "parents": [
+        133
+      ],
+      "depends_on": [
+        152
+      ]
+    },
+    {
+      "number": 297,
+      "state": "open",
+      "title": "[ARCH.P4.1] Promote the Session kernel to a wow-session crate",
+      "kind": "slice",
+      "parents": [
+        133
+      ],
+      "depends_on": [
+        359
       ]
     },
     {

--- a/tools/architecture/runtime-ownership-ledger.json
+++ b/tools/architecture/runtime-ownership-ledger.json
@@ -1828,9 +1828,11 @@
           "total_lines": 170300,
           "owner": "wow-world WorldSession/application monolith.",
           "open_retirement_issues": [
-            153
+            153,
+            297,
+            359
           ],
-          "retirement_condition": "Session is a thin protocol/lifecycle shell with no mutable Player/Map gameplay, concrete DB/catalog bag, or external impl growth; LOC alone does not close it."
+          "retirement_condition": "Session is a thin protocol/lifecycle shell with no mutable Player/Map gameplay, concrete DB/catalog bag, or external impl growth; LOC alone does not close it. #297 owns the kernel promotion and #359 the dispatcher decoupling that unblocks it; #252 owns the gameplay mirror. Until they land this row is a reviewed exception to the epic's 4,000-line signal, not a target."
         },
         {
           "path": "crates/wow-map/src/map/mod.rs",


### PR DESCRIPTION
Refs #133, #297, #359, #153.

#297 asked for a measurement before any code moved. It produced an answer the epic had not
recorded: the coupling that blocks a `wow-session` crate is the **routing mechanism**, not
`WorldSession`'s 729 fields.

- The six candidate kernel modules read **39** `WorldSession` fields between them — **33** already
  in kernel families, **zero** catalogs, and exactly six outside (three of which wait on #28).
- `dispatch.rs` carries **479 opcode match arms** and calls **376 handler methods** directly, while
  `handlers/` already carries **105 `inventory::submit!` registrations** of `PacketHandlerEntry`.

So #359 owns retiring the arms, and #297 owns the crate that becomes possible after. Both join the
issue ledger as slices under #133, sequenced before the terminal audit, and mirrored into the
documented refactor sequence so the JSON and the prose stay the same list.

## The row that had no owner

`session/mod.rs` is **74,614 production lines** — the epic's own 4,000-line signal, exceeded 18×.
Its hotspot row pointed only at #153, and #153 is explicitly *"no longer the gate where known work
is discovered"*: the terminal audit is where postponing work is forbidden, not where it gets done.
The row now names #297 and #359, and its retirement condition says what each owns.

Evidence: `check_architecture.py check` — exit 0; `self-test` — PASS;
**exhaustive** `session-ownership-check check` — PASS (the ledger rule from #341);
`./tools/validation-v2 final --base origin/3.4.3` — exit 0.