### PR TITLE
Keep the tests when a diff goes root-wide (#364)

### DIFF
--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -514,11 +514,51 @@ def test_planner_contract(repo: Path) -> None:
     assert ratchet in final and ratchet not in quick
     assert len({tuple(command) for command in final}) == len(final)
 
+    # A root-wide path widens the check to the whole workspace. It must not
+    # narrow the tests to nothing: the broader the change, the weaker that made
+    # the gate (#364). With nothing else changed, every library is tested.
     root_groups = runner.grouped_paths(["Cargo.lock"])
     root_workspace = runner.affected_workspace(repo, ["Cargo.lock"], root_groups, metadata)
     assert root_workspace["root_wide"] is True
     assert root_workspace["direct_packages"] == ["a", "b", "c"]
-    assert root_workspace["direct_library_packages"] == []
+    assert root_workspace["direct_library_packages"] == ["a", "b", "c"]
+
+    # With a crate changed alongside it, the root-wide path must not lose the
+    # tests that crate would have got on its own.
+    lock_and_crate = ["Cargo.lock", "crates/a/src/lib.rs"]
+    lock_and_crate_groups = runner.grouped_paths(lock_and_crate)
+    lock_and_crate_workspace = runner.affected_workspace(
+        repo, lock_and_crate, lock_and_crate_groups, metadata
+    )
+    assert lock_and_crate_workspace["root_wide"] is True
+    assert lock_and_crate_workspace["direct_library_packages"] == ["a"]
+
+    # The property both cases exist for: a plan that compiles the workspace
+    # must also run tests. A green gate that ran none is the defect #364 names.
+    for planned_workspace, planned_groups in (
+        (root_workspace, root_groups),
+        (lock_and_crate_workspace, lock_and_crate_groups),
+    ):
+        planned, _ = runner.validation_commands(
+            repo, "final", 2, "base", planned_groups, planned_workspace
+        )
+        assert any(
+            command[:5] == ["cargo", "check", "--locked", "--workspace", "--all-targets"]
+            for command in planned
+        )
+        assert any(command[:2] == ["cargo", "test"] for command in planned), planned
+    # Changing the gate must run the gate's own contract suite, not just a
+    # syntax check (#364).
+    harness_suite = repo / "tools" / "test_validation_v2.py"
+    harness_suite.parent.mkdir(parents=True, exist_ok=True)
+    harness_suite.write_text("fixture\n")
+    for changed in (["tools/validation-v2"], ["tools/test_validation_v2.py"]):
+        harness_groups = runner.grouped_paths(changed)
+        harness_commands, _ = runner.validation_commands(
+            repo, "final", 2, "base", harness_groups, None
+        )
+        assert ["python3", "tools/test_validation_v2.py"] in harness_commands, harness_commands
+
     docs_commands, _ = runner.validation_commands(
         repo, "quick", 2, "base", runner.grouped_paths(["docs/guide.md"]), None
     )
@@ -593,6 +633,10 @@ def test_planner_contract(repo: Path) -> None:
         command[:5] == ["cargo", "check", "--locked", "--workspace", "--all-targets"]
         for command in removed_commands
     )
+    # A removal resolves to no package, so there is nothing narrower to keep:
+    # it tests every library rather than none (#364).
+    assert removed_workspace["direct_library_packages"] == ["a", "b", "c"]
+    assert any(command[:2] == ["cargo", "test"] for command in removed_commands)
 
     # A manifest deleted while its package still resolves is an inconsistent
     # tree, and still fails closed.

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -35,6 +35,8 @@ DEFAULT_TIMEOUT = 900
 AUDIT_TIMEOUT = 3600
 DEFAULT_BASE = "origin/3.4.3"
 DEFAULT_HEAVY_LOCK = "/tmp/rustycore-validation-v2-heavy.lock"
+RUNNER_PATH = "tools/validation-v2"
+RUNNER_CONTRACT_SUITE = "tools/test_validation_v2.py"
 CHECKER_MANIFEST = "tools/architecture/handler-contract-check/Cargo.toml"
 BOT_MANIFEST = "tools/wow-test-bot/Cargo.toml"
 INTERRUPT_SIGNALS = (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
@@ -527,19 +529,32 @@ def affected_workspace(
     def names(package_ids: set[str]) -> list[str]:
         return sorted(str(by_id[package_id]["name"]) for package_id in package_ids)
 
-    library_ids = {
-        package_id
-        for package_id in direct_ids
-        if any(
-            isinstance(target, dict) and "lib" in target.get("kind", [])
-            for target in by_id[package_id].get("targets", [])
-        )
-    }
+    def library_ids(package_ids: set[str]) -> set[str]:
+        return {
+            package_id
+            for package_id in package_ids
+            if any(
+                isinstance(target, dict) and "lib" in target.get("kind", [])
+                for target in by_id[package_id].get("targets", [])
+            )
+        }
+
+    # A root-wide path widens the compile check to the whole workspace, and it
+    # used to blank this list — so the broader the change, the fewer tests ran
+    # (#364). It keeps at least the tests the same diff would have got without
+    # its root-wide path, and falls back to every library when the root-wide
+    # path is the only thing that changed, which is exactly when anything can
+    # break.
+    matched_library_ids = library_ids({package_id for _, package_id in matched})
+    if root_wide:
+        tested_library_ids = matched_library_ids or library_ids(set(by_id))
+    else:
+        tested_library_ids = library_ids(direct_ids)
     return {
         "root_wide": root_wide,
         "direct_packages": names(direct_ids),
         "reverse_closure_packages": names(closure),
-        "direct_library_packages": [] if root_wide else names(library_ids),
+        "direct_library_packages": names(tested_library_ids),
     }
 
 
@@ -680,6 +695,13 @@ def validation_commands(
         )
     if python_files:
         add_command(planned, ["python3", "-m", "py_compile", *python_files])
+        # Changing the gate must run the gate's own contract suite. A syntax
+        # check is what let #364 — a plan that compiled the workspace and tested
+        # nothing — be written here in the first place.
+        if any(path in {RUNNER_PATH, RUNNER_CONTRACT_SUITE} for path in python_files) and (
+            repo / RUNNER_CONTRACT_SUITE
+        ).exists():
+            add_command(planned, ["python3", RUNNER_CONTRACT_SUITE])
     if "workflow" in groups:
         workflow_files = existing(groups["workflow"])
         if workflow_files and shutil.which("actionlint"):


### PR DESCRIPTION
`final` is the pre-push gate, and for a first-party PR it is the only gate
before merge — the exhaustive `audit` runs after the push to `3.4.3`. A diff
that touched a root-wide path (`Cargo.lock`, the root manifest, a removed
crate) planned `cargo check --locked --workspace --all-targets` and then no
`cargo test` at all, because the planner blanked `direct_library_packages`
whenever `root_wide` was set. The broader the change, the weaker the gate.

It showed up on #359: 478 packet-handler registrations rewired, 1,640 lines of
dispatcher deleted, one `Cargo.lock` line touched — `status: passed`, zero
`wow-world` or `world-server` tests run. Those tests were run by hand, so
nothing shipped untested, but the gate would have passed a tree where every one
of them failed.

Blanking the list was a reasonable answer to "do not run every library's tests
on a lockfile bump", and it is still the wrong one: the fix for too many tests
cannot be none. The planner now keeps at least what the same diff would have got
without its root-wide path, and falls back to every library only when the
root-wide path is the only thing that changed — which is exactly when anything
can break.

    Cargo.lock + two crates   no tests  ->  -p wow-handler -p wow-world
    Cargo.lock alone          no tests  ->  all 34 libraries
    one crate                 1 library ->  unchanged

The contract suite now asserts the property directly: a plan that compiles the
workspace must also run tests. It covers the lockfile-only case, the
lockfile-plus-crate case, and the removed-crate case, so this cannot regress
into a green gate that ran nothing.

Second hole, same shape, found by this change's own gate run: editing the
runner planned `python3 -m py_compile` and nothing else, so the gate that
validates every PR was itself validated by a syntax check — which is how a
planner that compiled the workspace and tested nothing got written here. A
change to `tools/validation-v2` or `tools/test_validation_v2.py` now plans the
contract suite, and the suite asserts that too.

Checks: `python3 tools/test_validation_v2.py` passes; `./tools/validation-v2
self-test` passes; `./tools/validation-v2 final --base origin/3.4.3` passes and
now plans the test step this change is about.

Closes #364.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
