### PR TITLE
Assert the collector's invariants instead of nine stale numbers (#363)

### DIFF
--- a/tools/architecture/handler-contract-check/src/ownership.rs
+++ b/tools/architecture/handler-contract-check/src/ownership.rs
@@ -1564,11 +1564,34 @@ pub(crate) fn audit_package_source_mounts(
     ))
 }
 
+/// The logical mounts of every source, and which of them are reachable in
+/// production with no `cfg` on the way down.
+///
+/// The collector needs the second answer. Before #359 it had to *be* the crate
+/// root, which made a conditional parent impossible by construction; owning it
+/// by module path instead lost that for free, so the mount chain is now checked
+/// explicitly (#363).
 pub(crate) fn audit_package_source_graph(
     package_root: &Path,
     production_roots: &[PathBuf],
-) -> Result<(BTreeMap<PathBuf, BTreeSet<String>>, usize), String> {
+) -> Result<
+    (
+        BTreeMap<PathBuf, BTreeSet<String>>,
+        usize,
+        BTreeSet<PathBuf>,
+    ),
+    String,
+> {
     let (mounts, explicit_paths) = audit_package_source_mounts(package_root, production_roots)?;
+    let unconditional = mounts
+        .iter()
+        .filter(|(_, contexts)| {
+            contexts
+                .iter()
+                .any(|context| context.production_possible && context.cfg.is_empty())
+        })
+        .map(|(source, _)| source.clone())
+        .collect();
     Ok((
         mounts
             .into_iter()
@@ -1583,6 +1606,7 @@ pub(crate) fn audit_package_source_graph(
             })
             .collect(),
         explicit_paths,
+        unconditional,
     ))
 }
 
@@ -1745,7 +1769,7 @@ fn is_owned_handler_mount(
 pub(crate) fn audit_package_registration_sources(
     package_name: &str,
     sources: &BTreeMap<PathBuf, BTreeSet<String>>,
-    production_lib_roots: &BTreeSet<PathBuf>,
+    unconditional: &BTreeSet<PathBuf>,
 ) -> Result<(), String> {
     let test_owner = CapabilityOwner {
         capability: "handler_registration".to_owned(),
@@ -1754,18 +1778,13 @@ pub(crate) fn audit_package_registration_sources(
         allow_descendants: true,
         tracking_issue: 153,
     };
-    audit_package_registration_sources_with_owner(
-        package_name,
-        sources,
-        production_lib_roots,
-        &test_owner,
-    )
+    audit_package_registration_sources_with_owner(package_name, sources, unconditional, &test_owner)
 }
 
 pub(crate) fn audit_package_registration_sources_with_owner(
     package_name: &str,
     sources: &BTreeMap<PathBuf, BTreeSet<String>>,
-    production_lib_roots: &BTreeSet<PathBuf>,
+    unconditional: &BTreeSet<PathBuf>,
     owner: &CapabilityOwner,
 ) -> Result<(), String> {
     let mut errors = Vec::new();
@@ -1777,9 +1796,12 @@ pub(crate) fn audit_package_registration_sources_with_owner(
         let source = fs::read_to_string(source_path)
             .map_err(|error| format!("cannot read {}: {error}", source_path.display()))?;
         // The collector is no longer a crate root, so it is identified by its
-        // logical module rather than by being lib.rs (#359).
+        // logical module rather than by being lib.rs (#359) — and, because that
+        // no longer rules out a conditional parent by construction, by having an
+        // unconditional production mount (#363).
         let collector_owner = package_name == REGISTRY_PACKAGE_NAME
-            && logical_paths == &BTreeSet::from([REGISTRY_MODULE_PATH.to_owned()]);
+            && logical_paths == &BTreeSet::from([REGISTRY_MODULE_PATH.to_owned()])
+            && unconditional.contains(source_path);
         match analyze_registration_syntax_outside_handlers(source_path, &source, collector_owner) {
             Ok(report) => exact_collectors += report.exact_packet_handler_collectors,
             Err(error) => errors.push(format!("package {package_name}: {error}")),
@@ -1821,7 +1843,7 @@ pub(crate) fn audit_registration_ownership(
     let mut errors = Vec::new();
     let mut package_names = Vec::new();
     for scope in &scopes {
-        let (sources, explicit_paths) =
+        let (sources, explicit_paths, unconditional) =
             audit_package_source_graph(&scope.root, &scope.production_roots).map_err(|error| {
                 format!(
                     "invalid production source graph for {}: {error}",
@@ -1929,7 +1951,7 @@ pub(crate) fn audit_registration_ownership(
             if let Err(error) = audit_package_registration_sources_with_owner(
                 &scope.name,
                 &sources,
-                &scope.production_lib_roots,
+                &unconditional,
                 owner,
             ) {
                 errors.push(error);

--- a/tools/architecture/handler-contract-check/src/session_ownership.rs
+++ b/tools/architecture/handler-contract-check/src/session_ownership.rs
@@ -1874,10 +1874,6 @@ fn collect_workspace_persistence_baseline(
         .map_err(|error| format!("cannot inventory persistence accesses:\n{error}"))
 }
 
-fn collect_repository_baseline(repository_root: &Path) -> Result<SessionSyntaxBaseline, String> {
-    collect_repository_baseline_with_persistence(repository_root, true)
-}
-
 /// Collect the session syntax surface, optionally without the persistence scan.
 ///
 /// The persistence inventory costs a full workspace scan — minutes, and the
@@ -2938,11 +2934,26 @@ mod tests {
         );
     }
 
+    /// The collector sees the repository, and what it sees agrees with the
+    /// baseline the ratchet enforces.
+    ///
+    /// This used to restate nine sizes as literals — 738 fields, 80
+    /// `PlayerBroadcastInfo` fields, 685 registry rows — frozen when #181 first
+    /// baselined the scanner. Every one of those numbers is already owned by
+    /// `session-ownership-policy.json`, so the copies could only rot, and they
+    /// did: by #363 all but one were wrong. It asserts properties now, and the
+    /// counts stay in the one place that ratchets them.
+    ///
+    /// It also asked for the persistence inventory it never looked at, which
+    /// cost a full workspace scan and is why it was skipped by name in both
+    /// validation profiles. The syntax surface is what it asserts, so the
+    /// syntax surface is what it collects.
     #[test]
     fn repository_surface_can_be_collected() {
         let repository_root = crate::repository_root().expect("repository root");
-        let baseline = collect_repository_baseline(&repository_root)
+        let baseline = collect_repository_baseline_with_persistence(&repository_root, false)
             .unwrap_or_else(|error| panic!("repository baseline must parse:\n{error}"));
+
         let raw_session_source =
             fs::read_to_string(repository_root.join("crates/wow-world/src/session/mod.rs"))
                 .expect("read session source");
@@ -2955,39 +2966,69 @@ mod tests {
                 _ => None,
             })
             .expect("WorldSession definition");
-        assert_eq!(raw_fields.len(), 738);
-        let test_only_fields = raw_fields
+
+        // The collector reaches the same struct the parser does, field for field.
+        let raw_names: BTreeSet<String> = raw_fields
+            .iter()
+            .map(|field| {
+                field
+                    .ident
+                    .as_ref()
+                    .expect("WorldSession has named fields")
+                    .to_string()
+            })
+            .collect();
+        let collected_names: BTreeSet<String> = baseline
+            .world_session
+            .fields
+            .iter()
+            .map(|field| field.name.clone())
+            .collect();
+        assert_eq!(collected_names, raw_names);
+
+        // Production and test-fixture partition the surface: no field is both,
+        // none is neither, and the split matches the cfg the source declares.
+        let production = baseline
+            .world_session
+            .fields
+            .iter()
+            .filter(|field| field.source_class == "production")
+            .count();
+        let test_fixture = baseline
+            .world_session
+            .fields
+            .iter()
+            .filter(|field| field.source_class == "test_fixture")
+            .count();
+        assert_eq!(
+            production + test_fixture,
+            baseline.world_session.fields.len()
+        );
+        let raw_test_only = raw_fields
             .iter()
             .filter(|field| {
                 !cfg_context_allows_production(&[], &field.attrs)
                     .expect("repository field cfg is valid")
             })
             .count();
-        assert_eq!(test_only_fields, 11);
-        assert_eq!(baseline.world_session.fields.len(), 738);
-        assert_eq!(
-            baseline
-                .world_session
-                .fields
-                .iter()
-                .filter(|field| field.source_class == "production")
-                .count(),
-            727
-        );
-        assert_eq!(
-            baseline
-                .world_session
-                .fields
-                .iter()
-                .filter(|field| field.source_class == "test_fixture")
-                .count(),
-            11
-        );
-        assert_eq!(baseline.session_resources.fields.len(), 243);
-        assert_eq!(baseline.world_session.impls.len(), 20);
-        assert_eq!(baseline.session_command.variants.len(), 37);
-        assert_eq!(baseline.player_broadcast_info.fields.len(), 80);
-        assert_eq!(baseline.registry_accesses.accesses.len(), 685);
+        assert_eq!(test_fixture, raw_test_only);
+
+        // What it collected is what the checked-in baseline says it should be.
+        // This is the same comparison the gate performs, so a stale test and a
+        // stale ratchet can no longer disagree.
+        let policy = load_policy(&repository_root.join(POLICY_RELATIVE_PATH))
+            .expect("checked-in session ownership policy loads");
+        compare_baseline(&policy.syntax_baseline, &baseline)
+            .expect("the collected surface matches the checked-in baseline");
+
+        // Every surface the baseline tracks was actually collected, so an empty
+        // scan cannot pass the comparison by matching an empty baseline.
+        assert!(!baseline.world_session.fields.is_empty());
+        assert!(!baseline.world_session.impls.is_empty());
+        assert!(!baseline.session_resources.fields.is_empty());
+        assert!(!baseline.session_command.variants.is_empty());
+        assert!(!baseline.player_broadcast_info.fields.is_empty());
+        assert!(!baseline.registry_accesses.accesses.is_empty());
         assert!(baseline.registry_accesses.accesses.iter().all(|record| {
             record.source.starts_with("crates/") && !Path::new(&record.source).is_absolute()
         }));

--- a/tools/architecture/handler-contract-check/src/tests.rs
+++ b/tools/architecture/handler-contract-check/src/tests.rs
@@ -427,13 +427,10 @@ fn handler_module_policy_is_strict_and_registration_uses_declared_owner() {
         outside.canonicalize().expect("canonical outside source"),
         BTreeSet::from(["crate::handlers".to_owned()]),
     )]);
-    let error = audit_package_registration_sources_with_owner(
-        "wow-world",
-        &sources,
-        &BTreeSet::new(),
-        owner,
-    )
-    .expect_err("registration outside declared policy owner must fail");
+    let unconditional: BTreeSet<_> = sources.keys().cloned().collect();
+    let error =
+        audit_package_registration_sources_with_owner("wow-world", &sources, &unconditional, owner)
+            .expect_err("registration outside declared policy owner must fail");
     assert!(error.contains("inventory registration macro"), "{error}");
     fs::remove_dir_all(&fixture).expect("remove registration owner fixture");
 
@@ -1184,7 +1181,7 @@ fn ownership_source_graph_follows_cfg_path_and_target_directories() {
     fs::write(&regular_path, "pub fn legitimate() {}\n").expect("write regular path");
     fs::write(&target_path, "pub fn generated() {}\n").expect("write target path");
 
-    let (sources, explicit_paths) =
+    let (sources, explicit_paths, _) =
         audit_package_source_graph(&fixture, std::slice::from_ref(&crate_root))
             .expect("valid cfg-inactive #[path] modules");
     assert_eq!(explicit_paths, 2);
@@ -1297,14 +1294,15 @@ fn ownership_is_logical_not_a_physical_handlers_prefix() {
     )
     .expect("write hidden submission");
 
-    let (sources, _) = audit_package_source_graph(&fixture, std::slice::from_ref(&crate_root))
-        .expect("source graph resolves");
+    let (sources, _, unconditional) =
+        audit_package_source_graph(&fixture, std::slice::from_ref(&crate_root))
+            .expect("source graph resolves");
     let shadow = shadow.canonicalize().expect("canonical shadow");
     assert_eq!(
         sources.get(&shadow),
         Some(&BTreeSet::from(["crate::shadow".to_owned()]))
     );
-    let error = audit_package_registration_sources("wow-world", &sources, &BTreeSet::new())
+    let error = audit_package_registration_sources("wow-world", &sources, &unconditional)
         .expect_err("a physical handlers prefix must not confer logical ownership");
     assert!(
         error.contains(
@@ -1346,7 +1344,7 @@ fn ownership_propagates_every_logical_remount_to_descendants() {
     )
     .expect("write remounted child submission");
 
-    let (sources, explicit_paths) =
+    let (sources, explicit_paths, unconditional) =
         audit_package_source_graph(&fixture, std::slice::from_ref(&crate_root))
             .expect("every logical remount is traversed");
     assert_eq!(explicit_paths, 1);
@@ -1358,7 +1356,7 @@ fn ownership_propagates_every_logical_remount_to_descendants() {
             "crate::shadow::child".to_owned(),
         ]))
     );
-    let error = audit_package_registration_sources("wow-world", &sources, &BTreeSet::new())
+    let error = audit_package_registration_sources("wow-world", &sources, &unconditional)
         .expect_err("an outside remount must remove the handler-owner exemption from descendants");
     assert!(
         error.contains("inventory registration macro inventory::submit!"),
@@ -1413,15 +1411,15 @@ fn ownership_allows_only_the_exact_registry_module_collector() {
         canonical_root.clone(),
         BTreeSet::from(["crate::session::registry".to_owned()]),
     )]);
-    let production_lib_roots: BTreeSet<_> = sources.keys().cloned().collect();
+    let unconditional: BTreeSet<_> = sources.keys().cloned().collect();
 
-    audit_package_registration_sources("wow-world", &sources, &production_lib_roots)
+    audit_package_registration_sources("wow-world", &sources, &unconditional)
         .expect("one exact unconditional collector in the registry module must pass");
     let elsewhere = BTreeMap::from([(
         canonical_root,
         BTreeSet::from(["crate::session::driver".to_owned()]),
     )]);
-    let error = audit_package_registration_sources("wow-world", &elsewhere, &production_lib_roots)
+    let error = audit_package_registration_sources("wow-world", &elsewhere, &unconditional)
         .expect_err("another session module must not own the collector");
     assert!(
         error.contains("inventory registration macro inventory::collect!"),
@@ -1465,9 +1463,8 @@ fn ownership_allows_only_the_exact_registry_module_collector() {
         ),
     ] {
         fs::write(&crate_root, source).expect("write collector mutant");
-        let error =
-            audit_package_registration_sources("wow-world", &sources, &production_lib_roots)
-                .expect_err("collector mutant must fail closed");
+        let error = audit_package_registration_sources("wow-world", &sources, &unconditional)
+            .expect_err("collector mutant must fail closed");
         assert!(
             error.contains(expected_error),
             "{name}: expected {expected_error:?}, got {error:?}"
@@ -1476,7 +1473,7 @@ fn ownership_allows_only_the_exact_registry_module_collector() {
 
     fs::write(&crate_root, "inventory::collect!(PacketHandlerEntry);\n")
         .expect("restore exact collector");
-    let error = audit_package_registration_sources("world-server", &sources, &production_lib_roots)
+    let error = audit_package_registration_sources("world-server", &sources, &unconditional)
         .expect_err("the exact collector is forbidden outside the registry module");
     assert!(
         error.contains("inventory registration macro inventory::collect!"),
@@ -1495,26 +1492,28 @@ fn ownership_rejects_collector_mounted_below_a_conditional_parent() {
             "#[cfg_attr(windows, cfg(target_pointer_width = \"16\"))]",
         ),
     ] {
+        // Mount the collector at the owner path itself, so the only thing that
+        // can disqualify it is the conditional parent (#363).
         let fixture = source_graph_fixture(name);
         let crate_root = fixture.join("src/lib.rs");
-        let collector_module = fixture.join("src/registry.rs");
-        fs::create_dir_all(crate_root.parent().expect("crate root parent"))
+        let session_module = fixture.join("src/session/mod.rs");
+        let collector_module = fixture.join("src/session/registry.rs");
+        fs::create_dir_all(session_module.parent().expect("session module parent"))
             .expect("create collector fixture");
-        fs::write(&crate_root, format!("{parent_attribute}\nmod registry;\n"))
+        fs::write(&crate_root, format!("{parent_attribute}\nmod session;\n"))
             .expect("write conditional collector parent");
+        fs::write(&session_module, "pub mod registry;\n").expect("write session module");
         fs::write(
             &collector_module,
             "inventory::collect!(PacketHandlerEntry);\n",
         )
         .expect("write nested collector");
 
-        let (sources, _) = audit_package_source_graph(&fixture, std::slice::from_ref(&crate_root))
-            .expect("cfg-independent graph follows collector module");
-        let production_lib_roots =
-            BTreeSet::from([crate_root.canonicalize().expect("canonical lib root")]);
-        let error =
-            audit_package_registration_sources("wow-handler", &sources, &production_lib_roots)
-                .expect_err("a collector below a parent module is not the lib-root collector");
+        let (sources, _, unconditional) =
+            audit_package_source_graph(&fixture, std::slice::from_ref(&crate_root))
+                .expect("cfg-independent graph follows collector module");
+        let error = audit_package_registration_sources("wow-world", &sources, &unconditional)
+            .expect_err("a collector below a conditional parent does not own the collector");
         assert!(
             error.contains("inventory registration macro inventory::collect!"),
             "{name}: {error}"

--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -565,10 +565,26 @@ def test_planner_contract(repo: Path) -> None:
     assert not any(command and command[0] == "cargo" for command in docs_commands)
     assert runner.validation_commands(repo, "quick", 2, "base", {}, None)[0] == []
 
+    # No profile may silence a checker test by name. A skipped test is a test
+    # that rots: #363 was nine stale literals hiding behind `--skip`.
+    checker_groups = runner.grouped_paths(
+        ["tools/architecture/handler-contract-check/src/lib.rs"]
+    )
+    checker_commands, _ = runner.validation_commands(
+        repo, "final", 2, "base", checker_groups, None
+    )
+    checker_test = next(
+        command
+        for command in checker_commands
+        if command[:2] == ["cargo", "test"] and "handler-contract-check" in " ".join(command)
+    )
+    assert "--skip" not in checker_test, checker_test
+
     audit = runner.audit_steps("base", 2)
     for _ in range(10):
         assert audit == runner.audit_steps("base", 2)
     assert len({tuple(step["argv"]) for step in audit}) == len(audit)
+    assert not any("--skip" in step["argv"] for step in audit), audit
     assert [step["section"] for step in audit] == [
         "diff-hygiene",
         "architecture-policy-self-test",

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -588,8 +588,7 @@ def audit_steps(base_commit: str, jobs: int) -> list[dict[str, object]]:
             "handler-contract-unit-tests",
             [
                 "cargo", "test", "--release", "--locked", "--manifest-path",
-                CHECKER_MANIFEST, "--lib", "--jobs", str(jobs), "--", "--skip",
-                "repository_surface_can_be_collected",
+                CHECKER_MANIFEST, "--lib", "--jobs", str(jobs),
             ],
         ),
         (
@@ -753,7 +752,11 @@ def validation_commands(
         command = "test" if profile == "final" else "check"
         checker = ["cargo", command, "--locked", "--manifest-path", CHECKER_MANIFEST, "--jobs", str(jobs)]
         if profile == "final":
-            checker.extend(["--lib", "--", "--skip", "repository_surface_can_be_collected"])
+            # No test is skipped by name here. `repository_surface_can_be_collected`
+            # used to be, because it asked for a persistence inventory it never
+            # asserted; it collects the syntax surface it actually reads and runs
+            # in seconds (#363).
+            checker.append("--lib")
         add_command(planned, checker)
     if "wow-test-bot" in groups:
         add_command(


### PR DESCRIPTION
`repository_surface_can_be_collected` restated nine sizes as literals, frozen
when #181 first baselined the scanner: 738 `WorldSession` fields, 727
production, 11 test-only, 243 `SessionResources` fields, 20 impls, 37 command
variants, 80 `PlayerBroadcastInfo` fields, 685 registry rows. Every one of them
is already owned by `session-ownership-policy.json`, which the ratchet enforces
against the tree, so the copies could only rot. By now all but one had: the
real numbers are 741/729/12, 245, 45, 37, 72 and 570.

It asserts properties instead. The collector reaches the same struct the parser
does, field for field. Production and test-fixture partition that surface, and
the split matches the cfg the source declares. What it collected equals the
checked-in baseline, compared with the same `compare_baseline` the gate uses —
so a stale test and a stale ratchet can no longer disagree. Every tracked
surface is non-empty, so an empty scan cannot pass by matching an empty
baseline. No count is restated.

## Why it was invisible

It was skipped by name in both profiles, so the tool's own suite had been red
while every pipeline consuming it was green. The reason it was skipped is that
it asked for the persistence inventory — a full workspace scan, minutes — and
then asserted nothing about it. It collects the syntax surface it actually
reads: the test drops from over nine minutes to 17 seconds, the whole checker
suite from 855s to 34s, and the `--skip` comes out of `final` and `audit`. The
contract suite now asserts that no checker test is silenced by name in either.

## A regression this caught

Un-skipping it immediately failed `ownership_rejects_collector_mounted_below_a_
conditional_parent`, and it was right: #359 moved the collector's owner from
"is the crate root" to "is `crate::session::registry`", and a crate root cannot
sit under a `#[cfg]` parent while a module can. The property was lost silently
two PRs ago. `audit_package_source_graph` now reports which sources have an
unconditional production mount, and the collector must have one. The parameter
#359 left unused is gone with it.

Checks: `cargo test --manifest-path tools/architecture/handler-contract-check`
315/0 in 34s; `handler-contract-check check` PASS; the release build emits no
unused/dead-code warnings; `python3 tools/test_validation_v2.py` and
`./tools/validation-v2 self-test` pass; `./tools/validation-v2 final --base
origin/3.4.3` passes and now runs the checker suite unfiltered.

Closes #363.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
