### PR TITLE
Invert the mailbox pump so the kernel drains and gameplay applies (#368)

### DIFF
--- a/crates/wow-world/src/lib.rs
+++ b/crates/wow-world/src/lib.rs
@@ -17,6 +17,7 @@ pub mod phasing;
 pub(crate) mod profession;
 pub mod reputation;
 pub mod session;
+mod session_commands;
 mod session_policy;
 #[allow(dead_code)] // Private prerequisite seam consumed by trainer issue #157.
 pub(crate) mod spell_acquisition;

--- a/crates/wow-world/src/session/mailbox/pump.rs
+++ b/crates/wow-world/src/session/mailbox/pump.rs
@@ -5,12 +5,21 @@
 
 //! Session mailbox pump.
 //!
-//! One consumer — the owning session task — drains both rails and applies each
-//! committed command. Draining order is deliberate: the durable creature rail
-//! is presented first up to its first visibility-gated packet so a pending
-//! refresh can run before it, then the bounded general rail, then the deferred
-//! durable suffix. An overflowed durable backlog disconnects the desynchronized
-//! session rather than dropping authoritative transitions.
+//! One consumer — the owning session task — drains both rails and hands each
+//! committed command to gameplay. Draining order is deliberate: the durable
+//! creature rail is presented first up to its first visibility-gated packet so
+//! a pending refresh can run before it, then the bounded general rail, then the
+//! deferred durable suffix. An overflowed durable backlog disconnects the
+//! desynchronized session rather than dropping authoritative transitions.
+//!
+//! #368 moved what a command *does* to [`crate::session_commands`]: this file
+//! owns the queue, not the gameplay. That took the methods this module names in
+//! `handlers/` from 31 to one — `apply_pending_durable_item_loot_completions_like_cpp`,
+//! a four-line loot wrapper the pump must call *before* the overflow check so a
+//! session about to be disconnected still lands its committed loot. Hiding that
+//! last call behind a second one-implementation wrapper would buy a cleaner
+//! count and a worse boundary; the honest seam is the loot rail draining the way
+//! the command rails now do, which is loot's own work and not this issue's.
 
 use super::protocol::*;
 use crate::session::{SessionState, WorldSession};
@@ -78,137 +87,7 @@ impl WorldSession {
         }
         let commands = self.drain_session_commands();
         for command in commands {
-            match command {
-                SessionCommand::KickLikeCpp(command) => {
-                    self.kick(&command.reason);
-                }
-                SessionCommand::WorldSessionShutdownFlushLikeCpp(command) => {
-                    let _ = command
-                        .response_tx
-                        .try_send(WorldSessionShutdownFlushResultLikeCpp {
-                            diff_ms: command.diff_ms,
-                            disconnecting: self.is_disconnecting(),
-                        });
-                }
-                SessionCommand::ApplyCreatureMeleeDamageLikeCpp(command) => {
-                    self.handle_apply_creature_melee_damage_like_cpp_command_like_cpp(command);
-                }
-                SessionCommand::CreatureAttackStartLikeCpp(command) => {
-                    self.handle_creature_attack_start_like_cpp_command_like_cpp(command);
-                }
-                SessionCommand::CreatureAttackStopLikeCpp(command) => {
-                    self.handle_creature_attack_stop_like_cpp_command_like_cpp(command);
-                }
-                SessionCommand::ReconcilePvpCombatExpiryLikeCpp(command) => {
-                    self.handle_reconcile_pvp_combat_expiry_like_cpp(command);
-                }
-                SessionCommand::ApplyLootMoneyLikeCpp(command) => {
-                    self.handle_apply_loot_money_like_cpp_command(command).await;
-                }
-                SessionCommand::NotifyLootMoneyRemovedLikeCpp(command) => {
-                    self.handle_notify_loot_money_removed_like_cpp_command(command);
-                }
-                SessionCommand::MasterLootGive(command) => {
-                    self.handle_represented_master_loot_give_command_like_cpp(command)
-                        .await;
-                }
-                SessionCommand::LootRollStoreWinner(command) => {
-                    self.handle_represented_loot_roll_store_winner_command_like_cpp(command)
-                        .await;
-                }
-                SessionCommand::LootRollVote(command) => {
-                    self.handle_represented_loot_roll_vote_command_like_cpp(command)
-                        .await;
-                }
-                SessionCommand::ResetSeasonalQuestStatus(command) => {
-                    let _ = self.reset_seasonal_quest_status_like_cpp(
-                        command.event_id,
-                        command.event_start_time,
-                    );
-                }
-                SessionCommand::SendVisibleObjectValuesUpdate(command) => {
-                    self.handle_send_visible_object_values_update_command_like_cpp(command);
-                }
-                SessionCommand::RefreshVisibleWorldCreaturesLikeCpp(command) => {
-                    self.handle_refresh_visible_world_creatures_like_cpp_command_like_cpp(command)
-                        .await;
-                }
-                SessionCommand::SendCreatureLootReleaseValuesUpdateLikeCpp(command) => {
-                    self.handle_send_creature_loot_release_values_update_command_like_cpp(command);
-                }
-                SessionCommand::RefreshVisibleGameobjectsOrSpellClicksLikeCpp => {
-                    let _ = self.update_visible_gameobjects_or_spell_clicks_like_cpp();
-                }
-                SessionCommand::SyncGatheringNodeGameobjectStateAndRefreshLikeCpp(command) => {
-                    self.handle_sync_gathering_node_gameobject_state_and_refresh_like_cpp(command);
-                }
-                SessionCommand::SyncChestGameobjectStateAndRefreshLikeCpp(command) => {
-                    self.handle_sync_chest_gameobject_state_and_refresh_like_cpp(command);
-                }
-                SessionCommand::SyncGooberGameobjectStateAndRefreshLikeCpp(command) => {
-                    self.handle_sync_goober_gameobject_state_and_refresh_like_cpp(command);
-                }
-                SessionCommand::SetQuestSharingInfoAndSendDetails(command) => {
-                    self.handle_set_quest_sharing_info_and_send_details_command_like_cpp(command);
-                }
-                SessionCommand::SendRepeatableTurnInRequestItemsLikeCpp(command) => {
-                    self.handle_send_repeatable_turn_in_request_items_command_like_cpp(command);
-                }
-                SessionCommand::SendRealmPacketLikeCpp(command) => {
-                    if self.state() == SessionState::LoggedIn
-                        && self.player_guid() == Some(command.recipient)
-                    {
-                        self.send_raw_packet_realm(&command.packet_bytes);
-                    }
-                }
-                SessionCommand::SendPartyUpdateLikeCpp(command) => {
-                    self.handle_send_party_update_command_like_cpp(command);
-                }
-                SessionCommand::ApplyGroupRemovalLikeCpp(command) => {
-                    self.handle_apply_group_removal_command_like_cpp(command);
-                }
-                SessionCommand::ApplyGroupJoinLikeCpp(command) => {
-                    self.handle_apply_group_join_command_like_cpp(command);
-                }
-                SessionCommand::ApplyGroupDifficultyLikeCpp(command) => {
-                    self.handle_apply_group_difficulty_command_like_cpp(command);
-                }
-                SessionCommand::ApplyGroupSubgroupLikeCpp(command) => {
-                    self.handle_apply_group_subgroup_command_like_cpp(command);
-                }
-                SessionCommand::SendIfVisibleLikeCpp(command) => {
-                    self.handle_send_if_visible_like_cpp_command_like_cpp(command, false, false);
-                }
-                SessionCommand::SendCreatureSpellCastIfVisibleLikeCpp(command) => {
-                    self.handle_send_creature_spell_cast_if_visible_like_cpp_command_like_cpp(
-                        command,
-                    );
-                }
-                SessionCommand::SendRealmIfVisibleLikeCpp(command) => {
-                    self.handle_send_if_visible_like_cpp_command_like_cpp(command, true, false);
-                }
-                SessionCommand::SendRealmIfVisibleFromLegacySourceLikeCpp(command) => {
-                    self.handle_send_if_visible_like_cpp_command_like_cpp(command, true, true);
-                }
-                SessionCommand::SendAddonIfRegisteredLikeCpp(command) => {
-                    self.handle_send_addon_if_registered_like_cpp_command_like_cpp(command);
-                }
-                SessionCommand::CancelRepresentedTradeLikeCpp(command) => {
-                    self.handle_cancel_represented_trade_command_like_cpp(command);
-                }
-                SessionCommand::SendRepresentedTradeStatusLikeCpp(command) => {
-                    self.handle_send_represented_trade_status_command_like_cpp(command);
-                }
-                SessionCommand::UnacceptRepresentedTradeLikeCpp(command) => {
-                    self.handle_unaccept_represented_trade_command_like_cpp(command);
-                }
-                SessionCommand::SendRepresentedDuelCountdownLikeCpp(command) => {
-                    self.handle_send_represented_duel_countdown_command_like_cpp(command);
-                }
-                SessionCommand::SendRepresentedDuelRequestedLikeCpp(command) => {
-                    self.handle_send_represented_duel_requested_command_like_cpp(command);
-                }
-            }
+            self.apply_session_command_like_cpp(command).await;
         }
         self.flush_pending_visibility_refresh_like_cpp().await;
     }

--- a/crates/wow-world/src/session/tests/mailbox_pump.rs
+++ b/crates/wow-world/src/session/tests/mailbox_pump.rs
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 alseif0x
+// Licensed under GPL v3 — https://www.gnu.org/licenses/gpl-3.0.html
+
+//! What the mailbox pump owns after #368: the order commands are presented in,
+//! and the rule that an overflowed durable backlog disconnects the session
+//! before any command is applied.
+//!
+//! Applying a command moved to `crate::session_commands`, so these are the
+//! properties the kernel side must keep on its own.
+
+use super::*;
+use crate::session::mailbox::{
+    CreatureAttackStartLikeCppCommand, CreatureAttackStopLikeCppCommand,
+    MAX_DURABLE_CREATURE_RUNTIME_COMMANDS_LIKE_CPP,
+};
+
+/// Draining is deliberately not "durable, then general": the durable rail is
+/// presented only up to its first visibility-gated packet, so a refresh queued
+/// on the general rail runs before it, and the durable remainder follows.
+#[tokio::test]
+async fn drain_presents_the_durable_prefix_then_the_general_rail_then_the_suffix_like_cpp() {
+    let (session, _pkt_tx, _send_rx) = make_session();
+    let attacker = ObjectGuid::create_world_object(
+        wow_core::guid::HighGuid::Creature,
+        0,
+        1,
+        571,
+        0,
+        9001,
+        901,
+    );
+    let victim = ObjectGuid::create_player(1, 900);
+
+    // Durable rail: one non-visibility command, then a visibility-gated one.
+    {
+        let mut pending = session
+            .durable_creature_runtime_commands_like_cpp
+            .lock()
+            .expect("durable rail");
+        assert!(
+            pending.publish_attack_start_like_cpp(CreatureAttackStartLikeCppCommand {
+                attacker_guid: attacker,
+                victim_guid: victim,
+                previous_victim_guid: None,
+                map_id: 571,
+                instance_id: 0,
+                packet_already_broadcast: false,
+            })
+        );
+        assert!(
+            pending.publish_attack_stop_like_cpp(CreatureAttackStopLikeCppCommand {
+                attacker_guid: attacker,
+                victim_guid: victim,
+                map_id: 571,
+                instance_id: 0,
+            })
+        );
+    }
+
+    // General rail: one command enqueued after both durable ones.
+    session
+        .session_command_tx()
+        .send(SessionCommand::RefreshVisibleGameobjectsOrSpellClicksLikeCpp)
+        .expect("general rail accepts the command");
+
+    let drained = session.drain_session_commands();
+    let shapes: Vec<&'static str> = drained
+        .iter()
+        .map(|command| match command {
+            SessionCommand::CreatureAttackStartLikeCpp(_) => "durable:start",
+            SessionCommand::CreatureAttackStopLikeCpp(_) => "durable:stop",
+            SessionCommand::RefreshVisibleGameobjectsOrSpellClicksLikeCpp => "general:refresh",
+            _ => "other",
+        })
+        .collect();
+    assert_eq!(
+        shapes,
+        vec!["durable:start", "durable:stop", "general:refresh"],
+        "neither durable command is visibility-gated, so the whole rail precedes the general one"
+    );
+}
+
+/// An overflowed durable backlog means authoritative transitions were lost.
+/// The session is disconnected, and nothing queued behind the overflow is
+/// applied — the kick happens before the drain, not after it.
+#[tokio::test]
+async fn an_overflowed_durable_backlog_kicks_before_any_command_is_applied_like_cpp() {
+    let (mut session, _pkt_tx, _send_rx) = make_session();
+    session.set_state(SessionState::LoggedIn);
+
+    let attacker = ObjectGuid::create_world_object(
+        wow_core::guid::HighGuid::Creature,
+        0,
+        1,
+        571,
+        0,
+        9001,
+        903,
+    );
+    let overflowing = CreatureAttackStartLikeCppCommand {
+        attacker_guid: attacker,
+        victim_guid: ObjectGuid::create_player(1, 902),
+        previous_victim_guid: None,
+        map_id: 571,
+        instance_id: 0,
+        packet_already_broadcast: false,
+    };
+    {
+        let mut pending = session
+            .durable_creature_runtime_commands_like_cpp
+            .lock()
+            .expect("durable rail");
+        for _ in 0..MAX_DURABLE_CREATURE_RUNTIME_COMMANDS_LIKE_CPP {
+            assert!(pending.publish_attack_start_like_cpp(overflowing.clone()));
+        }
+        assert!(!pending.publish_attack_start_like_cpp(overflowing));
+    }
+    session
+        .session_command_tx()
+        .send(SessionCommand::RefreshVisibleGameobjectsOrSpellClicksLikeCpp)
+        .expect("general rail accepts the command");
+
+    session
+        .process_represented_session_commands_like_cpp()
+        .await;
+
+    assert!(
+        session.is_disconnecting(),
+        "an overflowed authoritative backlog must disconnect the desynchronized session"
+    );
+    assert_eq!(
+        session.session_command_rx.len(),
+        1,
+        "the pump returns before draining, so the queued command is not applied"
+    );
+}

--- a/crates/wow-world/src/session_commands.rs
+++ b/crates/wow-world/src/session_commands.rs
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 alseif0x
+// RustyCore — WoW WotLK 3.4.3 server in Rust
+// Based on TrinityCore protocol research (https://github.com/TrinityCore/TrinityCore)
+// Licensed under GPL v3 — https://www.gnu.org/licenses/gpl-3.0.html
+
+//! Applying one committed cross-session command.
+//!
+//! The mailbox owns the queue — draining, rail ordering, backpressure and the
+//! durable-overflow kick. What a command *does* is gameplay, and #368 moved it
+//! out of `session/mailbox/` so the kernel names one entry point instead of the
+//! 31 `handlers/` methods these arms reach.
+//!
+//! The match stays exhaustive with no wildcard on purpose. Unlike the opcode
+//! table #359 retired, this pairing is checked by the compiler: a new
+//! `SessionCommand` variant does not build until it is applied somewhere. That
+//! property is the reason the arms moved intact rather than becoming thunks.
+
+use crate::session::mailbox::{SessionCommand, WorldSessionShutdownFlushResultLikeCpp};
+use crate::session::{SessionState, WorldSession};
+
+impl WorldSession {
+    /// Apply one committed command, in the order the mailbox presented it.
+    pub(crate) async fn apply_session_command_like_cpp(&mut self, command: SessionCommand) {
+        match command {
+            SessionCommand::KickLikeCpp(command) => {
+                self.kick(&command.reason);
+            }
+            SessionCommand::WorldSessionShutdownFlushLikeCpp(command) => {
+                let _ = command
+                    .response_tx
+                    .try_send(WorldSessionShutdownFlushResultLikeCpp {
+                        diff_ms: command.diff_ms,
+                        disconnecting: self.is_disconnecting(),
+                    });
+            }
+            SessionCommand::ApplyCreatureMeleeDamageLikeCpp(command) => {
+                self.handle_apply_creature_melee_damage_like_cpp_command_like_cpp(command);
+            }
+            SessionCommand::CreatureAttackStartLikeCpp(command) => {
+                self.handle_creature_attack_start_like_cpp_command_like_cpp(command);
+            }
+            SessionCommand::CreatureAttackStopLikeCpp(command) => {
+                self.handle_creature_attack_stop_like_cpp_command_like_cpp(command);
+            }
+            SessionCommand::ReconcilePvpCombatExpiryLikeCpp(command) => {
+                self.handle_reconcile_pvp_combat_expiry_like_cpp(command);
+            }
+            SessionCommand::ApplyLootMoneyLikeCpp(command) => {
+                self.handle_apply_loot_money_like_cpp_command(command).await;
+            }
+            SessionCommand::NotifyLootMoneyRemovedLikeCpp(command) => {
+                self.handle_notify_loot_money_removed_like_cpp_command(command);
+            }
+            SessionCommand::MasterLootGive(command) => {
+                self.handle_represented_master_loot_give_command_like_cpp(command)
+                    .await;
+            }
+            SessionCommand::LootRollStoreWinner(command) => {
+                self.handle_represented_loot_roll_store_winner_command_like_cpp(command)
+                    .await;
+            }
+            SessionCommand::LootRollVote(command) => {
+                self.handle_represented_loot_roll_vote_command_like_cpp(command)
+                    .await;
+            }
+            SessionCommand::ResetSeasonalQuestStatus(command) => {
+                let _ = self.reset_seasonal_quest_status_like_cpp(
+                    command.event_id,
+                    command.event_start_time,
+                );
+            }
+            SessionCommand::SendVisibleObjectValuesUpdate(command) => {
+                self.handle_send_visible_object_values_update_command_like_cpp(command);
+            }
+            SessionCommand::RefreshVisibleWorldCreaturesLikeCpp(command) => {
+                self.handle_refresh_visible_world_creatures_like_cpp_command_like_cpp(command)
+                    .await;
+            }
+            SessionCommand::SendCreatureLootReleaseValuesUpdateLikeCpp(command) => {
+                self.handle_send_creature_loot_release_values_update_command_like_cpp(command);
+            }
+            SessionCommand::RefreshVisibleGameobjectsOrSpellClicksLikeCpp => {
+                let _ = self.update_visible_gameobjects_or_spell_clicks_like_cpp();
+            }
+            SessionCommand::SyncGatheringNodeGameobjectStateAndRefreshLikeCpp(command) => {
+                self.handle_sync_gathering_node_gameobject_state_and_refresh_like_cpp(command);
+            }
+            SessionCommand::SyncChestGameobjectStateAndRefreshLikeCpp(command) => {
+                self.handle_sync_chest_gameobject_state_and_refresh_like_cpp(command);
+            }
+            SessionCommand::SyncGooberGameobjectStateAndRefreshLikeCpp(command) => {
+                self.handle_sync_goober_gameobject_state_and_refresh_like_cpp(command);
+            }
+            SessionCommand::SetQuestSharingInfoAndSendDetails(command) => {
+                self.handle_set_quest_sharing_info_and_send_details_command_like_cpp(command);
+            }
+            SessionCommand::SendRepeatableTurnInRequestItemsLikeCpp(command) => {
+                self.handle_send_repeatable_turn_in_request_items_command_like_cpp(command);
+            }
+            SessionCommand::SendRealmPacketLikeCpp(command) => {
+                if self.state() == SessionState::LoggedIn
+                    && self.player_guid() == Some(command.recipient)
+                {
+                    self.send_raw_packet_realm(&command.packet_bytes);
+                }
+            }
+            SessionCommand::SendPartyUpdateLikeCpp(command) => {
+                self.handle_send_party_update_command_like_cpp(command);
+            }
+            SessionCommand::ApplyGroupRemovalLikeCpp(command) => {
+                self.handle_apply_group_removal_command_like_cpp(command);
+            }
+            SessionCommand::ApplyGroupJoinLikeCpp(command) => {
+                self.handle_apply_group_join_command_like_cpp(command);
+            }
+            SessionCommand::ApplyGroupDifficultyLikeCpp(command) => {
+                self.handle_apply_group_difficulty_command_like_cpp(command);
+            }
+            SessionCommand::ApplyGroupSubgroupLikeCpp(command) => {
+                self.handle_apply_group_subgroup_command_like_cpp(command);
+            }
+            SessionCommand::SendIfVisibleLikeCpp(command) => {
+                self.handle_send_if_visible_like_cpp_command_like_cpp(command, false, false);
+            }
+            SessionCommand::SendCreatureSpellCastIfVisibleLikeCpp(command) => {
+                self.handle_send_creature_spell_cast_if_visible_like_cpp_command_like_cpp(command);
+            }
+            SessionCommand::SendRealmIfVisibleLikeCpp(command) => {
+                self.handle_send_if_visible_like_cpp_command_like_cpp(command, true, false);
+            }
+            SessionCommand::SendRealmIfVisibleFromLegacySourceLikeCpp(command) => {
+                self.handle_send_if_visible_like_cpp_command_like_cpp(command, true, true);
+            }
+            SessionCommand::SendAddonIfRegisteredLikeCpp(command) => {
+                self.handle_send_addon_if_registered_like_cpp_command_like_cpp(command);
+            }
+            SessionCommand::CancelRepresentedTradeLikeCpp(command) => {
+                self.handle_cancel_represented_trade_command_like_cpp(command);
+            }
+            SessionCommand::SendRepresentedTradeStatusLikeCpp(command) => {
+                self.handle_send_represented_trade_status_command_like_cpp(command);
+            }
+            SessionCommand::UnacceptRepresentedTradeLikeCpp(command) => {
+                self.handle_unaccept_represented_trade_command_like_cpp(command);
+            }
+            SessionCommand::SendRepresentedDuelCountdownLikeCpp(command) => {
+                self.handle_send_represented_duel_countdown_command_like_cpp(command);
+            }
+            SessionCommand::SendRepresentedDuelRequestedLikeCpp(command) => {
+                self.handle_send_represented_duel_requested_command_like_cpp(command);
+            }
+        }
+    }
+}

--- a/crates/wow-world/src/session_tests.rs
+++ b/crates/wow-world/src/session_tests.rs
@@ -138,6 +138,16 @@ fn represented_test_give_player_xp_hook_like_cpp(
     }
 }
 
+/// How far to backdate a creature's clock so a scheduled assistance call is due.
+///
+/// `schedule_assistance_like_cpp` stores `now_ms() + family_assistance_delay_ms`
+/// as an absolute deadline on that creature's own clock, so backdating by
+/// `delay + 1` only makes it due if the test scheduled within one millisecond of
+/// the clock starting. That held on an idle machine and failed under load
+/// (#369). The margin is the delay plus room for the test to have taken its
+/// time getting there.
+const ASSISTANCE_DELAY_ELAPSED_LIKE_CPP: Duration = Duration::from_millis(1_500 + 250);
+
 fn make_session() -> (
     WorldSession,
     flume::Sender<WorldPacket>,
@@ -82653,7 +82663,7 @@ fn legacy_creature_call_assistance_accepts_represented_creature_victim_like_cpp(
         .unwrap()
         .find_creature_mut(0, 0, caller_guid)
         .unwrap()
-        .backdate_runtime_clock_for_test(Duration::from_millis(1_501));
+        .backdate_runtime_clock_for_test(ASSISTANCE_DELAY_ELAPSED_LIKE_CPP);
     let assisted = run_legacy_creature_aggro_tick_once_with_config_like_cpp(&manager, &[], config);
 
     assert_eq!(assisted.assistance_starts, 1);
@@ -82796,13 +82806,13 @@ fn legacy_creature_call_assistance_engages_same_faction_after_delay_like_cpp() {
         .unwrap()
         .find_creature_mut(0, 0, caller_guid)
         .unwrap()
-        .backdate_runtime_clock_for_test(Duration::from_millis(1_501));
+        .backdate_runtime_clock_for_test(ASSISTANCE_DELAY_ELAPSED_LIKE_CPP);
     {
         let mut manager = manager.write().unwrap();
         let dead_assistant = manager
             .find_creature_mut(0, 0, dead_assistant_guid)
             .unwrap();
-        dead_assistant.backdate_runtime_clock_for_test(Duration::from_millis(1_501));
+        dead_assistant.backdate_runtime_clock_for_test(ASSISTANCE_DELAY_ELAPSED_LIKE_CPP);
         dead_assistant
             .creature
             .unit_mut()
@@ -82810,14 +82820,14 @@ fn legacy_creature_call_assistance_engages_same_faction_after_delay_like_cpp() {
         let passive = manager
             .find_creature_mut(0, 0, passive_before_due_guid)
             .unwrap();
-        passive.backdate_runtime_clock_for_test(Duration::from_millis(1_501));
+        passive.backdate_runtime_clock_for_test(ASSISTANCE_DELAY_ELAPSED_LIKE_CPP);
         passive
             .creature
             .set_react_state(wow_entities::ReactState::Passive);
         let controlled = manager
             .find_creature_mut(0, 0, controlled_assistant_guid)
             .unwrap();
-        controlled.backdate_runtime_clock_for_test(Duration::from_millis(1_501));
+        controlled.backdate_runtime_clock_for_test(ASSISTANCE_DELAY_ELAPSED_LIKE_CPP);
         controlled
             .creature
             .unit_mut()
@@ -82993,7 +83003,7 @@ fn legacy_creature_overlapping_assistance_uses_later_valid_event_like_cpp() {
                 vec![assistant_guid],
                 1_500,
             ));
-            caller.backdate_runtime_clock_for_test(Duration::from_millis(1_501));
+            caller.backdate_runtime_clock_for_test(ASSISTANCE_DELAY_ELAPSED_LIKE_CPP);
         })
         .unwrap();
     session
@@ -83003,7 +83013,7 @@ fn legacy_creature_overlapping_assistance_uses_later_valid_event_like_cpp() {
                 vec![assistant_guid],
                 1_500,
             ));
-            caller.backdate_runtime_clock_for_test(Duration::from_millis(1_501));
+            caller.backdate_runtime_clock_for_test(ASSISTANCE_DELAY_ELAPSED_LIKE_CPP);
         })
         .unwrap();
     session

--- a/crates/wow-world/src/session_tests.rs
+++ b/crates/wow-world/src/session_tests.rs
@@ -23,6 +23,8 @@ mod driver;
 mod lifecycle;
 #[path = "session/tests/lifecycle_persistence.rs"]
 mod lifecycle_persistence;
+#[path = "session/tests/mailbox_pump.rs"]
+mod mailbox_pump;
 #[path = "session/tests/routing.rs"]
 mod routing;
 #[path = "session/tests/save_plan_order.rs"]

--- a/tools/architecture/architecture-issue-ledger.json
+++ b/tools/architecture/architecture-issue-ledger.json
@@ -449,7 +449,7 @@
     },
     {
       "number": 359,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.P4.1a] Retire the dispatcher's 479 match arms in favour of the registration that already exists",
       "kind": "slice",
       "parents": [

--- a/tools/architecture/runtime-ownership-ledger.json
+++ b/tools/architecture/runtime-ownership-ledger.json
@@ -1820,16 +1820,15 @@
       "entries": [
         {
           "path": "crates/wow-world/src/session/mod.rs",
-          "production_lines": 73057,
-          "test_lines": 95801,
-          "total_lines": 168858,
+          "production_lines": 72936,
+          "test_lines": 95939,
+          "total_lines": 168875,
           "owner": "wow-world WorldSession/application monolith.",
           "open_retirement_issues": [
             153,
-            297,
-            359
+            297
           ],
-          "retirement_condition": "Session is a thin protocol/lifecycle shell with no mutable Player/Map gameplay, concrete DB/catalog bag, or external impl growth; LOC alone does not close it. #297 owns the kernel promotion and #359 the dispatcher decoupling that unblocks it; #252 owns the gameplay mirror. Until they land this row is a reviewed exception to the epic's 4,000-line signal, not a target."
+          "retirement_condition": "Session is a thin protocol/lifecycle shell with no mutable Player/Map gameplay, concrete DB/catalog bag, or external impl growth; LOC alone does not close it. #359 landed the dispatcher decoupling and #368 the mailbox inversion; #297 owns the kernel promotion those unblock, and #252 the gameplay mirror. Until they land this row is a reviewed exception to the epic's 4,000-line signal, not a target."
         },
         {
           "path": "crates/wow-map/src/map/mod.rs",

--- a/tools/architecture/runtime-ownership-ledger.json
+++ b/tools/architecture/runtime-ownership-ledger.json
@@ -1821,8 +1821,8 @@
         {
           "path": "crates/wow-world/src/session/mod.rs",
           "production_lines": 72936,
-          "test_lines": 95939,
-          "total_lines": 168875,
+          "test_lines": 95949,
+          "total_lines": 168885,
           "owner": "wow-world WorldSession/application monolith.",
           "open_retirement_issues": [
             153,

--- a/tools/architecture/session-ownership-policy.json
+++ b/tools/architecture/session-ownership-policy.json
@@ -5489,6 +5489,12 @@
           "source_class": "production"
         },
         {
+          "module": "crate::session_commands",
+          "trait_path": null,
+          "cfg": [],
+          "source_class": "production"
+        },
+        {
           "module": "crate::spell_acquisition::adapter",
           "trait_path": null,
           "cfg": [],
@@ -48985,6 +48991,20 @@
           "cfg": [],
           "source_class": "production",
           "guards": []
+        },
+        {
+          "module": "crate::session_commands",
+          "trait_path": null,
+          "kind": "method",
+          "name": "apply_session_command_like_cpp",
+          "visibility": "pub (crate)",
+          "signature": "async fn apply_session_command_like_cpp (& mut self , command : SessionCommand)",
+          "cfg": [],
+          "source_class": "production",
+          "guards": [
+            "external_impl",
+            "visible"
+          ]
         },
         {
           "module": "crate::spell_acquisition::adapter",


### PR DESCRIPTION
Two commits, because the gate found a second defect while validating the first.

## 1. `Invert the mailbox pump so the kernel drains and gameplay applies` — closes #368

`process_represented_session_commands_like_cpp` drained the two rails and then named, arm by
arm, the gameplay each `SessionCommand` performs. 31 of the 38 methods `mailbox/` called on
`self` were defined in `handlers/`, which is the largest single reason #297's kernel cannot be
a crate.

The 37 arms move to `crate::session_commands` unchanged. `mailbox/` now names 3 methods
outside itself instead of 38, and 1 in `handlers/` instead of 31. Across the six candidate
kernel modules the union falls from 83 to 49. `session/mod.rs` production falls
73,057 → 72,936.

**This is not #359's shape.** That match is over an enum with 37 arms and no wildcard, so the
compiler already enforces the pairing — there is no second declaration and no silent-drop
failure mode. Giving each command a thunk would have thrown away that exhaustiveness. Only the
dependency direction was wrong, so only the dependency direction changed.

Two tests pin what the kernel still owns alone: drain order across the rails, and that an
overflowed authoritative backlog kicks *before* any command is applied.

One call to `handlers/` stays — a four-line loot wrapper that must run before the overflow
check. Hiding it behind a second one-implementation wrapper would reach zero on the count and
leave a worse boundary; it is documented in the pump instead.

## 2. `Stop the assistance-delay tests racing on a 1 ms margin` — closes #369

`validation-v2 final` failed this branch on
`legacy_creature_call_assistance_engages_same_faction_after_delay_like_cpp`. The failure was
real and pre-existing: 1 run in 5 on a loaded machine.

`schedule_assistance_like_cpp` stores an absolute deadline on the creature's own clock —
`now_ms() + 1500` captured at schedule time. Seven tests backdated that clock by exactly
`1_501` ms, so the assist was only due if the test had scheduled within one millisecond of the
creature's clock starting. Production arithmetic is correct and untouched; the margin now says
what it depends on. Measured 1-in-5 before, 0-in-30 after, same load.

It surfaced now because #364 made `final` run wow-world's tests on diffs that touch a
root-wide path. This branch touches `Cargo.lock`, so it was the first to be gated that way.

## Ledger

The syntax baseline gains one impl owner and one associated item, both
`crate::session_commands`. That registers as external impl growth against the hotspot's
retirement condition even though it is code leaving `session/`, not new surface — recorded
rather than left to look like an oversight. The row also drops #359 from its open retirement
issues and the mirrored issue state is refreshed to match.

Checks: `cargo test -p wow-world --lib` 3573/0 (×3), `-p world-server` 449/0;
`check_architecture.py check`/`self-test` PASS; `session-ownership-check` syntax-only and
exhaustive PASS; `./tools/validation-v2 final` PASS with the wow-world tests actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
