### PR TITLE
Give the spell catalog set its own owner outside the Session (#668)

### DIFF
--- a/crates/wow-world/src/handlers/character/session_state.rs
+++ b/crates/wow-world/src/handlers/character/session_state.rs
@@ -16,8 +16,8 @@ impl WorldSession {
         let Ok(spell_id) = u32::try_from(spell_id) else {
             return false;
         };
-        let Some(condition_id) = self
-            .spell_misc_store()
+        let misc = self.spell_catalogs.spell_misc_store();
+        let Some(condition_id) = misc
             .and_then(|store| store.entry_for_spell_difficulty_like_cpp(spell_id, 0))
             .map(|misc| misc.show_future_spell_player_condition_id)
             .filter(|condition_id| *condition_id > 0)
@@ -43,7 +43,7 @@ impl WorldSession {
             return wow_data::SkillRewardedSpellChangesLikeCpp::default();
         };
         let spell_store = self.spell_store().cloned();
-        let spell_levels_store = self.spell_levels_store().cloned();
+        let spell_levels_store = self.spell_catalogs.spell_levels_store().cloned();
 
         skill_store.skill_rewarded_spell_changes_like_cpp(
             skill_id,
@@ -1424,9 +1424,9 @@ impl WorldSession {
                 wow_persistence::PlayerLoginAuxiliaryLoadedLikeCpp::SpellCharges(rows),
             ) => {
                 for row in rows {
-                    let category_known_to_store = self
-                        .spell_category_store()
-                        .is_none_or(|store| store.get(row.category_id).is_some());
+                    let categories = self.spell_catalogs.spell_category_store();
+                    let category_known_to_store =
+                        categories.is_none_or(|store| store.get(row.category_id).is_some());
                     if category_known_to_store && row.recharge_end > now {
                         self.record_loaded_character_spell_charge_like_cpp(
                             row.category_id,

--- a/crates/wow-world/src/handlers/loot/requests.rs
+++ b/crates/wow-world/src/handlers/loot/requests.rs
@@ -926,8 +926,8 @@ impl WorldSession {
 
     pub(super) fn represented_spell_max_range_like_cpp(&self, spell_id: i32) -> Option<f32> {
         let spell_store = self.spell_store()?;
-        let spell_misc_store = self.spell_misc_store()?;
-        let spell_range_store = self.spell_range_store()?;
+        let spell_misc_store = self.spell_catalogs.spell_misc_store()?;
+        let spell_range_store = self.spell_catalogs.spell_range_store()?;
         spell_store.get(spell_id)?;
         let spell_id = u32::try_from(spell_id).ok()?;
         let range_index = spell_misc_store.get(spell_id)?.range_index;

--- a/crates/wow-world/src/handlers/trainer.rs
+++ b/crates/wow-world/src/handlers/trainer.rs
@@ -155,7 +155,7 @@ fn trainer_spell_class_race_fit_like_cpp(
 
 fn trainer_spell_product_like_cpp(session: &WorldSession, spell_id: u32) -> TrainerProductLikeCpp {
     const SPELL_EFFECT_LEARN_SPELL_LIKE_CPP: u32 = 36;
-    let Some(catalog) = session.spell_acquisition_catalog() else {
+    let Some(catalog) = session.spell_catalogs.spell_acquisition_catalog() else {
         return TrainerProductLikeCpp::InvalidOrUnsupportedWrapper;
     };
     let effects = match catalog.acquisition_effects_like_cpp(spell_id) {
@@ -351,8 +351,8 @@ impl WorldSession {
                 })
             })
         };
-        let battle_pet = match self
-            .spell_acquisition_catalog()
+        let acquisition = self.spell_catalogs.spell_acquisition_catalog();
+        let battle_pet = match acquisition
             .map(|catalog| catalog.battle_pet_classification_like_cpp(trainer_spell.spell_id))
         {
             Some(BattlePetClassificationLikeCpp::NotBattlePet) => {

--- a/crates/wow-world/src/lib.rs
+++ b/crates/wow-world/src/lib.rs
@@ -49,6 +49,7 @@ mod player_inventory_persistence_test_fixture;
 mod player_lifecycle_contract;
 #[cfg(test)]
 mod player_quest_persistence_test_fixture;
+mod spell_catalogs;
 #[cfg(test)]
 mod teleport_test_fixtures;
 #[cfg(test)]

--- a/crates/wow-world/src/session/catalogs/operations.rs
+++ b/crates/wow-world/src/session/catalogs/operations.rs
@@ -315,31 +315,31 @@ impl WorldSession {
         self.trait_definition_store.as_ref()
     }
     pub fn set_spell_group_store(&mut self, store: Arc<SpellGroupStoreLikeCpp>) {
-        self.spell_group_store = Some(store);
+        self.spell_catalogs.spell_group_store = Some(store);
     }
     pub fn set_spell_group_stack_rule_store(
         &mut self,
         store: Arc<SpellGroupStackRuleStoreLikeCpp>,
     ) {
-        self.spell_group_stack_rule_store = Some(store);
+        self.spell_catalogs.spell_group_stack_rule_store = Some(store);
     }
     pub fn set_spell_pet_aura_store(&mut self, store: Arc<SpellPetAuraStoreLikeCpp>) {
-        self.spell_pet_aura_store = Some(store);
+        self.spell_catalogs.spell_pet_aura_store = Some(store);
     }
     pub(crate) fn spell_pet_aura_store_like_cpp(&self) -> Option<&SpellPetAuraStoreLikeCpp> {
-        self.spell_pet_aura_store.as_deref()
+        self.spell_catalogs.spell_pet_aura_store.as_deref()
     }
     #[cfg(test)]
     pub fn set_pet_levelup_spell_store(&mut self, store: Arc<PetLevelupSpellStoreLikeCpp>) {
-        self.pet_levelup_spell_store = Some(store);
+        self.spell_catalogs.pet_levelup_spell_store = Some(store);
     }
     #[cfg(test)]
     pub fn set_pet_default_spell_store(&mut self, store: Arc<PetDefaultSpellStoreLikeCpp>) {
-        self.pet_default_spell_store = Some(store);
+        self.spell_catalogs.pet_default_spell_store = Some(store);
     }
     #[cfg(test)]
     pub fn set_pet_family_spell_store(&mut self, store: Arc<PetFamilySpellStoreLikeCpp>) {
-        self.pet_family_spell_store = Some(store);
+        self.spell_catalogs.pet_family_spell_store = Some(store);
     }
     pub fn set_movie_store(&mut self, store: Arc<MovieStore>) {
         self.movie_store = Some(store);

--- a/crates/wow-world/src/session/effect_learning.rs
+++ b/crates/wow-world/src/session/effect_learning.rs
@@ -63,11 +63,11 @@ impl EffectLearningRuntimeLikeCpp for WorldSession {
     }
 
     fn fallback_chains(&self) -> Option<&SpellChainStoreLikeCpp> {
-        self.spell_chain_store.as_deref()
+        self.spell_catalogs.spell_chain_store.as_deref()
     }
 
     fn fallback_requirements(&self) -> Option<&SpellRequiredStoreLikeCpp> {
-        self.spell_required_store.as_deref()
+        self.spell_catalogs.spell_required_store.as_deref()
     }
 
     fn fallback_traits(&self) -> Option<&wow_data::trait_tree::TraitDefinitionStore> {

--- a/crates/wow-world/src/session/mod.rs
+++ b/crates/wow-world/src/session/mod.rs
@@ -5543,7 +5543,8 @@ pub struct WorldSession {
     item_bonus_db2_store: Option<Arc<ItemBonusDb2Store>>,
     pvp_item_store: Option<Arc<PvpItemStore>>,
     item_set_store: Option<Arc<ItemSetStore>>,
-    item_set_spell_store: Option<Arc<ItemSetSpellStore>>,
+    /// Every spell and aura catalog slot, owned by one type (#668).
+    pub(crate) spell_catalogs: crate::spell_catalogs::SpellCatalogsLikeCpp,
     item_stats_store: Option<Arc<ItemStatsStore>>,
     durability_costs_store: Option<Arc<DurabilityCostsStore>>,
     durability_quality_store: Option<Arc<DurabilityQualityStore>>,
@@ -5598,12 +5599,7 @@ pub struct WorldSession {
     // Lock store (Lock.db2 data)
     lock_store: Option<Arc<LockStore>>,
 
-    // Spell item enchantment store (SpellItemEnchantment.db2 data)
-    spell_item_enchantment_store: Option<Arc<SpellItemEnchantmentStore>>,
-    spell_item_enchantment_condition_store: Option<Arc<SpellItemEnchantmentConditionStore>>,
     gem_properties_store: Option<Arc<GemPropertiesStore>>,
-    #[cfg(test)]
-    spell_enchant_proc_store: Option<Arc<SpellEnchantProcStoreLikeCpp>>,
 
     #[cfg(test)]
     tact_key_store: Option<Arc<TactKeyStore>>,
@@ -5703,7 +5699,6 @@ pub struct WorldSession {
     mount_capability_store: Option<Arc<MountCapabilityStore>>,
     mount_type_x_capability_store: Option<Arc<MountTypeXCapabilityStore>>,
     mount_x_display_store: Option<Arc<MountXDisplayStore>>,
-    spell_shapeshift_form_store: Option<Arc<SpellShapeshiftFormStore>>,
     vehicle_store: Option<Arc<VehicleStore>>,
     vehicle_seat_store: Option<Arc<VehicleSeatStore>>,
     #[cfg(test)]
@@ -6697,10 +6692,6 @@ pub struct WorldSession {
     #[cfg(test)]
     canonical_threat_aura_snapshots_like_cpp: HashMap<u8, CanonicalThreatAuraSnapshotLikeCpp>,
 
-    // ── Spell casting ──────────────────────────────────────────────
-    /// Spell store (metadata for all known spells: cast time, cooldown, effects, etc.)
-    pub spell_store: Option<Arc<SpellStore>>,
-    spell_acquisition_catalog: Option<Arc<SpellAcquisitionCatalogLikeCpp>>,
     pub(crate) spell_acquisition_cast_authority_like_cpp:
         Option<Arc<crate::spell_acquisition::SpellAcquisitionCastAuthorityLikeCpp>>,
     pub(crate) spell_acquisition_craft_authority_like_cpp:
@@ -6711,42 +6702,8 @@ pub struct WorldSession {
     spell_script_all_rank_root_spell_ids_like_cpp: Option<Arc<BTreeSet<u32>>>,
     legacy_spell_script_spell_ids_like_cpp: Option<Arc<BTreeSet<u32>>>,
     spell_linked_rejected_trigger_spell_ids_like_cpp: Option<Arc<BTreeSet<u32>>>,
-    spell_levels_store: Option<Arc<SpellLevelsStore>>,
     talent_store: Option<Arc<TalentStore>>,
     num_talents_at_level_store: Option<Arc<NumTalentsAtLevelStore>>,
-    spell_chain_store: Option<Arc<SpellChainStoreLikeCpp>>,
-    spell_category_store: Option<Arc<SpellCategoryStore>>,
-    npc_spell_click_store: Option<Arc<NpcSpellClickStoreLikeCpp>>,
-    spell_aura_options_store: Option<Arc<SpellAuraOptionsStore>>,
-    spell_aura_restrictions_store: Option<Arc<SpellAuraRestrictionsStore>>,
-    spell_target_restrictions_store: Option<Arc<SpellTargetRestrictionsStore>>,
-    spell_equipped_items_store: Option<Arc<SpellEquippedItemsStore>>,
-    spell_misc_store: Option<Arc<SpellMiscStore>>,
-    spell_group_store: Option<Arc<SpellGroupStoreLikeCpp>>,
-    spell_group_stack_rule_store: Option<Arc<SpellGroupStackRuleStoreLikeCpp>>,
-    spell_linked_store: Option<Arc<SpellLinkedStoreLikeCpp>>,
-    spell_pet_aura_store: Option<Arc<SpellPetAuraStoreLikeCpp>>,
-    spell_area_store: Option<Arc<SpellAreaStoreLikeCpp>>,
-    spell_custom_attribute_store: Option<Arc<SpellCustomAttributeStoreLikeCpp>>,
-    #[cfg(test)]
-    serverside_spell_store: Option<Arc<ServersideSpellStoreLikeCpp>>,
-    spell_learn_skill_store: Option<Arc<SpellLearnSkillStoreLikeCpp>>,
-    spell_learn_spell_store: Option<Arc<SpellLearnSpellStoreLikeCpp>>,
-    #[cfg(test)]
-    pet_levelup_spell_store: Option<Arc<PetLevelupSpellStoreLikeCpp>>,
-    #[cfg(test)]
-    pet_default_spell_store: Option<Arc<PetDefaultSpellStoreLikeCpp>>,
-    #[cfg(test)]
-    pet_family_spell_store: Option<Arc<PetFamilySpellStoreLikeCpp>>,
-    spell_proc_store: Option<Arc<SpellProcStoreLikeCpp>>,
-    spell_required_store: Option<Arc<SpellRequiredStoreLikeCpp>>,
-    spell_threat_store: Option<Arc<SpellThreatStoreLikeCpp>>,
-    spell_duration_store: Option<Arc<SpellDurationStore>>,
-    spell_radius_store: Option<Arc<SpellRadiusStore>>,
-    spell_range_store: Option<Arc<SpellRangeStore>>,
-    spell_target_position_store: Option<Arc<SpellTargetPositionStoreLikeCpp>>,
-    #[cfg(test)]
-    spell_totem_model_store: Option<Arc<SpellTotemModelStoreLikeCpp>>,
     chr_classes_store: Option<Arc<ChrClassesStore>>,
     #[cfg(test)]
     power_type_store: Option<Arc<PowerTypeStore>>,
@@ -7869,6 +7826,7 @@ impl WorldSession {
         connection.set_instance_endpoint([127, 0, 0, 1], 8086);
 
         Self {
+            spell_catalogs: crate::spell_catalogs::SpellCatalogsLikeCpp::default(),
             account_id,
             battlenet_account_id: account_id,
             realm_list_secret_like_cpp: [0; 32],
@@ -7977,7 +7935,6 @@ impl WorldSession {
             item_bonus_db2_store: None,
             pvp_item_store: None,
             item_set_store: None,
-            item_set_spell_store: None,
             item_stats_store: None,
             durability_costs_store: None,
             durability_quality_store: None,
@@ -8003,11 +7960,7 @@ impl WorldSession {
             disable_mgr: None,
             difficulty_store: None,
             lock_store: None,
-            spell_item_enchantment_store: None,
-            spell_item_enchantment_condition_store: None,
             gem_properties_store: None,
-            #[cfg(test)]
-            spell_enchant_proc_store: None,
             #[cfg(test)]
             tact_key_store: None,
             skill_store: None,
@@ -8082,7 +8035,6 @@ impl WorldSession {
             mount_capability_store: None,
             mount_type_x_capability_store: None,
             mount_x_display_store: None,
-            spell_shapeshift_form_store: None,
             vehicle_store: None,
             vehicle_seat_store: None,
             #[cfg(test)]
@@ -8706,50 +8658,14 @@ impl WorldSession {
             player_equipment_inventory_authority_complete_like_cpp: false,
             #[cfg(test)]
             canonical_threat_aura_snapshots_like_cpp: HashMap::new(),
-            spell_store: None,
-            spell_acquisition_catalog: None,
             spell_acquisition_cast_authority_like_cpp: None,
             spell_acquisition_craft_authority_like_cpp: None,
             spell_script_exact_spell_ids_like_cpp: None,
             spell_script_all_rank_root_spell_ids_like_cpp: None,
             legacy_spell_script_spell_ids_like_cpp: None,
             spell_linked_rejected_trigger_spell_ids_like_cpp: None,
-            spell_levels_store: None,
             talent_store: None,
             num_talents_at_level_store: None,
-            spell_chain_store: None,
-            spell_category_store: None,
-            npc_spell_click_store: None,
-            spell_aura_options_store: None,
-            spell_aura_restrictions_store: None,
-            spell_target_restrictions_store: None,
-            spell_equipped_items_store: None,
-            spell_misc_store: None,
-            spell_group_store: None,
-            spell_group_stack_rule_store: None,
-            spell_linked_store: None,
-            spell_pet_aura_store: None,
-            spell_area_store: None,
-            spell_custom_attribute_store: None,
-            #[cfg(test)]
-            serverside_spell_store: None,
-            spell_learn_skill_store: None,
-            spell_learn_spell_store: None,
-            #[cfg(test)]
-            pet_levelup_spell_store: None,
-            #[cfg(test)]
-            pet_default_spell_store: None,
-            #[cfg(test)]
-            pet_family_spell_store: None,
-            spell_proc_store: None,
-            spell_required_store: None,
-            spell_threat_store: None,
-            spell_duration_store: None,
-            spell_radius_store: None,
-            spell_range_store: None,
-            spell_target_position_store: None,
-            #[cfg(test)]
-            spell_totem_model_store: None,
             chr_classes_store: None,
             #[cfg(test)]
             power_type_store: None,
@@ -11377,11 +11293,13 @@ impl WorldSession {
     }
 
     pub(crate) fn spell_spell_group_map_bounds_like_cpp(&self, spell_id: u32) -> &[u32] {
-        self.spell_group_store
+        self.spell_catalogs
+            .spell_group_store
             .as_ref()
             .map(|store| {
                 store.spell_spell_group_map_bounds_like_cpp(spell_id, |lookup_spell_id| {
-                    self.spell_chain_store
+                    self.spell_catalogs
+                        .spell_chain_store
                         .as_ref()
                         .map(|spell_chains| {
                             spell_chains.first_spell_in_chain_like_cpp(lookup_spell_id)
@@ -11393,7 +11311,8 @@ impl WorldSession {
     }
 
     pub(crate) fn spell_group_spell_map_bounds_like_cpp(&self, group_id: u32) -> &[i32] {
-        self.spell_group_store
+        self.spell_catalogs
+            .spell_group_store
             .as_ref()
             .map(|store| store.spell_group_spell_map_bounds_like_cpp(group_id))
             .unwrap_or(&[])
@@ -11404,14 +11323,16 @@ impl WorldSession {
         spell_id: u32,
         group_id: u32,
     ) -> bool {
-        self.spell_group_store
+        self.spell_catalogs
+            .spell_group_store
             .as_ref()
             .map(|store| {
                 store.is_spell_member_of_spell_group_like_cpp(
                     spell_id,
                     group_id,
                     |lookup_spell_id| {
-                        self.spell_chain_store
+                        self.spell_catalogs
+                            .spell_chain_store
                             .as_ref()
                             .map(|spell_chains| {
                                 spell_chains.first_spell_in_chain_like_cpp(lookup_spell_id)
@@ -11424,7 +11345,8 @@ impl WorldSession {
     }
 
     pub(crate) fn set_of_spells_in_spell_group_like_cpp(&self, group_id: u32) -> BTreeSet<u32> {
-        self.spell_group_store
+        self.spell_catalogs
+            .spell_group_store
             .as_ref()
             .map(|store| store.set_of_spells_in_spell_group_like_cpp(group_id))
             .unwrap_or_default()
@@ -11434,7 +11356,8 @@ impl WorldSession {
         &self,
         group_id: u32,
     ) -> SpellGroupStackRuleLikeCpp {
-        self.spell_group_stack_rule_store
+        self.spell_catalogs
+            .spell_group_stack_rule_store
             .as_ref()
             .map(|store| store.spell_group_stack_rule_like_cpp(group_id))
             .unwrap_or(SpellGroupStackRuleLikeCpp::Default)
@@ -11445,10 +11368,10 @@ impl WorldSession {
         first_rank_spell_id_1: u32,
         first_rank_spell_id_2: u32,
     ) -> SpellGroupStackRuleLikeCpp {
-        let Some(stack_rules) = self.spell_group_stack_rule_store.as_ref() else {
+        let Some(stack_rules) = self.spell_catalogs.spell_group_stack_rule_store.as_ref() else {
             return SpellGroupStackRuleLikeCpp::Default;
         };
-        let Some(spell_groups) = self.spell_group_store.as_ref() else {
+        let Some(spell_groups) = self.spell_catalogs.spell_group_store.as_ref() else {
             return SpellGroupStackRuleLikeCpp::Default;
         };
         stack_rules.check_spell_group_stack_rules_like_cpp(
@@ -11463,7 +11386,8 @@ impl WorldSession {
         spell_id: u32,
         effect_index: u8,
     ) -> Option<&PetAuraLikeCpp> {
-        self.spell_pet_aura_store
+        self.spell_catalogs
+            .spell_pet_aura_store
             .as_ref()
             .and_then(|store| store.get_pet_aura_like_cpp(spell_id, effect_index))
     }
@@ -11473,7 +11397,8 @@ impl WorldSession {
         &self,
         pet_family: u32,
     ) -> Option<&PetLevelupSpellSetLikeCpp> {
-        self.pet_levelup_spell_store
+        self.spell_catalogs
+            .pet_levelup_spell_store
             .as_ref()
             .and_then(|store| store.get_pet_levelup_spell_list_like_cpp(pet_family))
     }
@@ -11483,21 +11408,24 @@ impl WorldSession {
         &self,
         id: i32,
     ) -> Option<&PetDefaultSpellsEntryLikeCpp> {
-        self.pet_default_spell_store
+        self.spell_catalogs
+            .pet_default_spell_store
             .as_ref()
             .and_then(|store| store.get_pet_default_spells_entry_like_cpp(id))
     }
 
     #[cfg(test)]
     pub(crate) fn pet_family_spells_like_cpp(&self, pet_family: u32) -> Option<Vec<u32>> {
-        self.pet_family_spell_store
+        self.spell_catalogs
+            .pet_family_spell_store
             .as_ref()
             .and_then(|store| store.get_pet_family_spells_like_cpp(pet_family))
     }
 
     #[cfg(test)]
     pub(crate) fn model_for_totem_like_cpp(&self, spell_id: u32, race_id: u8) -> u32 {
-        self.spell_totem_model_store
+        self.spell_catalogs
+            .spell_totem_model_store
             .as_ref()
             .map(|store| store.get_model_for_totem_like_cpp(spell_id, race_id))
             .unwrap_or(0)
@@ -13506,7 +13434,7 @@ impl WorldSession {
         rows: impl IntoIterator<Item = CharacterPetSpellChargeRowLikeCpp>,
     ) -> usize {
         self.invalidate_represented_character_pet_empty_authority_like_cpp();
-        let spell_category_store = self.spell_category_store().cloned();
+        let spell_category_store = self.spell_catalogs.spell_category_store().cloned();
         let charges: Vec<_> = rows
             .into_iter()
             .filter(|row| {
@@ -13546,8 +13474,8 @@ impl WorldSession {
         self.invalidate_represented_character_pet_empty_authority_like_cpp();
         let spell_store = self.spell_store().cloned();
         let difficulty_store = self.difficulty_store().cloned();
-        let aura_options_store = self.spell_aura_options_store.clone();
-        let spell_misc_store = self.spell_misc_store().cloned();
+        let aura_options_store = self.spell_catalogs.spell_aura_options_store.clone();
+        let spell_misc_store = self.spell_catalogs.spell_misc_store().cloned();
         let auras: Vec<_> = rows
             .into_iter()
             .filter(|row| {
@@ -15059,7 +14987,7 @@ impl WorldSession {
         };
 
         let state = change.state;
-        let spell_store = self.spell_store.as_ref().map(Arc::clone);
+        let spell_store = self.spell_catalogs.spell_store.as_ref().map(Arc::clone);
         let difficulty_store = self.difficulty_store.as_ref().map(Arc::clone);
         let Some(represented_visible_auras) = self.resolved_player_visible_auras_like_cpp() else {
             return RepresentedLiveIntentApplyOutcomeLikeCpp::RejectedMissingCanonicalPlayer;

--- a/crates/wow-world/src/session/pets/pet.rs
+++ b/crates/wow-world/src/session/pets/pet.rs
@@ -359,6 +359,7 @@ impl WorldSession {
             }
 
             if self
+                .spell_catalogs
                 .spell_misc_store()
                 .is_some_and(|store| !store.is_autocastable_like_cpp(action))
             {

--- a/crates/wow-world/src/session/player_items/enchantment.rs
+++ b/crates/wow-world/src/session/player_items/enchantment.rs
@@ -121,17 +121,17 @@ impl WorldSession {
     }
     /// Set the spell item enchantment store for this session.
     pub fn set_spell_item_enchantment_store(&mut self, store: Arc<SpellItemEnchantmentStore>) {
-        self.spell_item_enchantment_store = Some(store);
+        self.spell_catalogs.spell_item_enchantment_store = Some(store);
     }
     pub fn set_spell_item_enchantment_condition_store(
         &mut self,
         store: Arc<SpellItemEnchantmentConditionStore>,
     ) {
-        self.spell_item_enchantment_condition_store = Some(store);
+        self.spell_catalogs.spell_item_enchantment_condition_store = Some(store);
     }
     /// Get the spell item enchantment store reference.
     pub fn spell_item_enchantment_store(&self) -> Option<&Arc<SpellItemEnchantmentStore>> {
-        self.spell_item_enchantment_store.as_ref()
+        self.spell_catalogs.spell_item_enchantment_store.as_ref()
     }
     /// C++ `Player::EnchantmentFitsRequirements` for the currently equipped gems.
     fn enchantment_fits_requirements_like_cpp(
@@ -143,6 +143,7 @@ impl WorldSession {
             return true;
         }
         let Some(condition) = self
+            .spell_catalogs
             .spell_item_enchantment_condition_store
             .as_ref()
             .and_then(|store| store.get(enchantment_condition))
@@ -222,20 +223,22 @@ impl WorldSession {
     }
     #[cfg(test)]
     pub fn set_spell_enchant_proc_store(&mut self, store: Arc<SpellEnchantProcStoreLikeCpp>) {
-        self.spell_enchant_proc_store = Some(store);
+        self.spell_catalogs.spell_enchant_proc_store = Some(store);
     }
     #[cfg(test)]
     pub(crate) fn spell_enchant_proc_event_like_cpp(
         &self,
         enchantment_id: u32,
     ) -> Option<&SpellEnchantProcEntryLikeCpp> {
-        self.spell_enchant_proc_store
+        self.spell_catalogs
+            .spell_enchant_proc_store
             .as_ref()
             .and_then(|store| store.get_spell_enchant_proc_event_like_cpp(enchantment_id))
     }
     /// C++ `SpellMgr::IsArenaAllowedEnchancment`.
     pub fn is_arena_allowed_enchantment(&self, enchantment_id: u32) -> bool {
-        self.spell_item_enchantment_store
+        self.spell_catalogs
+            .spell_item_enchantment_store
             .as_ref()
             .is_some_and(|store| store.is_arena_allowed_enchantment(enchantment_id))
     }
@@ -247,7 +250,8 @@ impl WorldSession {
         condition_fits: bool,
     ) -> Option<ApplyEnchantmentTemplateRef> {
         let id = u32::try_from(enchantment_id).ok()?;
-        self.spell_item_enchantment_store
+        self.spell_catalogs
+            .spell_item_enchantment_store
             .as_ref()
             .and_then(|store| store.get(id))
             .map(|entry| {
@@ -266,7 +270,8 @@ impl WorldSession {
         &self,
         enchantment_id: u32,
     ) -> Option<[ApplyEnchantmentEffectRef; 3]> {
-        self.spell_item_enchantment_store
+        self.spell_catalogs
+            .spell_item_enchantment_store
             .as_ref()
             .and_then(|store| store.get(enchantment_id))
             .map(|entry| {
@@ -363,7 +368,12 @@ impl WorldSession {
             .id;
         let condition_fits = u32::try_from(enchantment_id)
             .ok()
-            .and_then(|id| self.spell_item_enchantment_store.as_ref()?.get(id))
+            .and_then(|id| {
+                self.spell_catalogs
+                    .spell_item_enchantment_store
+                    .as_ref()?
+                    .get(id)
+            })
             .is_none_or(|entry| {
                 self.enchantment_fits_requirements_like_cpp(u32::from(entry.condition_id), None)
             });
@@ -530,7 +540,12 @@ impl WorldSession {
             };
             let enchantment_entry = u32::try_from(enchantment.id)
                 .ok()
-                .and_then(|id| self.spell_item_enchantment_store.as_ref()?.get(id))
+                .and_then(|id| {
+                    self.spell_catalogs
+                        .spell_item_enchantment_store
+                        .as_ref()?
+                        .get(id)
+                })
                 .copied();
             let clear_mainhand = clear_mainhand_only
                 && enchantment_entry.is_some_and(|entry| {

--- a/crates/wow-world/src/session/player_items/equipment.rs
+++ b/crates/wow-world/src/session/player_items/equipment.rs
@@ -20,7 +20,7 @@ impl WorldSession {
         &self,
         spell_id: u32,
     ) -> bool {
-        let Some(spell_store) = self.spell_store.as_ref() else {
+        let Some(spell_store) = self.spell_catalogs.spell_store.as_ref() else {
             return true;
         };
         let Ok(spell_id) = i32::try_from(spell_id) else {
@@ -32,7 +32,8 @@ impl WorldSession {
         };
         spell_store
             .check_shapeshift_like_cpp(spell_id, form_id, |form| {
-                self.spell_shapeshift_form_store
+                self.spell_catalogs
+                    .spell_shapeshift_form_store
                     .as_ref()
                     .and_then(|store| store.get(form))
             })

--- a/crates/wow-world/src/session/player_items/equipment_sets.rs
+++ b/crates/wow-world/src/session/player_items/equipment_sets.rs
@@ -399,7 +399,7 @@ impl WorldSession {
         self.creature_equipment_store_like_cpp = Some(store);
     }
     pub fn set_spell_equipped_items_store(&mut self, store: Arc<SpellEquippedItemsStore>) {
-        self.spell_equipped_items_store = Some(store);
+        self.spell_catalogs.spell_equipped_items_store = Some(store);
     }
     /// Builds the represented statement sequence for C++ `Player::_SaveSpells`.
     ///

--- a/crates/wow-world/src/session/player_items/items.rs
+++ b/crates/wow-world/src/session/player_items/items.rs
@@ -527,12 +527,17 @@ impl WorldSession {
                 )
             }
             class if class == ItemClass::Armor as i8 => {
-                if self.spell_store.as_ref().is_some_and(|store| {
-                    store.has_attribute8_like_cpp(
-                        equipped.spell_id,
-                        SPELL_ATTR8_REQUIRES_EQUIPPED_INV_TYPES_LIKE_CPP,
-                    )
-                }) {
+                if self
+                    .spell_catalogs
+                    .spell_store
+                    .as_ref()
+                    .is_some_and(|store| {
+                        store.has_attribute8_like_cpp(
+                            equipped.spell_id,
+                            SPELL_ATTR8_REQUIRES_EQUIPPED_INV_TYPES_LIKE_CPP,
+                        )
+                    })
+                {
                     [
                         EQUIPMENT_SLOT_HEAD,
                         EQUIPMENT_SLOT_SHOULDERS,

--- a/crates/wow-world/src/session/player_items/modifiers.rs
+++ b/crates/wow-world/src/session/player_items/modifiers.rs
@@ -62,7 +62,7 @@ impl WorldSession {
         self.item_set_store = Some(store);
     }
     pub fn set_item_set_spell_store(&mut self, store: Arc<ItemSetSpellStore>) {
-        self.item_set_spell_store = Some(store);
+        self.spell_catalogs.item_set_spell_store = Some(store);
     }
     pub(crate) fn item_set_for_item_id_like_cpp(
         &self,
@@ -76,7 +76,8 @@ impl WorldSession {
         &self,
         item_set_id: u32,
     ) -> Vec<&wow_data::ItemSetSpellEntry> {
-        self.item_set_spell_store
+        self.spell_catalogs
+            .item_set_spell_store
             .as_ref()
             .map(|store| store.item_set_spells_like_cpp(item_set_id))
             .unwrap_or_default()
@@ -279,7 +280,8 @@ impl WorldSession {
         let Ok(spell_id) = i32::try_from(spell_id) else {
             return false;
         };
-        self.spell_store
+        self.spell_catalogs
+            .spell_store
             .as_ref()
             .is_none_or(|store| store.get(spell_id).is_some())
     }

--- a/crates/wow-world/src/session/quest/state.rs
+++ b/crates/wow-world/src/session/quest/state.rs
@@ -180,7 +180,8 @@ impl WorldSession {
         &self,
         quest_id: u32,
     ) -> Vec<&SpellAreaLikeCpp> {
-        self.spell_area_store
+        self.spell_catalogs
+            .spell_area_store
             .as_ref()
             .map(|store| store.spell_area_for_quest_map_bounds_like_cpp(quest_id))
             .unwrap_or_default()
@@ -189,7 +190,8 @@ impl WorldSession {
         &self,
         quest_id: u32,
     ) -> Vec<&SpellAreaLikeCpp> {
-        self.spell_area_store
+        self.spell_catalogs
+            .spell_area_store
             .as_ref()
             .map(|store| store.spell_area_for_quest_end_map_bounds_like_cpp(quest_id))
             .unwrap_or_default()

--- a/crates/wow-world/src/session/spell_effects/checks.rs
+++ b/crates/wow-world/src/session/spell_effects/checks.rs
@@ -167,11 +167,16 @@ impl WorldSession {
     ) -> Option<RepresentedMountSpellCheckOutcomeLikeCpp> {
         for effect in spell_info.effects() {
             if effect.is_mod_shapeshift_aura_like_cpp() {
-                if let Some(form) = self.spell_shapeshift_form_store.as_ref().and_then(|store| {
-                    u32::try_from(effect.effect_misc_value_1)
-                        .ok()
-                        .and_then(|form_id| store.get(form_id))
-                }) {
+                if let Some(form) = self
+                    .spell_catalogs
+                    .spell_shapeshift_form_store
+                    .as_ref()
+                    .and_then(|store| {
+                        u32::try_from(effect.effect_misc_value_1)
+                            .ok()
+                            .and_then(|form_id| store.get(form_id))
+                    })
+                {
                     let (is_submerged, is_in_water) =
                         self.represented_player_mount_liquid_state_like_cpp()?;
                     let riding_skill =

--- a/crates/wow-world/src/session/spell_effects/destinations.rs
+++ b/crates/wow-world/src/session/spell_effects/destinations.rs
@@ -45,6 +45,7 @@ impl WorldSession {
         mut position: Position,
     ) -> Position {
         if self
+            .spell_catalogs
             .spell_misc_store
             .as_deref()
             .and_then(|store| store.get_by_spell_id(u32::try_from(spell_id).ok()?))
@@ -204,6 +205,7 @@ impl WorldSession {
 
         let spell_id_u32 = u32::try_from(spell_info.spell_id).ok()?;
         let target_position = self
+            .spell_catalogs
             .spell_target_position_store
             .as_deref()
             .and_then(|store| store.get(spell_id_u32, effect.effect_index));
@@ -279,7 +281,8 @@ impl WorldSession {
             .as_ref()
             .is_some_and(|conditions| !conditions.is_empty());
         let target_position = if is_or_db && !has_implicit_conditions {
-            self.spell_target_position_store
+            self.spell_catalogs
+                .spell_target_position_store
                 .as_deref()
                 .and_then(|store| store.get(spell_id_u32, effect.effect_index))
         } else {
@@ -287,18 +290,20 @@ impl WorldSession {
         };
         let caster_position = self.player_position_like_cpp()?;
         let range = self
+            .spell_catalogs
             .spell_misc_store
             .as_deref()
             .and_then(|store| store.get_by_spell_id(spell_id_u32))
             .and_then(|misc| {
-                self.spell_range_store
+                self.spell_catalogs
+                    .spell_range_store
                     .as_deref()
                     .and_then(|store| store.get(u32::from(misc.range_index)))
             })
             .map(|range| range.range_max[0].max(range.range_max[1]))?;
         let radius = spell_effect_radius_like_cpp(
             effect.effect_radius_index_1,
-            self.spell_radius_store.as_deref(),
+            self.spell_catalogs.spell_radius_store.as_deref(),
         );
         let position = if let Some(target_position) = target_position {
             if target_position.target_map_id == self.player_map_id_like_cpp()

--- a/crates/wow-world/src/session/spell_effects/effect_apply.rs
+++ b/crates/wow-world/src/session/spell_effects/effect_apply.rs
@@ -271,16 +271,19 @@ impl WorldSession {
         let spell_id_u32 = u32::try_from(spell_id).ok()?;
         let spell_visual_id_i32 = i32::try_from(spell_visual_id).ok()?;
         let duration_index = self
+            .spell_catalogs
             .spell_misc_store
             .as_deref()
             .and_then(|store| store.get_by_spell_id(spell_id_u32))
             .map(|entry| u32::from(entry.duration_index))
             .unwrap_or(0);
-        let duration_ms =
-            spell_duration_ms_like_cpp(duration_index, self.spell_duration_store.as_deref());
+        let duration_ms = spell_duration_ms_like_cpp(
+            duration_index,
+            self.spell_catalogs.spell_duration_store.as_deref(),
+        );
         let radius = spell_effect_radius_like_cpp(
             effect.effect_radius_index_1,
-            self.spell_radius_store.as_deref(),
+            self.spell_catalogs.spell_radius_store.as_deref(),
         );
         let manager = Arc::clone(self.canonical_map_manager.as_ref()?);
         let mut manager = manager.lock().ok()?;
@@ -361,6 +364,7 @@ impl WorldSession {
         }
 
         let Some(hearthstone_cooldown_ms) = self
+            .spell_catalogs
             .spell_store
             .as_deref()
             .and_then(|store| store.get(HEARTHSTONE_SPELL_ID_LIKE_CPP))

--- a/crates/wow-world/src/session/spell_effects/effect_combat.rs
+++ b/crates/wow-world/src/session/spell_effects/effect_combat.rs
@@ -297,6 +297,7 @@ impl WorldSession {
         });
         let duration_ms = {
             let duration_index = self
+                .spell_catalogs
                 .spell_misc_store
                 .as_deref()
                 .and_then(|store| {
@@ -307,7 +308,10 @@ impl WorldSession {
                 })
                 .map(|entry| u32::from(entry.duration_index))
                 .unwrap_or(0);
-            spell_duration_ms_like_cpp(duration_index, self.spell_duration_store.as_deref())
+            spell_duration_ms_like_cpp(
+                duration_index,
+                self.spell_catalogs.spell_duration_store.as_deref(),
+            )
         };
 
         let Some((threat_value, taunt_slot)) = self

--- a/crates/wow-world/src/session/spell_effects/effect_summon.rs
+++ b/crates/wow-world/src/session/spell_effects/effect_summon.rs
@@ -139,13 +139,16 @@ impl WorldSession {
         };
         let spell_id_u32 = u32::try_from(spell_id).unwrap_or(0);
         let duration_index = self
+            .spell_catalogs
             .spell_misc_store
             .as_deref()
             .and_then(|store| store.get_by_spell_id(spell_id_u32))
             .map(|entry| u32::from(entry.duration_index))
             .unwrap_or(0);
-        let duration_ms =
-            spell_duration_ms_like_cpp(duration_index, self.spell_duration_store.as_deref());
+        let duration_ms = spell_duration_ms_like_cpp(
+            duration_index,
+            self.spell_catalogs.spell_duration_store.as_deref(),
+        );
         let lifecycle_record = wow_data::gameobject_template_lifecycle_record_like_cpp(template);
         let Ok(mut manager) = manager.lock() else {
             return Some(ApplyEffectSummonObjectWildSessionOutcomeLikeCpp {
@@ -319,13 +322,16 @@ impl WorldSession {
         };
         let spell_id_u32 = u32::try_from(spell_id).unwrap_or(0);
         let duration_index = self
+            .spell_catalogs
             .spell_misc_store
             .as_deref()
             .and_then(|store| store.get_by_spell_id(spell_id_u32))
             .map(|entry| u32::from(entry.duration_index))
             .unwrap_or(0);
-        let duration_ms =
-            spell_duration_ms_like_cpp(duration_index, self.spell_duration_store.as_deref());
+        let duration_ms = spell_duration_ms_like_cpp(
+            duration_index,
+            self.spell_catalogs.spell_duration_store.as_deref(),
+        );
         let lifecycle_record = wow_data::gameobject_template_lifecycle_record_like_cpp(template);
         let Ok(mut manager) = manager.lock() else {
             return Some(ApplyEffectSummonObjectSlotSessionOutcomeLikeCpp {

--- a/crates/wow-world/src/session/spell_effects/effects.rs
+++ b/crates/wow-world/src/session/spell_effects/effects.rs
@@ -179,7 +179,7 @@ impl WorldSession {
 
         if let (Some(spell_store), Some(shapeshift_form_store)) = (
             self.spell_store(),
-            self.spell_shapeshift_form_store.as_ref(),
+            self.spell_catalogs.spell_shapeshift_form_store.as_ref(),
         ) {
             for aura in visible_auras.values() {
                 let Some(spell_info) = spell_store.get(aura.spell_id) else {
@@ -424,7 +424,8 @@ impl WorldSession {
         spell_id: i32,
         effect_index: u32,
     ) -> Option<Arc<wow_data::ConditionContainer>> {
-        self.spell_store
+        self.spell_catalogs
+            .spell_store
             .as_deref()
             .and_then(|store| store.implicit_target_conditions_like_cpp(spell_id, effect_index))
             .and_then(|conditions| conditions.upgrade())

--- a/crates/wow-world/src/session/spell_effects/effects_progress.rs
+++ b/crates/wow-world/src/session/spell_effects/effects_progress.rs
@@ -163,6 +163,7 @@ impl WorldSession {
     ) -> Result<(), &'static str> {
         let _ = self.player_guid().ok_or("No player GUID")?;
         let Some(equipped) = self
+            .spell_catalogs
             .spell_equipped_items_store
             .as_ref()
             .and_then(|store| store.entry_for_spell_id_like_cpp(spell_id))

--- a/crates/wow-world/src/session/spell_state/aura.rs
+++ b/crates/wow-world/src/session/spell_state/aura.rs
@@ -50,15 +50,6 @@ impl WorldSession {
             }),
         }
     }
-    pub fn set_spell_aura_options_store(&mut self, store: Arc<SpellAuraOptionsStore>) {
-        self.spell_aura_options_store = Some(store);
-    }
-    pub fn set_spell_aura_restrictions_store(&mut self, store: Arc<SpellAuraRestrictionsStore>) {
-        self.spell_aura_restrictions_store = Some(store);
-    }
-    pub(crate) fn spell_aura_restrictions_store(&self) -> Option<&Arc<SpellAuraRestrictionsStore>> {
-        self.spell_aura_restrictions_store.as_ref()
-    }
     pub(in crate::session) fn player_aura_subsystem_snapshot_like_cpp(
         &self,
     ) -> Option<wow_entities::AuraSubsystem> {
@@ -259,7 +250,7 @@ impl WorldSession {
         if known_spells.is_empty() {
             return true;
         }
-        let Some(spell_store) = self.spell_store.as_ref() else {
+        let Some(spell_store) = self.spell_catalogs.spell_store.as_ref() else {
             return false;
         };
         known_spells.iter().copied().all(|spell_id| {
@@ -317,7 +308,8 @@ impl WorldSession {
         &self,
         spell_id: u32,
     ) -> Vec<&SpellAreaLikeCpp> {
-        self.spell_area_store
+        self.spell_catalogs
+            .spell_area_store
             .as_ref()
             .map(|store| store.spell_area_for_aura_map_bounds_like_cpp(spell_id))
             .unwrap_or_default()
@@ -373,8 +365,8 @@ impl WorldSession {
         };
         let spell_store = self.spell_store().cloned();
         let difficulty_store = self.difficulty_store().cloned();
-        let aura_options_store = self.spell_aura_options_store.clone();
-        let spell_misc_store = self.spell_misc_store().cloned();
+        let aura_options_store = self.spell_catalogs.spell_aura_options_store.clone();
+        let spell_misc_store = self.spell_catalogs.spell_misc_store().cloned();
 
         let effects: Vec<_> = effect_rows
             .into_iter()

--- a/crates/wow-world/src/session/spell_state/aura_application.rs
+++ b/crates/wow-world/src/session/spell_state/aura_application.rs
@@ -19,7 +19,8 @@ impl WorldSession {
         &self,
         group_id: u32,
     ) -> Option<&BTreeSet<i32>> {
-        self.spell_group_stack_rule_store
+        self.spell_catalogs
+            .spell_group_stack_rule_store
             .as_ref()
             .and_then(|store| store.same_effect_stack_rule_aura_types_like_cpp(group_id))
     }
@@ -279,6 +280,7 @@ impl WorldSession {
             }
 
             if let Some(equipped) = self
+                .spell_catalogs
                 .spell_equipped_items_store
                 .as_ref()
                 .and_then(|store| store.entry_for_spell_id_like_cpp(spell_id))
@@ -609,7 +611,7 @@ impl WorldSession {
         &mut self,
         attribute: u32,
     ) -> usize {
-        let Some(spell_store) = self.spell_store.as_ref() else {
+        let Some(spell_store) = self.spell_catalogs.spell_store.as_ref() else {
             return 0;
         };
         let Some(visible_auras) = self.resolved_player_visible_auras_like_cpp() else {
@@ -682,9 +684,14 @@ impl WorldSession {
                 // used for SPELL_AURA_MOD_SCALE in CancelGrowthAura. These
                 // represented effects model positive player-cancelable paths;
                 // SpellMisc attributes preserve the C++ no-player-cancel gate.
-                if self.spell_store.as_ref().is_some_and(|store| {
-                    store.has_attribute0_like_cpp(aura.spell_id, no_aura_cancel)
-                }) {
+                if self
+                    .spell_catalogs
+                    .spell_store
+                    .as_ref()
+                    .is_some_and(|store| {
+                        store.has_attribute0_like_cpp(aura.spell_id, no_aura_cancel)
+                    })
+                {
                     return None;
                 }
                 (aura.represented_effect == Some(represented_effect)).then_some(aura.slot)
@@ -702,7 +709,7 @@ impl WorldSession {
         spell_id: i32,
         caster_guid: ObjectGuid,
     ) -> usize {
-        let Some(spell_store) = self.spell_store.as_ref() else {
+        let Some(spell_store) = self.spell_catalogs.spell_store.as_ref() else {
             return 0;
         };
         if spell_store.get(spell_id).is_none()

--- a/crates/wow-world/src/session/spell_state/aura_publication.rs
+++ b/crates/wow-world/src/session/spell_state/aura_publication.rs
@@ -52,7 +52,7 @@ impl WorldSession {
         {
             return false;
         }
-        let Some(effects) = self.spell_store.as_ref().and_then(|store| {
+        let Some(effects) = self.spell_catalogs.spell_store.as_ref().and_then(|store| {
             store.effects_for_difficulty_like_cpp(
                 aura.spell_id,
                 aura.difficulty_id,

--- a/crates/wow-world/src/session/spell_state/cast.rs
+++ b/crates/wow-world/src/session/spell_state/cast.rs
@@ -208,12 +208,16 @@ impl WorldSession {
     pub(in crate::session) fn represented_spell_area_autocast_source_is_empty_like_cpp(
         &self,
     ) -> bool {
-        self.spell_area_store.as_ref().is_some_and(|store| {
-            store.areas_like_cpp().iter().all(|spell_area| {
-                spell_area.flags & SPELL_AREA_FLAG_AUTOCAST_LIKE_CPP == 0
-                    || !self.represented_spell_area_could_autocast_for_player_like_cpp(spell_area)
+        self.spell_catalogs
+            .spell_area_store
+            .as_ref()
+            .is_some_and(|store| {
+                store.areas_like_cpp().iter().all(|spell_area| {
+                    spell_area.flags & SPELL_AREA_FLAG_AUTOCAST_LIKE_CPP == 0
+                        || !self
+                            .represented_spell_area_could_autocast_for_player_like_cpp(spell_area)
+                })
             })
-        })
     }
     /// Represented C++ first-login `PlayerInfo::castSpells[GetCreateMode()]`.
     ///
@@ -343,7 +347,7 @@ impl WorldSession {
         &self,
         spell_id: i32,
     ) -> bool {
-        let Some(spell_store) = self.spell_store.as_ref() else {
+        let Some(spell_store) = self.spell_catalogs.spell_store.as_ref() else {
             return false;
         };
         let (stances, _) = spell_store.shapeshift_masks_like_cpp(spell_id);
@@ -370,6 +374,7 @@ impl WorldSession {
             return false;
         };
         let caster_aura_state = self
+            .spell_catalogs
             .spell_aura_restrictions_store
             .as_ref()
             .and_then(|store| {

--- a/crates/wow-world/src/session/spell_state/catalog.rs
+++ b/crates/wow-world/src/session/spell_state/catalog.rs
@@ -34,128 +34,22 @@ impl WorldSession {
     ) {
         self.player_create_custom_spell_store_like_cpp = Some(store);
     }
-    pub fn set_spell_shapeshift_form_store(&mut self, store: Arc<SpellShapeshiftFormStore>) {
-        self.spell_shapeshift_form_store = Some(store);
-    }
-    #[allow(dead_code)]
-    pub(crate) fn spell_shapeshift_form_store(&self) -> Option<&Arc<SpellShapeshiftFormStore>> {
-        self.spell_shapeshift_form_store.as_ref()
-    }
     /// Set the spell store for this session.
     pub fn set_spell_store(&mut self, store: Arc<SpellStore>) {
         self.invalidate_canonical_player_spell_hit_aura_authority_like_cpp();
-        self.spell_store = Some(store);
-    }
-    /// Get the spell store reference.
-    pub fn spell_store(&self) -> Option<&Arc<SpellStore>> {
-        self.spell_store.as_ref()
-    }
-    pub fn set_spell_acquisition_catalog(&mut self, catalog: Arc<SpellAcquisitionCatalogLikeCpp>) {
-        self.spell_acquisition_catalog = Some(catalog);
-    }
-    pub(crate) fn spell_acquisition_catalog(&self) -> Option<&Arc<SpellAcquisitionCatalogLikeCpp>> {
-        self.spell_acquisition_catalog.as_ref()
-    }
-    pub fn set_spell_levels_store(&mut self, store: Arc<SpellLevelsStore>) {
-        self.spell_levels_store = Some(store);
-    }
-    pub(crate) fn spell_levels_store(&self) -> Option<&Arc<SpellLevelsStore>> {
-        self.spell_levels_store.as_ref()
+        self.spell_catalogs.spell_store = Some(store);
     }
     pub fn set_spell_chain_store(&mut self, store: Arc<SpellChainStoreLikeCpp>) {
         self.invalidate_canonical_player_spell_hit_aura_authority_like_cpp();
-        self.spell_chain_store = Some(store);
-    }
-    pub(crate) fn spell_chain_store(&self) -> Option<&Arc<SpellChainStoreLikeCpp>> {
-        self.spell_chain_store.as_ref()
-    }
-    pub fn set_spell_category_store(&mut self, store: Arc<SpellCategoryStore>) {
-        self.spell_category_store = Some(store);
-    }
-    pub(crate) fn spell_category_store(&self) -> Option<&Arc<SpellCategoryStore>> {
-        self.spell_category_store.as_ref()
-    }
-    pub fn set_npc_spell_click_store(&mut self, store: Arc<NpcSpellClickStoreLikeCpp>) {
-        self.npc_spell_click_store = Some(store);
-    }
-    #[allow(dead_code)]
-    pub(crate) fn npc_spell_click_store(&self) -> Option<&Arc<NpcSpellClickStoreLikeCpp>> {
-        self.npc_spell_click_store.as_ref()
-    }
-    pub fn set_spell_target_restrictions_store(
-        &mut self,
-        store: Arc<SpellTargetRestrictionsStore>,
-    ) {
-        self.spell_target_restrictions_store = Some(store);
-    }
-    pub(crate) fn spell_target_restrictions_store(
-        &self,
-    ) -> Option<&Arc<SpellTargetRestrictionsStore>> {
-        self.spell_target_restrictions_store.as_ref()
-    }
-    pub fn set_spell_misc_store(&mut self, store: Arc<SpellMiscStore>) {
-        self.spell_misc_store = Some(store);
+        self.spell_catalogs.spell_chain_store = Some(store);
     }
     pub fn set_spell_linked_store(&mut self, store: Arc<SpellLinkedStoreLikeCpp>) {
         self.invalidate_canonical_player_spell_hit_aura_authority_like_cpp();
-        self.spell_linked_store = Some(store);
-    }
-    pub(crate) fn spell_linked_store_like_cpp(&self) -> Option<&SpellLinkedStoreLikeCpp> {
-        self.spell_linked_store.as_deref()
+        self.spell_catalogs.spell_linked_store = Some(store);
     }
     pub fn set_spell_area_store(&mut self, store: Arc<SpellAreaStoreLikeCpp>) {
         self.invalidate_canonical_player_spell_hit_aura_authority_like_cpp();
-        self.spell_area_store = Some(store);
-    }
-    pub fn set_spell_custom_attribute_store(
-        &mut self,
-        store: Arc<SpellCustomAttributeStoreLikeCpp>,
-    ) {
-        self.spell_custom_attribute_store = Some(store);
-    }
-    pub(crate) fn spell_custom_attribute_store_like_cpp(
-        &self,
-    ) -> Option<&Arc<SpellCustomAttributeStoreLikeCpp>> {
-        self.spell_custom_attribute_store.as_ref()
-    }
-    #[cfg(test)]
-    pub fn set_serverside_spell_store(&mut self, store: Arc<ServersideSpellStoreLikeCpp>) {
-        self.serverside_spell_store = Some(store);
-    }
-    pub fn set_spell_proc_store(&mut self, store: Arc<SpellProcStoreLikeCpp>) {
-        self.spell_proc_store = Some(store);
-    }
-    #[allow(dead_code)]
-    pub(crate) fn spell_proc_store(&self) -> Option<&Arc<SpellProcStoreLikeCpp>> {
-        self.spell_proc_store.as_ref()
-    }
-    pub fn set_spell_required_store(&mut self, store: Arc<SpellRequiredStoreLikeCpp>) {
-        self.spell_required_store = Some(store);
-    }
-    pub(crate) fn spell_required_store_like_cpp(&self) -> Option<&Arc<SpellRequiredStoreLikeCpp>> {
-        self.spell_required_store.as_ref()
-    }
-    #[cfg(test)]
-    pub fn set_spell_totem_model_store(&mut self, store: Arc<SpellTotemModelStoreLikeCpp>) {
-        self.spell_totem_model_store = Some(store);
-    }
-    pub fn set_spell_duration_store(&mut self, store: Arc<SpellDurationStore>) {
-        self.spell_duration_store = Some(store);
-    }
-    pub fn set_spell_radius_store(&mut self, store: Arc<SpellRadiusStore>) {
-        self.spell_radius_store = Some(store);
-    }
-    pub(crate) fn spell_misc_store(&self) -> Option<&Arc<SpellMiscStore>> {
-        self.spell_misc_store.as_ref()
-    }
-    pub fn set_spell_range_store(&mut self, store: Arc<SpellRangeStore>) {
-        self.spell_range_store = Some(store);
-    }
-    pub(crate) fn spell_range_store(&self) -> Option<&Arc<SpellRangeStore>> {
-        self.spell_range_store.as_ref()
-    }
-    pub fn set_spell_target_position_store(&mut self, store: Arc<SpellTargetPositionStoreLikeCpp>) {
-        self.spell_target_position_store = Some(store);
+        self.spell_catalogs.spell_area_store = Some(store);
     }
     #[cfg(test)]
     pub(in crate::session) fn store_player_spell_runtime_fixture_like_cpp(
@@ -184,5 +78,81 @@ impl WorldSession {
             return true;
         }
         false
+    }
+}
+
+impl WorldSession {
+    pub fn set_spell_aura_restrictions_store(&mut self, store: Arc<SpellAuraRestrictionsStore>) {
+        self.spell_catalogs.set_spell_aura_restrictions_store(store);
+    }
+    pub fn set_spell_aura_options_store(&mut self, store: Arc<SpellAuraOptionsStore>) {
+        self.spell_catalogs.set_spell_aura_options_store(store);
+    }
+    pub fn set_spell_target_position_store(&mut self, store: Arc<SpellTargetPositionStoreLikeCpp>) {
+        self.spell_catalogs.set_spell_target_position_store(store);
+    }
+    pub fn set_spell_range_store(&mut self, store: Arc<SpellRangeStore>) {
+        self.spell_catalogs.set_spell_range_store(store);
+    }
+    pub fn set_spell_radius_store(&mut self, store: Arc<SpellRadiusStore>) {
+        self.spell_catalogs.set_spell_radius_store(store);
+    }
+    pub fn set_spell_duration_store(&mut self, store: Arc<SpellDurationStore>) {
+        self.spell_catalogs.set_spell_duration_store(store);
+    }
+    #[cfg(test)]
+    pub fn set_spell_totem_model_store(&mut self, store: Arc<SpellTotemModelStoreLikeCpp>) {
+        self.spell_catalogs.set_spell_totem_model_store(store);
+    }
+    pub fn set_spell_required_store(&mut self, store: Arc<SpellRequiredStoreLikeCpp>) {
+        self.spell_catalogs.set_spell_required_store(store);
+    }
+    pub fn set_spell_proc_store(&mut self, store: Arc<SpellProcStoreLikeCpp>) {
+        self.spell_catalogs.set_spell_proc_store(store);
+    }
+    #[cfg(test)]
+    pub fn set_serverside_spell_store(&mut self, store: Arc<ServersideSpellStoreLikeCpp>) {
+        self.spell_catalogs.set_serverside_spell_store(store);
+    }
+    pub fn set_spell_custom_attribute_store(
+        &mut self,
+        store: Arc<SpellCustomAttributeStoreLikeCpp>,
+    ) {
+        self.spell_catalogs.set_spell_custom_attribute_store(store);
+    }
+    pub fn set_spell_misc_store(&mut self, store: Arc<SpellMiscStore>) {
+        self.spell_catalogs.set_spell_misc_store(store);
+    }
+    pub fn set_spell_target_restrictions_store(
+        &mut self,
+        store: Arc<SpellTargetRestrictionsStore>,
+    ) {
+        self.spell_catalogs
+            .set_spell_target_restrictions_store(store);
+    }
+    pub fn set_npc_spell_click_store(&mut self, store: Arc<NpcSpellClickStoreLikeCpp>) {
+        self.spell_catalogs.set_npc_spell_click_store(store);
+    }
+    pub fn set_spell_category_store(&mut self, store: Arc<SpellCategoryStore>) {
+        self.spell_catalogs.set_spell_category_store(store);
+    }
+    pub fn set_spell_levels_store(&mut self, store: Arc<SpellLevelsStore>) {
+        self.spell_catalogs.set_spell_levels_store(store);
+    }
+    pub fn set_spell_acquisition_catalog(&mut self, catalog: Arc<SpellAcquisitionCatalogLikeCpp>) {
+        self.spell_catalogs.set_spell_acquisition_catalog(catalog);
+    }
+    /// Get the spell store reference.
+    pub fn spell_store(&self) -> Option<&Arc<SpellStore>> {
+        self.spell_catalogs.spell_store()
+    }
+    pub fn set_spell_shapeshift_form_store(&mut self, store: Arc<SpellShapeshiftFormStore>) {
+        self.spell_catalogs.set_spell_shapeshift_form_store(store);
+    }
+    pub fn set_spell_learn_spell_store(&mut self, store: Arc<SpellLearnSpellStoreLikeCpp>) {
+        self.spell_catalogs.set_spell_learn_spell_store(store);
+    }
+    pub fn set_spell_learn_skill_store(&mut self, store: Arc<SpellLearnSkillStoreLikeCpp>) {
+        self.spell_catalogs.set_spell_learn_skill_store(store);
     }
 }

--- a/crates/wow-world/src/session/spell_state/cooldown.rs
+++ b/crates/wow-world/src/session/spell_state/cooldown.rs
@@ -207,7 +207,7 @@ impl WorldSession {
         }
 
         // Per-spell cooldown (if exists in SpellStore)
-        if let Some(store) = &self.spell_store {
+        if let Some(store) = &self.spell_catalogs.spell_store {
             if let Some(spell_info) = store.get(spell_id) {
                 if elapsed_ms < spell_info.cooldown_ms {
                     return true;

--- a/crates/wow-world/src/session/spell_state/spell.rs
+++ b/crates/wow-world/src/session/spell_state/spell.rs
@@ -130,8 +130,8 @@ impl WorldSession {
             self.legacy_spell_script_spell_ids_like_cpp.as_deref(),
             self.spell_linked_rejected_trigger_spell_ids_like_cpp
                 .as_deref(),
-            self.spell_chain_store.as_deref(),
-            self.spell_linked_store.as_deref(),
+            self.spell_catalogs.spell_chain_store.as_deref(),
+            self.spell_catalogs.spell_linked_store.as_deref(),
         )
     }
     /// Prove that every effective effect and every world-table hook for one
@@ -147,7 +147,7 @@ impl WorldSession {
         if !self.spell_has_no_unrepresented_runtime_hooks_like_cpp(spell_id) {
             return false;
         }
-        let Some(spell_store) = self.spell_store.as_ref() else {
+        let Some(spell_store) = self.spell_catalogs.spell_store.as_ref() else {
             return false;
         };
         if spell_store.get(spell_id_i32).is_none() {
@@ -166,19 +166,22 @@ impl WorldSession {
             })
     }
     pub(crate) fn next_spell_in_chain_like_cpp(&self, spell_id: u32) -> u32 {
-        self.spell_chain_store
+        self.spell_catalogs
+            .spell_chain_store
             .as_ref()
             .map(|store| store.next_spell_in_chain_like_cpp(spell_id))
             .unwrap_or(0)
     }
     pub(crate) fn first_spell_in_chain_like_cpp(&self, spell_id: u32) -> u32 {
-        self.spell_chain_store
+        self.spell_catalogs
+            .spell_chain_store
             .as_ref()
             .map(|store| store.first_spell_in_chain_like_cpp(spell_id))
             .unwrap_or(spell_id)
     }
     pub(crate) fn prev_spell_in_chain_like_cpp(&self, spell_id: u32) -> u32 {
-        self.spell_chain_store
+        self.spell_catalogs
+            .spell_chain_store
             .as_ref()
             .map(|store| store.prev_spell_in_chain_like_cpp(spell_id))
             .unwrap_or(0)
@@ -196,13 +199,15 @@ impl WorldSession {
         link_type: SpellLinkedTypeLikeCpp,
         spell_id: u32,
     ) -> &[i32] {
-        self.spell_linked_store
+        self.spell_catalogs
+            .spell_linked_store
             .as_ref()
             .and_then(|store| store.get_spell_linked_like_cpp(link_type, spell_id))
             .unwrap_or(&[])
     }
     pub(crate) fn spell_area_map_bounds_like_cpp(&self, spell_id: u32) -> Vec<&SpellAreaLikeCpp> {
-        self.spell_area_store
+        self.spell_catalogs
+            .spell_area_store
             .as_ref()
             .map(|store| store.spell_area_map_bounds_like_cpp(spell_id))
             .unwrap_or_default()
@@ -211,7 +216,8 @@ impl WorldSession {
         &self,
         area_id: u32,
     ) -> Vec<&SpellAreaLikeCpp> {
-        self.spell_area_store
+        self.spell_catalogs
+            .spell_area_store
             .as_ref()
             .map(|store| store.spell_area_for_area_map_bounds_like_cpp(area_id))
             .unwrap_or_default()
@@ -221,7 +227,8 @@ impl WorldSession {
         spell_id: u32,
         difficulty: u32,
     ) -> u32 {
-        self.spell_custom_attribute_store
+        self.spell_catalogs
+            .spell_custom_attribute_store
             .as_ref()
             .map(|store| store.attributes_for_spell_difficulty_like_cpp(spell_id, difficulty))
             .unwrap_or(0)
@@ -232,7 +239,8 @@ impl WorldSession {
         spell_id: u32,
         difficulty: u32,
     ) -> Option<&ServersideSpellInfoLikeCpp> {
-        self.serverside_spell_store
+        self.spell_catalogs
+            .serverside_spell_store
             .as_ref()
             .and_then(|store| store.get_serverside_spell_like_cpp(spell_id, difficulty))
     }
@@ -241,7 +249,7 @@ impl WorldSession {
         spell_id: u32,
         difficulty: u32,
     ) -> Option<&SpellProcEntryLikeCpp> {
-        let store = self.spell_proc_store.as_ref()?;
+        let store = self.spell_catalogs.spell_proc_store.as_ref()?;
         store.spell_proc_entry_with_fallback_like_cpp(spell_id, difficulty, |current_difficulty| {
             self.difficulty_store
                 .as_ref()
@@ -250,19 +258,22 @@ impl WorldSession {
         })
     }
     pub(crate) fn spells_required_for_spell_like_cpp(&self, spell_id: u32) -> &[u32] {
-        self.spell_required_store
+        self.spell_catalogs
+            .spell_required_store
             .as_ref()
             .map(|store| store.spells_required_for_spell_like_cpp(spell_id))
             .unwrap_or(&[])
     }
     pub(crate) fn spells_requiring_spell_like_cpp(&self, req_spell: u32) -> &[u32] {
-        self.spell_required_store
+        self.spell_catalogs
+            .spell_required_store
             .as_ref()
             .map(|store| store.spells_requiring_spell_like_cpp(req_spell))
             .unwrap_or(&[])
     }
     pub(crate) fn is_spell_requiring_spell_like_cpp(&self, spell_id: u32, req_spell: u32) -> bool {
-        self.spell_required_store
+        self.spell_catalogs
+            .spell_required_store
             .as_ref()
             .map(|store| store.is_spell_requiring_spell_like_cpp(spell_id, req_spell))
             .unwrap_or(false)
@@ -272,7 +283,8 @@ impl WorldSession {
         spell_id: u32,
         difficulty: u8,
     ) -> u32 {
-        self.spell_misc_store()
+        self.spell_catalogs
+            .spell_misc_store()
             .and_then(|store| {
                 store.entry_for_spell_difficulty_with_fallback_like_cpp(
                     spell_id,

--- a/crates/wow-world/src/session/spell_state/spell_click.rs
+++ b/crates/wow-world/src/session/spell_state/spell_click.rs
@@ -19,7 +19,7 @@ impl WorldSession {
     ) -> RepresentedSpellClickPlanLikeCpp {
         let mut plan = RepresentedSpellClickPlanLikeCpp::default();
 
-        let Some(spell_click_store) = self.npc_spell_click_store.as_ref() else {
+        let Some(spell_click_store) = self.spell_catalogs.npc_spell_click_store.as_ref() else {
             plan.exact_context_unrepresented = true;
             return plan;
         };
@@ -382,7 +382,7 @@ impl WorldSession {
         .await
     }
     pub(crate) fn update_visible_spell_clicks_like_cpp(&mut self) -> usize {
-        let Some(spell_click_store) = self.npc_spell_click_store.as_ref() else {
+        let Some(spell_click_store) = self.spell_catalogs.npc_spell_click_store.as_ref() else {
             return 0;
         };
         let Some(condition_store) = self.condition_store.as_ref() else {

--- a/crates/wow-world/src/session/spell_state/spellbook.rs
+++ b/crates/wow-world/src/session/spell_state/spellbook.rs
@@ -9,14 +9,6 @@ impl WorldSession {
     pub fn set_offhand_check_at_spell_unlearn_like_cpp(&mut self, enabled: bool) {
         self.represented_offhand_check_at_spell_unlearn_like_cpp = enabled;
     }
-    pub fn set_spell_learn_skill_store(&mut self, store: Arc<SpellLearnSkillStoreLikeCpp>) {
-        self.spell_learn_skill_store = Some(store);
-    }
-    pub(crate) fn spell_learn_skill_store_like_cpp(
-        &self,
-    ) -> Option<&Arc<SpellLearnSkillStoreLikeCpp>> {
-        self.spell_learn_skill_store.as_ref()
-    }
     pub(crate) fn spell_learn_skill_like_cpp(
         &self,
         spell_id: u32,
@@ -32,35 +24,31 @@ impl WorldSession {
         &self,
         spell_id: u32,
     ) -> SpellLearnSkillLookupLikeCpp<'_> {
-        self.spell_learn_skill_store
+        self.spell_catalogs
+            .spell_learn_skill_store
             .as_ref()
             .map(|store| store.spell_learn_skill_lookup_like_cpp(spell_id))
             .unwrap_or(SpellLearnSkillLookupLikeCpp::MissingCoverage)
-    }
-    pub fn set_spell_learn_spell_store(&mut self, store: Arc<SpellLearnSpellStoreLikeCpp>) {
-        self.spell_learn_spell_store = Some(store);
-    }
-    pub(crate) fn spell_learn_spell_store_like_cpp(
-        &self,
-    ) -> Option<&Arc<SpellLearnSpellStoreLikeCpp>> {
-        self.spell_learn_spell_store.as_ref()
     }
     pub(crate) fn spell_learn_spell_map_bounds_like_cpp(
         &self,
         spell_id: u32,
     ) -> &[SpellLearnSpellNodeLikeCpp] {
-        self.spell_learn_spell_store
+        self.spell_catalogs
+            .spell_learn_spell_store
             .as_ref()
             .map(|store| store.get_spell_learn_spell_map_bounds_like_cpp(spell_id))
             .unwrap_or(&[])
     }
     pub(crate) fn is_spell_learn_spell_like_cpp(&self, spell_id: u32) -> bool {
-        self.spell_learn_spell_store
+        self.spell_catalogs
+            .spell_learn_spell_store
             .as_ref()
             .is_some_and(|store| store.is_spell_learn_spell_like_cpp(spell_id))
     }
     pub(crate) fn is_spell_learn_to_spell_like_cpp(&self, spell_id1: u32, spell_id2: u32) -> bool {
-        self.spell_learn_spell_store
+        self.spell_catalogs
+            .spell_learn_spell_store
             .as_ref()
             .is_some_and(|store| store.is_spell_learn_to_spell_like_cpp(spell_id1, spell_id2))
     }
@@ -104,7 +92,7 @@ impl WorldSession {
         &self,
         known_spells: &mut Vec<i32>,
     ) -> usize {
-        let Some(spell_chains) = self.spell_chain_store() else {
+        let Some(spell_chains) = self.spell_catalogs.spell_chain_store() else {
             return 0;
         };
 
@@ -639,6 +627,7 @@ impl WorldSession {
                 if prev_spell_id != 0 {
                     if let Ok(prev_known_spell_id) = i32::try_from(prev_spell_id) {
                         let current_spell_is_ranked = self
+                            .spell_catalogs
                             .spell_chain_store()
                             .and_then(|store| store.spell_chain_node_like_cpp(current_spell_id))
                             .is_some();

--- a/crates/wow-world/src/session/tests/scenarios_spell_state_1.rs
+++ b/crates/wow-world/src/session/tests/scenarios_spell_state_1.rs
@@ -19,12 +19,11 @@ fn spell_acquisition_catalog_arc_is_shared_with_session() {
 
     session.set_spell_acquisition_catalog(Arc::clone(&catalog));
 
-    assert!(Arc::ptr_eq(
-        &catalog,
-        session
-            .spell_acquisition_catalog()
-            .expect("the process-wide catalog must be installed")
-    ));
+    let catalogs = &session.spell_catalogs;
+    let installed = catalogs
+        .spell_acquisition_catalog()
+        .expect("the process-wide catalog must be installed");
+    assert!(Arc::ptr_eq(&catalog, installed));
 }
 #[test]
 fn spell_proc_entry_prefers_exact_difficulty_like_cpp() {

--- a/crates/wow-world/src/session/tests/scenarios_spell_state_14.rs
+++ b/crates/wow-world/src/session/tests/scenarios_spell_state_14.rs
@@ -439,7 +439,8 @@ fn resummon_pet_validates_action_bar_spells_like_cpp() {
         no_autocast_misc,
         autocastable_misc,
     ])));
-    let spell_misc_store = session
+    let catalogs = &session.spell_catalogs;
+    let spell_misc_store = catalogs
         .spell_misc_store()
         .expect("spell misc store should be installed");
     assert!(!spell_misc_store.is_autocastable_like_cpp(1_111));

--- a/crates/wow-world/src/session/world_entities/aggro.rs
+++ b/crates/wow-world/src/session/world_entities/aggro.rs
@@ -72,15 +72,16 @@ impl WorldSession {
         }
     }
     pub fn set_spell_threat_store(&mut self, store: Arc<SpellThreatStoreLikeCpp>) {
-        self.spell_threat_store = Some(store);
+        self.spell_catalogs.spell_threat_store = Some(store);
     }
     pub(crate) fn spell_threat_entry_like_cpp(
         &self,
         spell_id: u32,
     ) -> Option<&SpellThreatEntryLikeCpp> {
-        let store = self.spell_threat_store.as_ref()?;
+        let store = self.spell_catalogs.spell_threat_store.as_ref()?;
         store.get_spell_threat_entry_like_cpp(spell_id, |lookup_spell_id| {
-            self.spell_chain_store
+            self.spell_catalogs
+                .spell_chain_store
                 .as_ref()
                 .map(|spell_chains| spell_chains.first_spell_in_chain_like_cpp(lookup_spell_id))
                 .unwrap_or(lookup_spell_id)
@@ -117,7 +118,8 @@ impl WorldSession {
         }
 
         Some(
-            self.spell_levels_store
+            self.spell_catalogs
+                .spell_levels_store
                 .as_deref()
                 .and_then(|store| {
                     let mut difficulty_id = difficulty;

--- a/crates/wow-world/src/session/world_entities/spell_click.rs
+++ b/crates/wow-world/src/session/world_entities/spell_click.rs
@@ -43,7 +43,7 @@ impl WorldSession {
         &self,
         creature_guid: ObjectGuid,
     ) -> RepresentedCanSeeSpellClickOutcomeLikeCpp {
-        let Some(spell_click_store) = self.npc_spell_click_store.as_ref() else {
+        let Some(spell_click_store) = self.spell_catalogs.npc_spell_click_store.as_ref() else {
             return RepresentedCanSeeSpellClickOutcomeLikeCpp::ExactContextUnrepresented;
         };
         let Some(condition_store) = self.condition_store.as_ref() else {

--- a/crates/wow-world/src/spell_acquisition/adapter.rs
+++ b/crates/wow-world/src/spell_acquisition/adapter.rs
@@ -188,12 +188,12 @@ impl crate::session::WorldSession {
             Some(skill_lines),
             Some(skill_tiers),
         ) = (
-            self.spell_acquisition_catalog(),
-            self.spell_chain_store(),
-            self.spell_learn_skill_store_like_cpp(),
-            self.spell_learn_spell_store_like_cpp(),
-            self.spell_required_store_like_cpp(),
-            self.spell_custom_attribute_store_like_cpp(),
+            self.spell_catalogs.spell_acquisition_catalog(),
+            self.spell_catalogs.spell_chain_store(),
+            self.spell_catalogs.spell_learn_skill_store_like_cpp(),
+            self.spell_catalogs.spell_learn_spell_store_like_cpp(),
+            self.spell_catalogs.spell_required_store_like_cpp(),
+            self.spell_catalogs.spell_custom_attribute_store_like_cpp(),
             self.trait_definition_store(),
             self.skill_store(),
             self.skill_line_store(),
@@ -247,7 +247,7 @@ impl crate::session::WorldSession {
         &self,
         spell_id: u32,
     ) -> Option<PlayerCastAcquisitionResolutionLikeCpp> {
-        let catalog = self.spell_acquisition_catalog()?;
+        let catalog = self.spell_catalogs.spell_acquisition_catalog()?;
         let difficulty_chain = self.current_map_difficulty_chain_for_acquisition_like_cpp();
         let effective_effects = match catalog.resolved_effects_for_difficulty_chain_like_cpp(
             spell_id,
@@ -292,7 +292,7 @@ impl crate::session::WorldSession {
         // HUMANOID mask. Do not combine sibling difficulty rows: a heroic
         // restriction cannot reject a normal cast (or vice versa).
         if !trainer_target_restriction_admits_player_like_cpp(
-            self.spell_target_restrictions_store()?,
+            self.spell_catalogs.spell_target_restrictions_store()?,
             spell_id,
             difficulty_chain.iter().copied(),
         ) {
@@ -312,6 +312,7 @@ impl crate::session::WorldSession {
         // state-based rows remain unavailable until Unit AuraState is owned.
         let visible_auras = self.resolved_player_visible_auras_like_cpp()?;
         let aura_restriction_result = self
+            .spell_catalogs
             .spell_aura_restrictions_store()?
             .resolved_for_difficulty_chain_like_cpp(spell_id, difficulty_chain.iter().copied())
             .map_or(TrainerAuraRestrictionResultLikeCpp::Pass, |restriction| {
@@ -455,7 +456,7 @@ impl crate::session::WorldSession {
         trainer_effects: &[SpellAcquisitionEffectLikeCpp],
         no_immunities: bool,
     ) -> Option<u32> {
-        let linked = self.spell_linked_store_like_cpp()?;
+        let linked = self.spell_catalogs.spell_linked_store_like_cpp()?;
         let visible_auras = self.resolved_player_visible_auras_like_cpp()?;
         let mut immunized_effect_mask = 0_u32;
         for aura in visible_auras.values() {

--- a/crates/wow-world/src/spell_catalogs.rs
+++ b/crates/wow-world/src/spell_catalogs.rs
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 alseif0x
+// RustyCore — WoW WotLK 3.4.3 server in Rust
+// Based on TrinityCore protocol research (https://github.com/TrinityCore/TrinityCore)
+// Licensed under GPL v3 — https://www.gnu.org/licenses/gpl-3.0.html
+
+//! The spell and aura catalog authority a session reads rules from.
+//!
+//! C++ keeps these stores in `SpellMgr`/`ObjectMgr` and reaches them from
+//! `WorldSession` through global accessors. Rust cannot use a global, so the
+//! slots were session fields until #668 gave them their own owner: this type
+//! owns every spell/aura catalog slot, and `WorldSession` holds exactly one of
+//! it. No store slot remains on the session, so there is no second mirror to
+//! keep in sync.
+//!
+//! The owner depends on `wow-data` stores only - no session, no map, no packet
+//! and no database. It performs no async work and holds no lock; every slot is
+//! filled once at startup and read afterwards.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+/// Every spell and aura catalog slot a session reads, owned in one place.
+#[derive(Default)]
+pub(crate) struct SpellCatalogsLikeCpp {
+    pub(crate) item_set_spell_store: Option<Arc<wow_data::ItemSetSpellStore>>,
+    pub(crate) npc_spell_click_store: Option<Arc<wow_data::NpcSpellClickStoreLikeCpp>>,
+    pub(crate) pet_default_spell_store: Option<Arc<wow_data::PetDefaultSpellStoreLikeCpp>>,
+    pub(crate) pet_family_spell_store: Option<Arc<wow_data::PetFamilySpellStoreLikeCpp>>,
+    pub(crate) pet_levelup_spell_store: Option<Arc<wow_data::PetLevelupSpellStoreLikeCpp>>,
+    pub(crate) serverside_spell_store: Option<Arc<wow_data::ServersideSpellStoreLikeCpp>>,
+    pub(crate) spell_acquisition_catalog: Option<Arc<wow_data::SpellAcquisitionCatalogLikeCpp>>,
+    pub(crate) spell_area_store: Option<Arc<wow_data::SpellAreaStoreLikeCpp>>,
+    pub(crate) spell_aura_options_store: Option<Arc<wow_data::SpellAuraOptionsStore>>,
+    pub(crate) spell_aura_restrictions_store: Option<Arc<wow_data::SpellAuraRestrictionsStore>>,
+    pub(crate) spell_category_store: Option<Arc<wow_data::SpellCategoryStore>>,
+    pub(crate) spell_chain_store: Option<Arc<wow_data::SpellChainStoreLikeCpp>>,
+    pub(crate) spell_custom_attribute_store:
+        Option<Arc<wow_data::SpellCustomAttributeStoreLikeCpp>>,
+    pub(crate) spell_duration_store: Option<Arc<wow_data::SpellDurationStore>>,
+    pub(crate) spell_enchant_proc_store: Option<Arc<wow_data::SpellEnchantProcStoreLikeCpp>>,
+    pub(crate) spell_equipped_items_store: Option<Arc<wow_data::SpellEquippedItemsStore>>,
+    pub(crate) spell_group_stack_rule_store: Option<Arc<wow_data::SpellGroupStackRuleStoreLikeCpp>>,
+    pub(crate) spell_group_store: Option<Arc<wow_data::SpellGroupStoreLikeCpp>>,
+    pub(crate) spell_item_enchantment_condition_store:
+        Option<Arc<wow_data::SpellItemEnchantmentConditionStore>>,
+    pub(crate) spell_item_enchantment_store: Option<Arc<wow_data::SpellItemEnchantmentStore>>,
+    pub(crate) spell_learn_skill_store: Option<Arc<wow_data::SpellLearnSkillStoreLikeCpp>>,
+    pub(crate) spell_learn_spell_store: Option<Arc<wow_data::SpellLearnSpellStoreLikeCpp>>,
+    pub(crate) spell_levels_store: Option<Arc<wow_data::SpellLevelsStore>>,
+    pub(crate) spell_linked_store: Option<Arc<wow_data::SpellLinkedStoreLikeCpp>>,
+    pub(crate) spell_misc_store: Option<Arc<wow_data::SpellMiscStore>>,
+    pub(crate) spell_pet_aura_store: Option<Arc<wow_data::SpellPetAuraStoreLikeCpp>>,
+    pub(crate) spell_proc_store: Option<Arc<wow_data::SpellProcStoreLikeCpp>>,
+    pub(crate) spell_radius_store: Option<Arc<wow_data::SpellRadiusStore>>,
+    pub(crate) spell_range_store: Option<Arc<wow_data::SpellRangeStore>>,
+    pub(crate) spell_required_store: Option<Arc<wow_data::SpellRequiredStoreLikeCpp>>,
+    pub(crate) spell_shapeshift_form_store: Option<Arc<wow_data::SpellShapeshiftFormStore>>,
+    pub(crate) spell_store: Option<Arc<wow_data::SpellStore>>,
+    pub(crate) spell_target_position_store: Option<Arc<wow_data::SpellTargetPositionStoreLikeCpp>>,
+    pub(crate) spell_target_restrictions_store: Option<Arc<wow_data::SpellTargetRestrictionsStore>>,
+    pub(crate) spell_threat_store: Option<Arc<wow_data::SpellThreatStoreLikeCpp>>,
+    pub(crate) spell_totem_model_store: Option<Arc<wow_data::SpellTotemModelStoreLikeCpp>>,
+}
+
+impl SpellCatalogsLikeCpp {
+    #[allow(dead_code)]
+    pub(crate) fn npc_spell_click_store(
+        &self,
+    ) -> Option<&Arc<wow_data::NpcSpellClickStoreLikeCpp>> {
+        self.npc_spell_click_store.as_ref()
+    }
+    pub(crate) fn set_npc_spell_click_store(
+        &mut self,
+        store: Arc<wow_data::NpcSpellClickStoreLikeCpp>,
+    ) {
+        self.npc_spell_click_store = Some(store);
+    }
+    #[cfg(test)]
+    pub(crate) fn set_serverside_spell_store(
+        &mut self,
+        store: Arc<wow_data::ServersideSpellStoreLikeCpp>,
+    ) {
+        self.serverside_spell_store = Some(store);
+    }
+    pub(crate) fn set_spell_acquisition_catalog(
+        &mut self,
+        catalog: Arc<wow_data::SpellAcquisitionCatalogLikeCpp>,
+    ) {
+        self.spell_acquisition_catalog = Some(catalog);
+    }
+    pub(crate) fn set_spell_aura_options_store(
+        &mut self,
+        store: Arc<wow_data::SpellAuraOptionsStore>,
+    ) {
+        self.spell_aura_options_store = Some(store);
+    }
+    pub(crate) fn set_spell_aura_restrictions_store(
+        &mut self,
+        store: Arc<wow_data::SpellAuraRestrictionsStore>,
+    ) {
+        self.spell_aura_restrictions_store = Some(store);
+    }
+    pub(crate) fn set_spell_category_store(&mut self, store: Arc<wow_data::SpellCategoryStore>) {
+        self.spell_category_store = Some(store);
+    }
+    pub(crate) fn set_spell_custom_attribute_store(
+        &mut self,
+        store: Arc<wow_data::SpellCustomAttributeStoreLikeCpp>,
+    ) {
+        self.spell_custom_attribute_store = Some(store);
+    }
+    pub(crate) fn set_spell_duration_store(&mut self, store: Arc<wow_data::SpellDurationStore>) {
+        self.spell_duration_store = Some(store);
+    }
+    pub(crate) fn set_spell_learn_skill_store(
+        &mut self,
+        store: Arc<wow_data::SpellLearnSkillStoreLikeCpp>,
+    ) {
+        self.spell_learn_skill_store = Some(store);
+    }
+    pub(crate) fn set_spell_learn_spell_store(
+        &mut self,
+        store: Arc<wow_data::SpellLearnSpellStoreLikeCpp>,
+    ) {
+        self.spell_learn_spell_store = Some(store);
+    }
+    pub(crate) fn set_spell_levels_store(&mut self, store: Arc<wow_data::SpellLevelsStore>) {
+        self.spell_levels_store = Some(store);
+    }
+    pub(crate) fn set_spell_misc_store(&mut self, store: Arc<wow_data::SpellMiscStore>) {
+        self.spell_misc_store = Some(store);
+    }
+    pub(crate) fn set_spell_proc_store(&mut self, store: Arc<wow_data::SpellProcStoreLikeCpp>) {
+        self.spell_proc_store = Some(store);
+    }
+    pub(crate) fn set_spell_radius_store(&mut self, store: Arc<wow_data::SpellRadiusStore>) {
+        self.spell_radius_store = Some(store);
+    }
+    pub(crate) fn set_spell_range_store(&mut self, store: Arc<wow_data::SpellRangeStore>) {
+        self.spell_range_store = Some(store);
+    }
+    pub(crate) fn set_spell_required_store(
+        &mut self,
+        store: Arc<wow_data::SpellRequiredStoreLikeCpp>,
+    ) {
+        self.spell_required_store = Some(store);
+    }
+    pub(crate) fn set_spell_shapeshift_form_store(
+        &mut self,
+        store: Arc<wow_data::SpellShapeshiftFormStore>,
+    ) {
+        self.spell_shapeshift_form_store = Some(store);
+    }
+    pub(crate) fn set_spell_target_position_store(
+        &mut self,
+        store: Arc<wow_data::SpellTargetPositionStoreLikeCpp>,
+    ) {
+        self.spell_target_position_store = Some(store);
+    }
+    pub(crate) fn set_spell_target_restrictions_store(
+        &mut self,
+        store: Arc<wow_data::SpellTargetRestrictionsStore>,
+    ) {
+        self.spell_target_restrictions_store = Some(store);
+    }
+    #[cfg(test)]
+    pub(crate) fn set_spell_totem_model_store(
+        &mut self,
+        store: Arc<wow_data::SpellTotemModelStoreLikeCpp>,
+    ) {
+        self.spell_totem_model_store = Some(store);
+    }
+    pub(crate) fn spell_acquisition_catalog(
+        &self,
+    ) -> Option<&Arc<wow_data::SpellAcquisitionCatalogLikeCpp>> {
+        self.spell_acquisition_catalog.as_ref()
+    }
+    pub(crate) fn spell_aura_restrictions_store(
+        &self,
+    ) -> Option<&Arc<wow_data::SpellAuraRestrictionsStore>> {
+        self.spell_aura_restrictions_store.as_ref()
+    }
+    pub(crate) fn spell_category_store(&self) -> Option<&Arc<wow_data::SpellCategoryStore>> {
+        self.spell_category_store.as_ref()
+    }
+    pub(crate) fn spell_chain_store(&self) -> Option<&Arc<wow_data::SpellChainStoreLikeCpp>> {
+        self.spell_chain_store.as_ref()
+    }
+    pub(crate) fn spell_custom_attribute_store_like_cpp(
+        &self,
+    ) -> Option<&Arc<wow_data::SpellCustomAttributeStoreLikeCpp>> {
+        self.spell_custom_attribute_store.as_ref()
+    }
+    pub(crate) fn spell_learn_skill_store_like_cpp(
+        &self,
+    ) -> Option<&Arc<wow_data::SpellLearnSkillStoreLikeCpp>> {
+        self.spell_learn_skill_store.as_ref()
+    }
+    pub(crate) fn spell_learn_spell_store_like_cpp(
+        &self,
+    ) -> Option<&Arc<wow_data::SpellLearnSpellStoreLikeCpp>> {
+        self.spell_learn_spell_store.as_ref()
+    }
+    pub(crate) fn spell_levels_store(&self) -> Option<&Arc<wow_data::SpellLevelsStore>> {
+        self.spell_levels_store.as_ref()
+    }
+    pub(crate) fn spell_linked_store_like_cpp(&self) -> Option<&wow_data::SpellLinkedStoreLikeCpp> {
+        self.spell_linked_store.as_deref()
+    }
+    pub(crate) fn spell_misc_store(&self) -> Option<&Arc<wow_data::SpellMiscStore>> {
+        self.spell_misc_store.as_ref()
+    }
+    #[allow(dead_code)]
+    pub(crate) fn spell_proc_store(&self) -> Option<&Arc<wow_data::SpellProcStoreLikeCpp>> {
+        self.spell_proc_store.as_ref()
+    }
+    pub(crate) fn spell_range_store(&self) -> Option<&Arc<wow_data::SpellRangeStore>> {
+        self.spell_range_store.as_ref()
+    }
+    pub(crate) fn spell_required_store_like_cpp(
+        &self,
+    ) -> Option<&Arc<wow_data::SpellRequiredStoreLikeCpp>> {
+        self.spell_required_store.as_ref()
+    }
+    #[allow(dead_code)]
+    pub(crate) fn spell_shapeshift_form_store(
+        &self,
+    ) -> Option<&Arc<wow_data::SpellShapeshiftFormStore>> {
+        self.spell_shapeshift_form_store.as_ref()
+    }
+    /// Get the spell store reference.
+    pub(crate) fn spell_store(&self) -> Option<&Arc<wow_data::SpellStore>> {
+        self.spell_store.as_ref()
+    }
+    pub(crate) fn spell_target_restrictions_store(
+        &self,
+    ) -> Option<&Arc<wow_data::SpellTargetRestrictionsStore>> {
+        self.spell_target_restrictions_store.as_ref()
+    }
+}

--- a/tools/architecture/runtime-ownership-ledger.json
+++ b/tools/architecture/runtime-ownership-ledger.json
@@ -38,13 +38,13 @@
       "member_key": "name",
       "zero_gaps": true,
       "zero_overlap": true,
-      "expected_field_count": 716,
+      "expected_field_count": 681,
       "validation": "Compare the sorted AST names with the sorted concatenation of every family.field_names; reject a missing name, duplicate name, stale name, family count mismatch, or total count mismatch."
     },
     "families": [
       {
         "id": "test_only_fixtures",
-        "expected_field_count": 433,
+        "expected_field_count": 427,
         "field_names": [
           "account_mounts_like_cpp",
           "active_player_local_flags_like_cpp",
@@ -157,9 +157,6 @@
           "party_raid_warnings_like_cpp",
           "pass_on_group_loot",
           "pending_teleport",
-          "pet_default_spell_store",
-          "pet_family_spell_store",
-          "pet_levelup_spell_store",
           "player_alive_like_cpp",
           "player_area_id_like_cpp",
           "player_aura_authority_complete_like_cpp",
@@ -457,9 +454,6 @@
           "seasonal_quest_changed_like_cpp",
           "seasonal_quests_like_cpp",
           "selection_guid",
-          "serverside_spell_store",
-          "spell_enchant_proc_store",
-          "spell_totem_model_store",
           "start_all_explored_like_cpp",
           "start_all_reputation_like_cpp",
           "start_all_spells_like_cpp",
@@ -638,7 +632,7 @@
       },
       {
         "id": "immutable_catalogs_configuration_and_services",
-        "expected_field_count": 132,
+        "expected_field_count": 103,
         "field_names": [
           "access_requirement_store",
           "area_table_store",
@@ -683,7 +677,6 @@
           "item_random_properties_store",
           "item_random_suffix_store",
           "item_search_name_store",
-          "item_set_spell_store",
           "item_set_store",
           "item_spec_override_store",
           "item_stats_store",
@@ -704,7 +697,6 @@
           "mount_type_x_capability_store",
           "mount_x_display_store",
           "movie_store",
-          "npc_spell_click_store",
           "num_talents_at_level_store",
           "paragon_reputation_store",
           "phase_group_store",
@@ -732,34 +724,7 @@
           "skill_line_store",
           "skill_store",
           "skill_tiers_store",
-          "spell_acquisition_catalog",
-          "spell_area_store",
-          "spell_aura_options_store",
-          "spell_aura_restrictions_store",
-          "spell_category_store",
-          "spell_chain_store",
-          "spell_custom_attribute_store",
-          "spell_duration_store",
-          "spell_equipped_items_store",
-          "spell_group_stack_rule_store",
-          "spell_group_store",
-          "spell_item_enchantment_condition_store",
-          "spell_item_enchantment_store",
-          "spell_learn_skill_store",
-          "spell_learn_spell_store",
-          "spell_levels_store",
-          "spell_linked_store",
-          "spell_misc_store",
-          "spell_pet_aura_store",
-          "spell_proc_store",
-          "spell_radius_store",
-          "spell_range_store",
-          "spell_required_store",
-          "spell_shapeshift_form_store",
-          "spell_store",
-          "spell_target_position_store",
-          "spell_target_restrictions_store",
-          "spell_threat_store",
+          "spell_catalogs",
           "talent_store",
           "terrain_swap_store",
           "toy_store",
@@ -773,7 +738,7 @@
           "waypoint_path_resolver_like_cpp",
           "world_safe_loc_store_like_cpp"
         ],
-        "current_storage": "132 production immutable catalog/configuration/service fields remain on WorldSession. The unused DungeonEncounter Session dependency is deleted; startup loading remains. TraitNodeEntry is required in process-owned PlayerBootstrap and borrowed by login and teleport trait loading, with no Session field, accessor or fixture mirror. The gameobject lifecycle catalog identifier is reconciled to its actual _like_cpp name. Grid-load, hotfix, glyph and talent-tab catalogs are borrowed by their consumers. Fifty former catalog fixture fields are listed only under test_only_fixtures. The remaining production catalog bag is not an approved terminal boundary.",
+        "current_storage": "The 36 spell and aura catalog slots left this struct under #668: they are now owned by crates/wow-world/src/spell_catalogs.rs (SpellCatalogsLikeCpp), and WorldSession holds exactly one field of that type, so no store slot is mirrored here. The remaining names are the other immutable catalogs, configuration and service handles still held directly. 132 production immutable catalog/configuration/service fields remain on WorldSession. The unused DungeonEncounter Session dependency is deleted; startup loading remains. TraitNodeEntry is required in process-owned PlayerBootstrap and borrowed by login and teleport trait loading, with no Session field, accessor or fixture mirror. The gameobject lifecycle catalog identifier is reconciled to its actual _like_cpp name. Grid-load, hotfix, glyph and talent-tab catalogs are borrowed by their consumers. Fifty former catalog fixture fields are listed only under test_only_fixtures. The remaining production catalog bag is not an approved terminal boundary.",
         "sole_writer": "world-server bootstrap constructs the process-wide value; create_session/setters assign the Session handle once. Runtime code should read but not mutate immutable catalogs.",
         "readers": "Handlers and gameplay helpers across wow-world.",
         "clock_lifetime": "Mostly process lifetime; a Session retains Arc handles for its connection lifetime. Generators and mutable services retain their own process-wide owner.",
@@ -1044,10 +1009,10 @@
         "review": "docs/architecture/session-578-checkpoint.md; current exact membership, not terminal ownership acceptance."
       }
     ],
-    "expected_field_count": 716,
-    "expected_unique_field_count": 716,
-    "expected_production_field_count": 283,
-    "expected_test_fixture_field_count": 433
+    "expected_field_count": 681,
+    "expected_unique_field_count": 681,
+    "expected_production_field_count": 254,
+    "expected_test_fixture_field_count": 427
   },
   "inventories": {
     "session_resources": {
@@ -1449,9 +1414,9 @@
       "entries": [
         {
           "path": "crates/wow-world/src/session/mod.rs",
-          "production_lines": 84455,
+          "production_lines": 84190,
           "test_lines": 109114,
-          "total_lines": 193569,
+          "total_lines": 193304,
           "owner": "wow-world WorldSession/application monolith.",
           "latest_growth_review": "2026-09-09 #599: the represented world-entity responsibility - creature, gameobject, aggro and spawn - leaves the Session root for 18 bounded session/world_entities submodules. The physical root drops 6,767 lines, from 66,808 to 60,041, and its ceiling is tightened to that figure. Logical production rises 25 lines because each of the 18 new files carries a module header and an impl wrapper; the methods themselves are unchanged, with an identical impl surface of 2,149 methods before and after and 37 visibilities widened from private to pub(in crate::session). As in #597, logical totals barely move because the new modules are reviewed private descendants of the same owner: this makes the responsibility navigable and separately ownable, ahead of the semantic extraction. | 2026-09-09 #597: the represented item and inventory family leaves the Session root for 18 bounded session/player_items submodules. The physical root drops 8,653 lines, from 75,841 to 67,187, and its ceiling is tightened to that figure. Logical totals barely move because the new modules are reviewed private descendants of this same owner: that is the point - this delivery makes the responsibility navigable and separately ownable, it does not yet remove it from the Session tree. The move is method-for-method with an identical impl surface of 3,761 associated items before and after, 52 visibilities widened from private to pub(in crate::session) and nothing made public. Semantic extraction behind a narrow application follows. | 2026-09-08 #589: +1308 production/+683 test lines for the represented Player cast-request lifecycle. Production growth is the private session/player_cast adapters (identity, state, checks, power, publication, wire), 1543 lines that concentrate the cast responsibility in one owner while handlers/spell.rs shrinks 455 lines and the Session root itself shrinks 267; the orchestration proper lives outside Session in the private wow-world::player_cast application. Test growth is the bounded session/tests/player_cast_lifecycle.rs module. The 1015-line player spell-hit source authority suite moved from session_tests.rs into session/tests/player_spell_hit_source.rs: net-neutral for this logical scope and a real reduction of the physical file, whose ceiling drops from 95703 to 94691. No new WorldSession field, Player mirror, clock, task or lock; one new SessionCommand variant reuses the existing bounded durable rail from #588. This is cast lifecycle adaptation, not retirement of remaining gameplay ownership; the #584 C2/C4 exits remain. Campaign follow-up: +3 production/+169 test lines. Two cast lifecycle scenarios cover the C++ Start/Go flag assembly and the residence fence over a server-triggered cast, and the three spell-click scenarios install and adopt a canonical Player like login does. | 2026-09-08 #588: +128 production/+568 test lines for the map-selected visibility adapter, retained mailbox slot/order and directory delivery; no WorldSession field, Player mirror or new lock/task. Ten bounded Session tests cover ACK, current client ledger, backpressure, committed-prefix order and stale consumers. Session root shrinks 24 physical lines. This is necessary protocol/lifecycle adaptation, not retirement of remaining gameplay ownership; #584 C2/C4 exits remain. PR #586 writer-order repair: +25 production/+111 test lines for interruptible far-transfer publication (immediate and delayed), instance-to-realm logout fencing and cancellation/failure coverage. Four existing update methods become async; no added field/task/lock/mirror. Tests use bounded existing modules; root +16 physical lines retains its #584:C4 split exit. 2026-09-07 final QA: +7 production lines preserve loaded canonical reputation on repeated same-race/class identity hydration; no field, API, lock or owner added. 2026-09-07 #585 above integrated 59f5bced: +563 production/+1 fixture lines for finalization extraction, then +9 production/+28 fixture lines for canonical far-destination orientation normalization. Fresh paired logout capture then requires realm publication: +1 production separator/+60 test lines in lifecycle/finalization.rs for the two-route backpressure/closed-realm regression, with unchanged send_async semantics and no new method, field, clock, lock or recovery owner. Account/offline/buyback adapters moved from character into private lifecycle modules; finite policy lives outside Session in crate::finalization. One task-owned ledger retains progress and recovery input. Physical new modules remain below 500 lines; root physical ceiling unchanged. Remaining Session authority stays under #584. See session-finalization-585.md.",
           "open_retirement_issues": [

--- a/tools/architecture/session-ownership-policy.json
+++ b/tools/architecture/session-ownership-policy.json
@@ -1232,13 +1232,6 @@
           "source_class": "production"
         },
         {
-          "name": "item_set_spell_store",
-          "type": "Option < Arc < ItemSetSpellStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
           "name": "item_set_store",
           "type": "Option < Arc < ItemSetStore > >",
           "visibility": "private",
@@ -1841,13 +1834,6 @@
           "source_class": "production"
         },
         {
-          "name": "npc_spell_click_store",
-          "type": "Option < Arc < NpcSpellClickStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
           "name": "num_talents_at_level_store",
           "type": "Option < Arc < NumTalentsAtLevelStore > >",
           "visibility": "private",
@@ -1982,33 +1968,6 @@
           "visibility": "pub (crate)",
           "cfg": [],
           "source_class": "production"
-        },
-        {
-          "name": "pet_default_spell_store",
-          "type": "Option < Arc < PetDefaultSpellStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [
-            "cfg (test)"
-          ],
-          "source_class": "test_fixture"
-        },
-        {
-          "name": "pet_family_spell_store",
-          "type": "Option < Arc < PetFamilySpellStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [
-            "cfg (test)"
-          ],
-          "source_class": "test_fixture"
-        },
-        {
-          "name": "pet_levelup_spell_store",
-          "type": "Option < Arc < PetLevelupSpellStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [
-            "cfg (test)"
-          ],
-          "source_class": "test_fixture"
         },
         {
           "name": "pet_load_query_holder_rows_like_cpp",
@@ -5195,15 +5154,6 @@
           "source_class": "production"
         },
         {
-          "name": "serverside_spell_store",
-          "type": "Option < Arc < ServersideSpellStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [
-            "cfg (test)"
-          ],
-          "source_class": "test_fixture"
-        },
-        {
           "name": "session_command_rx",
           "type": "flume :: Receiver < SessionCommand >",
           "visibility": "private",
@@ -5281,13 +5231,6 @@
           "source_class": "production"
         },
         {
-          "name": "spell_acquisition_catalog",
-          "type": "Option < Arc < SpellAcquisitionCatalogLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
           "name": "spell_acquisition_craft_authority_like_cpp",
           "type": "Option < Arc < crate :: spell_acquisition :: SpellAcquisitionCraftValidityAuthorityLikeCpp > >",
           "visibility": "pub (crate)",
@@ -5295,171 +5238,15 @@
           "source_class": "production"
         },
         {
-          "name": "spell_area_store",
-          "type": "Option < Arc < SpellAreaStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_aura_options_store",
-          "type": "Option < Arc < SpellAuraOptionsStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_aura_restrictions_store",
-          "type": "Option < Arc < SpellAuraRestrictionsStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_category_store",
-          "type": "Option < Arc < SpellCategoryStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_chain_store",
-          "type": "Option < Arc < SpellChainStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_custom_attribute_store",
-          "type": "Option < Arc < SpellCustomAttributeStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_duration_store",
-          "type": "Option < Arc < SpellDurationStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_enchant_proc_store",
-          "type": "Option < Arc < SpellEnchantProcStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [
-            "cfg (test)"
-          ],
-          "source_class": "test_fixture"
-        },
-        {
-          "name": "spell_equipped_items_store",
-          "type": "Option < Arc < SpellEquippedItemsStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_group_stack_rule_store",
-          "type": "Option < Arc < SpellGroupStackRuleStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_group_store",
-          "type": "Option < Arc < SpellGroupStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_item_enchantment_condition_store",
-          "type": "Option < Arc < SpellItemEnchantmentConditionStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_item_enchantment_store",
-          "type": "Option < Arc < SpellItemEnchantmentStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_learn_skill_store",
-          "type": "Option < Arc < SpellLearnSkillStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_learn_spell_store",
-          "type": "Option < Arc < SpellLearnSpellStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_levels_store",
-          "type": "Option < Arc < SpellLevelsStore > >",
-          "visibility": "private",
+          "name": "spell_catalogs",
+          "type": "crate :: spell_catalogs :: SpellCatalogsLikeCpp",
+          "visibility": "pub (crate)",
           "cfg": [],
           "source_class": "production"
         },
         {
           "name": "spell_linked_rejected_trigger_spell_ids_like_cpp",
           "type": "Option < Arc < BTreeSet < u32 > > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_linked_store",
-          "type": "Option < Arc < SpellLinkedStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_misc_store",
-          "type": "Option < Arc < SpellMiscStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_pet_aura_store",
-          "type": "Option < Arc < SpellPetAuraStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_proc_store",
-          "type": "Option < Arc < SpellProcStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_radius_store",
-          "type": "Option < Arc < SpellRadiusStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_range_store",
-          "type": "Option < Arc < SpellRangeStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_required_store",
-          "type": "Option < Arc < SpellRequiredStoreLikeCpp > >",
           "visibility": "private",
           "cfg": [],
           "source_class": "production"
@@ -5477,50 +5264,6 @@
           "visibility": "private",
           "cfg": [],
           "source_class": "production"
-        },
-        {
-          "name": "spell_shapeshift_form_store",
-          "type": "Option < Arc < SpellShapeshiftFormStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_store",
-          "type": "Option < Arc < SpellStore > >",
-          "visibility": "pub",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_target_position_store",
-          "type": "Option < Arc < SpellTargetPositionStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_target_restrictions_store",
-          "type": "Option < Arc < SpellTargetRestrictionsStore > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_threat_store",
-          "type": "Option < Arc < SpellThreatStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "spell_totem_model_store",
-          "type": "Option < Arc < SpellTotemModelStoreLikeCpp > >",
-          "visibility": "private",
-          "cfg": [
-            "cfg (test)"
-          ],
-          "source_class": "test_fixture"
         },
         {
           "name": "start_all_explored_like_cpp",
@@ -32805,19 +32548,6 @@
           "module": "crate::session",
           "trait_path": null,
           "kind": "method",
-          "name": "npc_spell_click_store",
-          "visibility": "pub (crate)",
-          "signature": "fn npc_spell_click_store (& self) -> Option < & Arc < NpcSpellClickStoreLikeCpp > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
           "name": "num_talents_at_level_store",
           "visibility": "pub (crate)",
           "signature": "fn num_talents_at_level_store (& self) -> Option < & Arc < NumTalentsAtLevelStore > >",
@@ -53237,19 +52967,6 @@
           "module": "crate::session",
           "trait_path": null,
           "kind": "method",
-          "name": "spell_acquisition_catalog",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_acquisition_catalog (& self) -> Option < & Arc < SpellAcquisitionCatalogLikeCpp > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
           "name": "spell_area_for_area_map_bounds_like_cpp",
           "visibility": "pub (crate)",
           "signature": "fn spell_area_for_area_map_bounds_like_cpp (& self , area_id : u32 ,) -> Vec < & SpellAreaLikeCpp >",
@@ -53305,58 +53022,6 @@
           "name": "spell_area_map_bounds_like_cpp",
           "visibility": "pub (crate)",
           "signature": "fn spell_area_map_bounds_like_cpp (& self , spell_id : u32) -> Vec < & SpellAreaLikeCpp >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
-          "name": "spell_aura_restrictions_store",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_aura_restrictions_store (& self) -> Option < & Arc < SpellAuraRestrictionsStore > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
-          "name": "spell_category_store",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_category_store (& self) -> Option < & Arc < SpellCategoryStore > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
-          "name": "spell_chain_store",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_chain_store (& self) -> Option < & Arc < SpellChainStoreLikeCpp > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
-          "name": "spell_custom_attribute_store_like_cpp",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_custom_attribute_store_like_cpp (& self ,) -> Option < & Arc < SpellCustomAttributeStoreLikeCpp > >",
           "cfg": [],
           "source_class": "production",
           "guards": [
@@ -53512,19 +53177,6 @@
           "module": "crate::session",
           "trait_path": null,
           "kind": "method",
-          "name": "spell_learn_skill_store_like_cpp",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_learn_skill_store_like_cpp (& self ,) -> Option < & Arc < SpellLearnSkillStoreLikeCpp > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
           "name": "spell_learn_spell_map_bounds_like_cpp",
           "visibility": "pub (crate)",
           "signature": "fn spell_learn_spell_map_bounds_like_cpp (& self , spell_id : u32 ,) -> & [SpellLearnSpellNodeLikeCpp]",
@@ -53538,61 +53190,9 @@
           "module": "crate::session",
           "trait_path": null,
           "kind": "method",
-          "name": "spell_learn_spell_store_like_cpp",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_learn_spell_store_like_cpp (& self ,) -> Option < & Arc < SpellLearnSpellStoreLikeCpp > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
-          "name": "spell_levels_store",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_levels_store (& self) -> Option < & Arc < SpellLevelsStore > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
           "name": "spell_linked_like_cpp",
           "visibility": "pub (crate)",
           "signature": "fn spell_linked_like_cpp (& self , link_type : SpellLinkedTypeLikeCpp , spell_id : u32 ,) -> & [i32]",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
-          "name": "spell_linked_store_like_cpp",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_linked_store_like_cpp (& self) -> Option < & SpellLinkedStoreLikeCpp >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
-          "name": "spell_misc_store",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_misc_store (& self) -> Option < & Arc < SpellMiscStore > >",
           "cfg": [],
           "source_class": "production",
           "guards": [
@@ -53640,61 +53240,9 @@
           "module": "crate::session",
           "trait_path": null,
           "kind": "method",
-          "name": "spell_proc_store",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_proc_store (& self) -> Option < & Arc < SpellProcStoreLikeCpp > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
-          "name": "spell_range_store",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_range_store (& self) -> Option < & Arc < SpellRangeStore > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
-          "name": "spell_required_store_like_cpp",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_required_store_like_cpp (& self) -> Option < & Arc < SpellRequiredStoreLikeCpp > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
           "name": "spell_school_mask_for_difficulty_like_cpp",
           "visibility": "pub (in crate :: session)",
           "signature": "fn spell_school_mask_for_difficulty_like_cpp (& self , spell_id : u32 , difficulty : u8 ,) -> u32",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
-          "name": "spell_shapeshift_form_store",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_shapeshift_form_store (& self) -> Option < & Arc < SpellShapeshiftFormStore > >",
           "cfg": [],
           "source_class": "production",
           "guards": [
@@ -53721,19 +53269,6 @@
           "name": "spell_store",
           "visibility": "pub",
           "signature": "fn spell_store (& self) -> Option < & Arc < SpellStore > >",
-          "cfg": [],
-          "source_class": "production",
-          "guards": [
-            "visible"
-          ]
-        },
-        {
-          "module": "crate::session",
-          "trait_path": null,
-          "kind": "method",
-          "name": "spell_target_restrictions_store",
-          "visibility": "pub (crate)",
-          "signature": "fn spell_target_restrictions_store (& self ,) -> Option < & Arc < SpellTargetRestrictionsStore > >",
           "cfg": [],
           "source_class": "production",
           "guards": [
@@ -75182,7 +74717,7 @@
               "multiplicity": 1
             }
           ],
-          "fingerprint": "signature=struct::WorldSession|surface=fnv1a64x2:3d1b500c3d1d8e580537b29e59e42e43:len=96483|evidence=fnv1a64x2:2e6cfac122e1f70b6b6193924d25bd6c:len=187",
+          "fingerprint": "signature=struct::WorldSession|surface=fnv1a64x2:7cfdb90c2f2f5558f8ddd4ead7731f7b:len=93901|evidence=fnv1a64x2:2e6cfac122e1f70b6b6193924d25bd6c:len=187",
           "cfg": [],
           "multiplicity": 1
         },


### PR DESCRIPTION
First semantic vertical of #584's C0-C4 work, after #666 recorded that relocation is exhausted and only a responsibility *leaving* an owner can reduce a curated hotspot.

`WorldSession` declared 716 fields, and 36 were the spell and aura catalog slots a session reads rules from - `spell_store`, `spell_chain_store`, `spell_aura_options_store`, `spell_proc_store`, `pet_levelup_spell_store` and the rest. They are one responsibility, and they now have one owner: `crates/wow-world/src/spell_catalogs.rs`. The session holds exactly one field of it, so no store slot is mirrored, and the 16 crate-internal accessors moved with the state. The 21 public setters and readers stay on the session as thin delegations, because world-server fills them at startup and the field is crate-private.

## Verified results

| Metric | Before | After |
| --- | --- | --- |
| `WorldSession` fields | 716 | 681 |
| production fields | 283 | 254 |
| test-fixture fields | 433 | 427 |
| associated items | 3,761 | 3,745 |
| session hotspot production lines | 84,233 | 84,190 |
| session hotspot total lines | 192,877 | 192,834 |

No item was added. The hotspot ledger baseline is tightened to the reduced figures - this is the ratchet's hotspot-reduction case, not an exception. The ledger's responsibility families keep exact field membership: the 36 names leave `immutable_catalogs_configuration_and_services` and `test_only_fixtures`, `spell_catalogs` joins the former, and that family now records where the slots went.

## Two findings the next vertical needs

**A delegation layer can cost more than the extraction saves.** Keeping all 37 accessors on the session as wrappers made the aggregate *grow* by 13 lines. Dropping the 16 crate-internal wrappers and routing their 25 call sites through the owner is what turned the change into a reduction. An extraction only reduces an owner if the façade goes with it.

**The catalog rules are not catalog-only.** 28 methods looked extractable because they touch no player state, but each composes other session helpers, so moving them would pull a helper chain along. They stayed. The rules are session behaviour that reads catalogs; only the state and its accessors were separable here.

## Evidence

- 3,822 `wow-world` lib tests pass unchanged.
- Workspace build clean; architecture check, self-test, physical ratchet, hotspot ratchet and `session-ownership-check check --syntax-only` pass, the last reporting 254 + 427 fields and 3,745 items.
- `./tools/validation-v2 final --base origin/3.4.3` passed at 36f3b375 (clean tree, aarch64 host).

No spell rule, catalog content, startup order or publication changes, and no new crate edge. `set_spell_store`'s invalidation of the canonical player's spell-hit aura authority stays with the session, because that side effect is session state. This closes neither #133 nor #584.

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)
