### PR TITLE
Make pooled not-run trace test deterministic

### DIFF
--- a/crates/wow-database/src/database.rs
+++ b/crates/wow-database/src/database.rs
@@ -636,7 +636,12 @@ mod tests {
         let recorder = PersistenceRecorder::new();
         let _recording = RecordingSession::install(recorder.clone());
 
-        let db: Database<CharStatements> = Database::from_pool(unreachable_pool());
+        // A closed pool yields `PoolClosed` before any connection attempt. That
+        // exercises the definite non-execution branch without relying on a
+        // network timeout winning a race with an immediate connection refusal.
+        let pool = unreachable_pool();
+        pool.close().await;
+        let db: Database<CharStatements> = Database::from_pool(pool);
         let stmt = db.prepare(CharStatements::SEL_ENUM);
         let _ = db.query(&stmt).await;
 


### PR DESCRIPTION
## Summary

- replace a network-timing-dependent acquisition failure with a closed SQLx pool
- deterministically exercise the existing `PoolClosed` definite non-execution classification
- leave production behavior unchanged

## Validation

- focused test passed 3 consecutive runs
- `cargo test -p wow-database --lib`: 326 passed, 0 failed, 1 ignored (live MariaDB fixture)
- `./tools/validation-v2 final --base origin/3.4.3`: passed

Closes #559