### PR TITLE
Retire the three shared delivery handles from PlayerBroadcastInfo (#361)

### DIFF
--- a/crates/world-server/src/main_tests.rs
+++ b/crates/world-server/src/main_tests.rs
@@ -269,9 +269,6 @@ fn player_broadcast_info_fixture_like_cpp(
             in_combat: false,
             liquid_status: 0,
             is_in_world: true,
-            client_visible_guids_like_cpp: Default::default(),
-            advanced_combat_logging_enabled_like_cpp: Default::default(),
-            visibility_refresh_pending_like_cpp: Default::default(),
             active_loot_rolls: Vec::new(),
             pass_on_group_loot: false,
             enchanting_skill: 0,
@@ -342,6 +339,9 @@ fn player_broadcast_info_fixture_like_cpp(
         send_tx,
         command_tx,
         durable_creature_runtime_commands_like_cpp: Default::default(),
+        client_visible_guids_like_cpp: Default::default(),
+        advanced_combat_logging_enabled_like_cpp: Default::default(),
+        visibility_refresh_pending_like_cpp: Default::default(),
     }
 }
 
@@ -6917,9 +6917,6 @@ fn game_event_seasonal_post_db_delete_fanout_queues_session_command_like_cpp() {
                 in_combat: false,
                 liquid_status: 0,
                 is_in_world: true,
-                client_visible_guids_like_cpp: Default::default(),
-                advanced_combat_logging_enabled_like_cpp: Default::default(),
-                visibility_refresh_pending_like_cpp: Default::default(),
                 active_loot_rolls: Vec::new(),
                 pass_on_group_loot: false,
                 enchanting_skill: 0,
@@ -6990,6 +6987,9 @@ fn game_event_seasonal_post_db_delete_fanout_queues_session_command_like_cpp() {
             send_tx,
             command_tx,
             durable_creature_runtime_commands_like_cpp: Default::default(),
+            client_visible_guids_like_cpp: Default::default(),
+            advanced_combat_logging_enabled_like_cpp: Default::default(),
+            visibility_refresh_pending_like_cpp: Default::default(),
         },
         Default::default(),
     );
@@ -10570,11 +10570,9 @@ fn creature_spell_start_go_is_one_atomic_observer_command_without_victim_drain_l
     let (observer_info, _observer_command_rx) =
         make_registry_player_like_cpp(571, 0, Position::new(25.0, 0.0, 0.0, 0.0), true);
     victim_info
-        .info
         .client_visible_guids_like_cpp
         .insert(make_source_guid());
     observer_info
-        .info
         .client_visible_guids_like_cpp
         .insert(make_source_guid());
     registry.register_or_replace(victim_guid, victim_info, Default::default());
@@ -10634,11 +10632,9 @@ fn creature_spell_plan_skips_invisible_observer_but_reaches_victim_like_cpp() {
     // Both viewers already have the caster at client; only range separates
     // them here.
     victim_info
-        .info
         .client_visible_guids_like_cpp
         .insert(make_source_guid());
     invisible_observer_info
-        .info
         .client_visible_guids_like_cpp
         .insert(make_source_guid());
     registry.register_or_replace(victim_guid, victim_info, Default::default());
@@ -10685,10 +10681,9 @@ fn creature_spell_plan_commits_have_at_client_at_resolution_like_cpp() {
     let (unaware_info, _unaware_command_rx) =
         make_registry_player_like_cpp(571, 0, Position::new(25.0, 0.0, 0.0, 0.0), true);
     victim_info
-        .info
         .client_visible_guids_like_cpp
         .insert(make_source_guid());
-    let unaware_visibility = unaware_info.info.client_visible_guids_like_cpp.clone();
+    let unaware_visibility = unaware_info.client_visible_guids_like_cpp.clone();
     registry.register_or_replace(victim_guid, victim_info, Default::default());
     registry.register_or_replace(unaware_guid, unaware_info, Default::default());
 

--- a/crates/wow-world/src/handlers/chat.rs
+++ b/crates/wow-world/src/handlers/chat.rs
@@ -1928,9 +1928,6 @@ mod tests {
                 combat_reach: 0.0,
                 liquid_status: 0,
                 is_in_world: true,
-                client_visible_guids_like_cpp: Default::default(),
-                advanced_combat_logging_enabled_like_cpp: Default::default(),
-                visibility_refresh_pending_like_cpp: Default::default(),
                 active_loot_rolls: Vec::new(),
                 in_combat: false,
                 pass_on_group_loot: false,
@@ -2002,6 +1999,9 @@ mod tests {
             send_tx,
             command_tx,
             durable_creature_runtime_commands_like_cpp: Default::default(),
+            client_visible_guids_like_cpp: Default::default(),
+            advanced_combat_logging_enabled_like_cpp: Default::default(),
+            visibility_refresh_pending_like_cpp: Default::default(),
         }
     }
 

--- a/crates/wow-world/src/handlers/group_tests.rs
+++ b/crates/wow-world/src/handlers/group_tests.rs
@@ -104,9 +104,6 @@ fn broadcast_info_with_command_tx(
             combat_reach: 0.0,
             liquid_status: 0,
             is_in_world: true,
-            client_visible_guids_like_cpp: Default::default(),
-            advanced_combat_logging_enabled_like_cpp: Default::default(),
-            visibility_refresh_pending_like_cpp: Default::default(),
             active_loot_rolls: Vec::new(),
             in_combat: false,
             pass_on_group_loot: false,
@@ -178,6 +175,9 @@ fn broadcast_info_with_command_tx(
         send_tx,
         command_tx,
         durable_creature_runtime_commands_like_cpp: Default::default(),
+        client_visible_guids_like_cpp: Default::default(),
+        advanced_combat_logging_enabled_like_cpp: Default::default(),
+        visibility_refresh_pending_like_cpp: Default::default(),
     }
 }
 

--- a/crates/wow-world/src/handlers/loot_tests.rs
+++ b/crates/wow-world/src/handlers/loot_tests.rs
@@ -4766,9 +4766,6 @@ fn broadcast_info(
             combat_reach: 0.0,
             liquid_status: 0,
             is_in_world: true,
-            client_visible_guids_like_cpp: Default::default(),
-            advanced_combat_logging_enabled_like_cpp: Default::default(),
-            visibility_refresh_pending_like_cpp: Default::default(),
             active_loot_rolls: Vec::new(),
             in_combat: false,
             pass_on_group_loot: false,
@@ -4840,6 +4837,9 @@ fn broadcast_info(
         send_tx,
         command_tx,
         durable_creature_runtime_commands_like_cpp: Default::default(),
+        client_visible_guids_like_cpp: Default::default(),
+        advanced_combat_logging_enabled_like_cpp: Default::default(),
+        visibility_refresh_pending_like_cpp: Default::default(),
     }
 }
 

--- a/crates/wow-world/src/handlers/misc/tests/mod.rs
+++ b/crates/wow-world/src/handlers/misc/tests/mod.rs
@@ -736,9 +736,6 @@ fn broadcast_info_with_command_tx(
             combat_reach: 0.0,
             liquid_status: 0,
             is_in_world: true,
-            client_visible_guids_like_cpp: Default::default(),
-            advanced_combat_logging_enabled_like_cpp: Default::default(),
-            visibility_refresh_pending_like_cpp: Default::default(),
             active_loot_rolls: Vec::new(),
             in_combat: false,
             pass_on_group_loot: false,
@@ -810,6 +807,9 @@ fn broadcast_info_with_command_tx(
         send_tx,
         command_tx,
         durable_creature_runtime_commands_like_cpp: Default::default(),
+        client_visible_guids_like_cpp: Default::default(),
+        advanced_combat_logging_enabled_like_cpp: Default::default(),
+        visibility_refresh_pending_like_cpp: Default::default(),
     }
 }
 

--- a/crates/wow-world/src/handlers/movement.rs
+++ b/crates/wow-world/src/handlers/movement.rs
@@ -2752,9 +2752,6 @@ mod tests {
                 combat_reach: 0.0,
                 liquid_status: 0,
                 is_in_world: true,
-                client_visible_guids_like_cpp: Default::default(),
-                advanced_combat_logging_enabled_like_cpp: Default::default(),
-                visibility_refresh_pending_like_cpp: Default::default(),
                 active_loot_rolls: Vec::new(),
                 in_combat: false,
                 pass_on_group_loot: false,
@@ -2826,6 +2823,9 @@ mod tests {
             send_tx,
             command_tx,
             durable_creature_runtime_commands_like_cpp: Default::default(),
+            client_visible_guids_like_cpp: Default::default(),
+            advanced_combat_logging_enabled_like_cpp: Default::default(),
+            visibility_refresh_pending_like_cpp: Default::default(),
         }
     }
 

--- a/crates/wow-world/src/session/directory.rs
+++ b/crates/wow-world/src/session/directory.rs
@@ -41,10 +41,12 @@ use wow_packet::packets::update::ChrCustomizationChoiceValuesUpdate;
 /// Everything a session hands the directory when it registers.
 ///
 /// #270 splits this from [`PlayerBroadcastInfo`]: the projection is the
-/// gameplay state other sessions read, while these four handles are this
-/// session's own delivery channels and durable rail. They live beside the
-/// private registry entry, exactly as #189 placed the durable loot-money
-/// coordinator, so no remote reader can obtain a raw sender from a snapshot.
+/// gameplay state other sessions read, while these handles are this session's
+/// own delivery channels, durable rail, and the visibility/combat-logging state
+/// producers resolve against (#361). They live beside the private registry
+/// entry, exactly as #189 placed the durable loot-money coordinator, so no
+/// remote reader can obtain a handle from a snapshot and no gameplay publish
+/// can replace one.
 #[derive(Clone)]
 pub struct PlayerSessionRegistrationLikeCpp {
     /// Gameplay projection stored for other sessions to read.
@@ -61,6 +63,24 @@ pub struct PlayerSessionRegistrationLikeCpp {
     /// Durable FIFO rail for authoritative creature combat transitions.
     pub durable_creature_runtime_commands_like_cpp:
         Arc<Mutex<DurableCreatureRuntimeCommandsLikeCpp>>,
+    /// Shared C++ `Player::m_clientGUIDs` membership for this session.
+    ///
+    /// Producers that must commit a recipient decision at the moment a message
+    /// is resolved read it here instead of leaving the receiving session to
+    /// re-derive visibility from state that moved on in the meantime.
+    pub client_visible_guids_like_cpp: SharedClientVisibleGuidsLikeCpp,
+    /// Shared C++ advanced-combat-logging preference for this session.
+    ///
+    /// `WorldObject::SendCombatLogMessage` picks the basic or full `SMSG_SPELL_GO`
+    /// frame per receiver while it distributes the cast, so a producer reads this
+    /// when the cast resolves rather than leaving the choice to drain time.
+    pub advanced_combat_logging_enabled_like_cpp: Arc<AtomicBool>,
+    /// Durable/coalesced equivalent of C++'s retained visibility notify bit.
+    ///
+    /// Senders set this before attempting the bounded command queue. The owning
+    /// session consumes it even when the queue was full, so player entry/exit
+    /// visibility cannot be lost under command backpressure.
+    pub visibility_refresh_pending_like_cpp: Arc<AtomicBool>,
 }
 
 /// Information stored for each active player session.
@@ -86,24 +106,6 @@ pub struct PlayerBroadcastInfo {
     pub liquid_status: u32,
     /// Represented C++ `Player::IsInWorld()` receiver gate for global-message fanout.
     pub is_in_world: bool,
-    /// Shared C++ `Player::m_clientGUIDs` membership for this session.
-    ///
-    /// Producers that must commit a recipient decision at the moment a message
-    /// is resolved read it here instead of leaving the receiving session to
-    /// re-derive visibility from state that moved on in the meantime.
-    pub client_visible_guids_like_cpp: SharedClientVisibleGuidsLikeCpp,
-    /// Shared C++ advanced-combat-logging preference for this session.
-    ///
-    /// `WorldObject::SendCombatLogMessage` picks the basic or full `SMSG_SPELL_GO`
-    /// frame per receiver while it distributes the cast, so a producer reads this
-    /// when the cast resolves rather than leaving the choice to drain time.
-    pub advanced_combat_logging_enabled_like_cpp: Arc<AtomicBool>,
-    /// Durable/coalesced equivalent of C++'s retained visibility notify bit.
-    ///
-    /// Senders set this before attempting the bounded command queue. The owning
-    /// session consumes it even when the queue was full, so player entry/exit
-    /// visibility cannot be lost under command backpressure.
-    pub visibility_refresh_pending_like_cpp: Arc<AtomicBool>,
     /// Exact represented pending loot-roll identities owned by this session.
     /// The packet key may be reused, so cross-session routing must clone this
     /// identity into the queued command rather than publishing keys alone.
@@ -579,6 +581,11 @@ struct PlayerRegistryEntry {
     realm_send_tx: flume::Sender<Vec<u8>>,
     command_tx: flume::Sender<SessionCommand>,
     durable_creature_runtime_commands_like_cpp: Arc<Mutex<DurableCreatureRuntimeCommandsLikeCpp>>,
+    /// Shared handles read live at resolve time; beside the entry, not in the
+    /// projection, so publishing gameplay state cannot replace one (#361).
+    client_visible_guids_like_cpp: SharedClientVisibleGuidsLikeCpp,
+    advanced_combat_logging_enabled_like_cpp: Arc<AtomicBool>,
+    visibility_refresh_pending_like_cpp: Arc<AtomicBool>,
     /// Durable loot-money coordination for this incarnation.
     ///
     /// Issue #189 keeps this beside the entry rather than inside
@@ -587,6 +594,32 @@ struct PlayerRegistryEntry {
     /// resolved here only so a remote looter can address the recipient's
     /// coordinator. It creates no second store and no second authority.
     durable_loot_money: Arc<DurableLootMoneyPersistenceTrackerLikeCpp>,
+}
+
+impl PlayerRegistryEntry {
+    /// One recipient snapshot, built the same way for the bulk and single-GUID
+    /// resolvers so a gate added to one cannot be missed by the other.
+    fn runtime_recipient_like_cpp(&self, guid: ObjectGuid) -> PlayerRuntimeRecipient {
+        PlayerRuntimeRecipient {
+            registration: PlayerRegistration {
+                guid,
+                generation: self.generation,
+            },
+            guid,
+            map_id: self.info.map_id,
+            instance_id: self.info.instance_id,
+            position: self.info.position,
+            combat_reach: self.info.combat_reach,
+            liquid_status: self.info.liquid_status,
+            is_in_world: self.info.is_in_world,
+            is_alive: self.info.is_alive,
+            account_id: self.info.account_id,
+            advanced_combat_logging: self
+                .advanced_combat_logging_enabled_like_cpp
+                .load(Ordering::Relaxed),
+            committed_visibility: self.client_visible_guids_like_cpp.clone(),
+        }
+    }
 }
 
 /// Thread-safe directory of active player sessions, keyed by player GUID.
@@ -642,6 +675,9 @@ impl PlayerRegistry {
             realm_send_tx,
             command_tx,
             durable_creature_runtime_commands_like_cpp,
+            client_visible_guids_like_cpp,
+            advanced_combat_logging_enabled_like_cpp,
+            visibility_refresh_pending_like_cpp,
         } = registration;
         self.entries.insert(
             guid,
@@ -652,6 +688,9 @@ impl PlayerRegistry {
                 realm_send_tx,
                 command_tx,
                 durable_creature_runtime_commands_like_cpp,
+                client_visible_guids_like_cpp,
+                advanced_combat_logging_enabled_like_cpp,
+                visibility_refresh_pending_like_cpp,
                 durable_loot_money,
             },
         );
@@ -706,30 +745,7 @@ impl PlayerRegistry {
     pub fn runtime_recipients(&self) -> Vec<PlayerRuntimeRecipient> {
         self.entries
             .iter()
-            .map(|entry| {
-                let guid = *entry.key();
-                let entry = entry.value();
-                PlayerRuntimeRecipient {
-                    registration: PlayerRegistration {
-                        guid,
-                        generation: entry.generation,
-                    },
-                    guid,
-                    map_id: entry.info.map_id,
-                    instance_id: entry.info.instance_id,
-                    position: entry.info.position,
-                    combat_reach: entry.info.combat_reach,
-                    liquid_status: entry.info.liquid_status,
-                    is_in_world: entry.info.is_in_world,
-                    is_alive: entry.info.is_alive,
-                    account_id: entry.info.account_id,
-                    advanced_combat_logging: entry
-                        .info
-                        .advanced_combat_logging_enabled_like_cpp
-                        .load(Ordering::Relaxed),
-                    committed_visibility: entry.info.client_visible_guids_like_cpp.clone(),
-                }
-            })
+            .map(|entry| entry.value().runtime_recipient_like_cpp(*entry.key()))
             .collect()
     }
 
@@ -737,26 +753,7 @@ impl PlayerRegistry {
     #[must_use]
     pub fn runtime_recipient(&self, guid: ObjectGuid) -> Option<PlayerRuntimeRecipient> {
         let entry = self.entries.get(&guid)?;
-        Some(PlayerRuntimeRecipient {
-            registration: PlayerRegistration {
-                guid,
-                generation: entry.generation,
-            },
-            guid,
-            map_id: entry.info.map_id,
-            instance_id: entry.info.instance_id,
-            position: entry.info.position,
-            combat_reach: entry.info.combat_reach,
-            liquid_status: entry.info.liquid_status,
-            is_in_world: entry.info.is_in_world,
-            is_alive: entry.info.is_alive,
-            account_id: entry.info.account_id,
-            advanced_combat_logging: entry
-                .info
-                .advanced_combat_logging_enabled_like_cpp
-                .load(Ordering::Relaxed),
-            committed_visibility: entry.info.client_visible_guids_like_cpp.clone(),
-        })
+        Some(entry.runtime_recipient_like_cpp(guid))
     }
 
     /// Resolve one connected chat/social identity by case-insensitive player
@@ -1755,7 +1752,7 @@ impl PlayerRegistry {
             .get(&registration.guid)
             .filter(|entry| entry.generation == registration.generation)
             .ok_or(PlayerDirectorySendError::StaleRegistration)?;
-        let pending = Arc::clone(&entry.info.visibility_refresh_pending_like_cpp);
+        let pending = Arc::clone(&entry.visibility_refresh_pending_like_cpp);
         let tx = entry.command_tx.clone();
         drop(entry);
         pending.store(true, Ordering::Release);
@@ -1844,9 +1841,6 @@ mod tests {
                 combat_reach: 0.0,
                 liquid_status: 0,
                 is_in_world: true,
-                client_visible_guids_like_cpp: Default::default(),
-                advanced_combat_logging_enabled_like_cpp: Default::default(),
-                visibility_refresh_pending_like_cpp: Default::default(),
                 active_loot_rolls: Vec::new(),
                 in_combat: false,
                 pass_on_group_loot: false,
@@ -1918,6 +1912,9 @@ mod tests {
             send_tx,
             command_tx,
             durable_creature_runtime_commands_like_cpp: Default::default(),
+            client_visible_guids_like_cpp: Default::default(),
+            advanced_combat_logging_enabled_like_cpp: Default::default(),
+            visibility_refresh_pending_like_cpp: Default::default(),
         };
         assert_eq!(info.info.instance_id, 42);
         assert_eq!(info.info.map_id, 571);

--- a/crates/wow-world/src/session/mod.rs
+++ b/crates/wow-world/src/session/mod.rs
@@ -34839,13 +34839,6 @@ impl WorldSession {
             combat_reach: self.canonical_player_combat_reach_snapshot_like_cpp(),
             liquid_status: self.player_liquid_status_like_cpp(),
             is_in_world: self.player_is_in_world_for_registry_like_cpp(),
-            client_visible_guids_like_cpp: self.client_visible_guids_like_cpp.clone(),
-            advanced_combat_logging_enabled_like_cpp: Arc::clone(
-                &self.advanced_combat_logging_enabled_like_cpp,
-            ),
-            visibility_refresh_pending_like_cpp: Arc::clone(
-                &self.visibility_refresh_pending_like_cpp,
-            ),
             active_loot_rolls: self
                 .represented_loot_rolls
                 .values()
@@ -34942,6 +34935,13 @@ impl WorldSession {
                 command_tx: self.session_command_tx.clone(),
                 durable_creature_runtime_commands_like_cpp: Arc::clone(
                     &self.durable_creature_runtime_commands_like_cpp,
+                ),
+                client_visible_guids_like_cpp: self.client_visible_guids_like_cpp.clone(),
+                advanced_combat_logging_enabled_like_cpp: Arc::clone(
+                    &self.advanced_combat_logging_enabled_like_cpp,
+                ),
+                visibility_refresh_pending_like_cpp: Arc::clone(
+                    &self.visibility_refresh_pending_like_cpp,
                 ),
             },
             Arc::clone(&self.durable_loot_money_persistence_like_cpp),

--- a/crates/wow-world/src/session_tests.rs
+++ b/crates/wow-world/src/session_tests.rs
@@ -35614,6 +35614,64 @@ fn broadcast_info(
     broadcast_info_with_command(guid, send_tx, command_tx)
 }
 
+/// The three shared handles are registration input beside the private registry
+/// entry, not gameplay state (#361). A session publishes gameplay facts by
+/// replacing the projection, and that publish must not be able to detach or
+/// swap a handle a producer resolves against.
+/// C++ anchor: `Player::m_clientGUIDs` (`Object.h`) and the session's own
+/// visibility/combat-logging state live on the player, never in the copy other
+/// players read while distributing a message.
+#[test]
+fn publishing_gameplay_state_cannot_detach_the_shared_session_handles_like_cpp() {
+    let registry = PlayerRegistry::new();
+    let guid = ObjectGuid::create_player(1, 900);
+    let (send_tx, _send_rx) = flume::bounded::<Vec<u8>>(4);
+    let (command_tx, _command_rx) = flume::bounded::<SessionCommand>(4);
+    let registration = broadcast_info_with_command(guid, send_tx, command_tx);
+    let visibility = registration.client_visible_guids_like_cpp.clone();
+    let refresh = Arc::clone(&registration.visibility_refresh_pending_like_cpp);
+    registration
+        .advanced_combat_logging_enabled_like_cpp
+        .store(true, Ordering::Release);
+    let registered = registry.register_or_replace(guid, registration, Default::default());
+
+    let seen = ObjectGuid::create_player(1, 901);
+    visibility.insert(seen);
+
+    // The only thing a gameplay publish can replace is the projection.
+    assert!(registry.fixture_update(guid, |info| info.map_id = 571));
+    assert_eq!(
+        registry.fixture_snapshot(guid).expect("registered").map_id,
+        571,
+        "the projection still carries published gameplay state"
+    );
+
+    let recipient = registry.runtime_recipient(guid).expect("registered");
+    assert_eq!(recipient.map_id, 571);
+    assert!(
+        recipient.committed_visibility.contains(&seen),
+        "the live visibility handle survives a gameplay publish"
+    );
+    assert!(
+        recipient.advanced_combat_logging,
+        "the receiver preference is resolved from the session handle"
+    );
+
+    recipient.committed_visibility.remove(&seen);
+    assert!(
+        !visibility.contains(&seen),
+        "resolving against the directory reaches the session's own set"
+    );
+
+    registry
+        .request_current_visibility_refresh(registered, 571, 0)
+        .expect("a current registration accepts a refresh");
+    assert!(
+        refresh.load(Ordering::Acquire),
+        "the retained notify bit is the session's own handle"
+    );
+}
+
 fn broadcast_info_with_command(
     guid: ObjectGuid,
     send_tx: flume::Sender<Vec<u8>>,
@@ -35627,9 +35685,6 @@ fn broadcast_info_with_command(
             combat_reach: 0.0,
             liquid_status: 0,
             is_in_world: true,
-            client_visible_guids_like_cpp: Default::default(),
-            advanced_combat_logging_enabled_like_cpp: Default::default(),
-            visibility_refresh_pending_like_cpp: Default::default(),
             active_loot_rolls: Vec::new(),
             in_combat: false,
             pass_on_group_loot: false,
@@ -35701,6 +35756,9 @@ fn broadcast_info_with_command(
         send_tx,
         command_tx,
         durable_creature_runtime_commands_like_cpp: Default::default(),
+        client_visible_guids_like_cpp: Default::default(),
+        advanced_combat_logging_enabled_like_cpp: Default::default(),
+        visibility_refresh_pending_like_cpp: Default::default(),
     }
 }
 
@@ -35953,7 +36011,7 @@ async fn player_visibility_refresh_survives_full_command_queue_like_cpp() {
 
     let mut receiver_info =
         broadcast_info_with_command(receiver_guid, receiver_send_tx, full_command_tx);
-    receiver_info.info.visibility_refresh_pending_like_cpp =
+    receiver_info.visibility_refresh_pending_like_cpp =
         Arc::clone(&receiver.visibility_refresh_pending_like_cpp);
     source_registry.register_or_replace(receiver_guid, receiver_info, Default::default());
 

--- a/docs/architecture/player-broadcast-info-retirement.tsv
+++ b/docs/architecture/player-broadcast-info-retirement.tsv
@@ -4,11 +4,9 @@ active_expansion	Session admission identity	#252	query immutable admitted-client
 active_loot_rolls	wow-loot roll authority	#252	query exact active roll identities from loot owner
 active_quest_objective_counts	canonical Player quest log	#252	query immutable quest objective state
 active_quest_statuses	canonical Player quest log	#252	query immutable quest status
-advanced_combat_logging_enabled_like_cpp	canonical Player presentation preferences	#252	query receiver preference at resolution
 auto_reply_msg_like_cpp	canonical Player social presence	#252	query immutable AFK/DND response
 base_mana	canonical Player/Unit powers	#252	query immutable CREATE power facts
 class	canonical Player identity	#252	query immutable character identity
-client_visible_guids_like_cpp	canonical Player visibility membership	#252	query versioned receiver visibility membership
 combat_reach	canonical Player/Unit combat geometry	#252	query immutable target geometry
 completed_achievements	canonical Player achievements	#252	query immutable achievement membership
 current_health	canonical Player/Unit vitals	#252	query immutable party/runtime vitals
@@ -69,7 +67,6 @@ transport	canonical Player location under MapRuntime	#252	query immutable transp
 unit_flags	canonical Player/Unit state flags	#252	query immutable targetability flags
 unit_flags2	canonical Player/Unit state flags	#252	query immutable secondary flags
 unit_state	canonical Player/Unit state machine	#252	query immutable unit-state mask
-visibility_refresh_pending_like_cpp	canonical Player visibility scheduling	#252	consume versioned visibility refresh intent
 visible_items	canonical Player inventory presentation	#252	query immutable equipped-item presentation
 yesterday_contribution	canonical Player PvP progression	#252	query immutable inspect honor facts
 yesterday_honorable_kills	canonical Player PvP progression	#252	query immutable inspect honor facts

--- a/tools/architecture/runtime-ownership-ledger.json
+++ b/tools/architecture/runtime-ownership-ledger.json
@@ -1397,7 +1397,7 @@
         "cross_check": "tools/architecture/session-ownership-policy.json#syntax_baseline.player_broadcast_info.fields"
       },
       "audited_summary": {
-        "field_count": 75,
+        "field_count": 72,
         "count_kind": "baseline observation; AST is authoritative"
       },
       "coverage_rule": {
@@ -1405,7 +1405,7 @@
         "member_key": "name",
         "zero_gaps": true,
         "zero_overlap": true,
-        "expected_field_count": 75,
+        "expected_field_count": 72,
         "validation": "Compare sorted AST field names with the sorted concatenation of every entry.field_names; reject gaps, duplicates, stale names, entry count drift, or total count drift."
       },
       "entries": [
@@ -1425,14 +1425,11 @@
         },
         {
           "id": "directory_delivery_and_visibility_handles",
-          "expected_field_count": 4,
+          "expected_field_count": 1,
           "field_names": [
-            "advanced_combat_logging_enabled_like_cpp",
-            "client_visible_guids_like_cpp",
-            "visibility_refresh_pending_like_cpp",
             "visible_items"
           ],
-          "owner": "Player/session publishes receiver-local delivery state into PlayerRegistry; Map selects spatial candidates and Player owns client-visible membership.",
+          "owner": "Player/session publishes receiver-local delivery state into PlayerRegistry; the shared visibility and combat-logging handles now live beside the private registry entry (#361), so only the visible-items projection remains here.",
           "open_retirement_issues": [
             252
           ],
@@ -1540,7 +1537,7 @@
           "retirement_condition": "#252 removes every assigned residual through bounded canonical queries and deletes the broad projection without introducing a replacement mirror."
         }
       ],
-      "expected_field_count": 75
+      "expected_field_count": 72
     },
     "session_command": {
       "coverage_source": {
@@ -1823,9 +1820,9 @@
       "entries": [
         {
           "path": "crates/wow-world/src/session/mod.rs",
-          "production_lines": 74614,
-          "test_lines": 95686,
-          "total_lines": 170300,
+          "production_lines": 74611,
+          "test_lines": 95744,
+          "total_lines": 170355,
           "owner": "wow-world WorldSession/application monolith.",
           "open_retirement_issues": [
             153,

--- a/tools/architecture/session-ownership-policy.json
+++ b/tools/architecture/session-ownership-policy.json
@@ -55604,13 +55604,6 @@
           "source_class": "production"
         },
         {
-          "name": "advanced_combat_logging_enabled_like_cpp",
-          "type": "Arc < AtomicBool >",
-          "visibility": "pub",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
           "name": "auto_reply_msg_like_cpp",
           "type": "String",
           "visibility": "pub",
@@ -55627,13 +55620,6 @@
         {
           "name": "class",
           "type": "u8",
-          "visibility": "pub",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "client_visible_guids_like_cpp",
-          "type": "SharedClientVisibleGuidsLikeCpp",
           "visibility": "pub",
           "cfg": [],
           "source_class": "production"
@@ -56054,13 +56040,6 @@
         {
           "name": "unit_state",
           "type": "u32",
-          "visibility": "pub",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "visibility_refresh_pending_like_cpp",
-          "type": "Arc < AtomicBool >",
           "visibility": "pub",
           "cfg": [],
           "source_class": "production"


### PR DESCRIPTION
#343 moved the four transport endpoints beside the private `PlayerRegistryEntry`
but left `client_visible_guids_like_cpp`, `advanced_combat_logging_enabled_like_cpp`
and `visibility_refresh_pending_like_cpp` in the gameplay projection. They are
not gameplay state: they are shared handles the owning session holds, so any
session cloning a snapshot obtained a live handle to another session's client
visibility, and publishing gameplay state could replace one.

The three fields move to `PlayerSessionRegistrationLikeCpp` and to the private
entry, exactly where #189 put the durable loot-money coordinator and #343 the
transport endpoints. `PlayerBroadcastInfo` is the projection alone, 75 fields
down to 72. The five reads repoint from `entry.info.<handle>` to
`entry.<handle>`; the two recipient resolvers that read two of them were
building the same eleven-field `PlayerRuntimeRecipient` literal twice, so they
now share one builder on the entry.

Behaviour is unchanged: `MessageDistDeliverer`-style producers still resolve the
receiver's committed visibility and combat-logging preference at the moment the
message is resolved, and `request_current_visibility_refresh` still sets the
session's own retained notify bit before the bounded queue attempt.

C++ anchors: `Player.h:2450 : Player::m_clientGUIDs`,
`Object.cpp:1785 : WorldObject::SendCombatLogMessage`, and
`GridNotifiersImpl.h:38 : MessageDistDeliverer::Visit`.

Checks: `cargo check --workspace --tests` clean; `cargo test -p wow-world --lib`
3570/0 and `-p world-server` 449/0; `check_architecture.py check` and `self-test`
PASS; `session-ownership-check check --syntax-only` and the exhaustive `check`
PASS; `./tools/validation-v2 final` PASS. Hotspot production lines fall
74614 -> 74611.

Closes #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
