### PR TITLE
Keep the GPL text recognizable and preserve project notices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ and live server changes retain their separate authorization gates.
 ## License
 
 RustyCore uses **GPL-3.0-or-later**, as declared in [Cargo.toml](Cargo.toml).
-Read the project notice and full terms in [LICENSE](LICENSE). Contributions must be
+Read the [project notice](NOTICE) and [full license terms](LICENSE). Contributions must be
 compatible with those terms. Preserve upstream authorship, license notices and provenance
 when adapting code or data.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,36 +1,6 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
-RustyCore — WoW WotLK 3.4.3 Server in Rust
-Copyright (C) 2026 alseif0x
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
----
-
-WoW protocol research based on:
-- TrinityCore (https://github.com/TrinityCore/TrinityCore) — GPL v2
-- MaNGOS (https://github.com/mangos/MaNGOS) — GPL v2
-
-World of Warcraft and related trademarks are property of Blizzard Entertainment.
-This project is not affiliated with or endorsed by Blizzard Entertainment.
-
-Full GPL v3 license text (https://www.gnu.org/licenses/gpl-3.0.html):
-
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
-
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,30 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+RustyCore — WoW WotLK 3.4.3 Server in Rust
+Copyright (C) 2026 alseif0x
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+WoW protocol research based on:
+- TrinityCore (https://github.com/TrinityCore/TrinityCore) — GPL v2
+- MaNGOS (https://github.com/mangos/MaNGOS) — GPL v2
+
+World of Warcraft and related trademarks are property of Blizzard Entertainment.
+This project is not affiliated with or endorsed by Blizzard Entertainment.
+
+The complete GNU GPL version 3 text is provided in LICENSE.
+The project license grant above and Cargo.toml specify GPL-3.0-or-later.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ support the time needed to keep the project moving.
 ## License
 
 RustyCore is licensed under **GPL-3.0-or-later** (GNU GPL version 3 or any later version).
-See [LICENSE](LICENSE) for the project notice and complete license text.
+See [LICENSE](LICENSE) for the complete license text and [NOTICE](NOTICE) for the
+project's license grant and attribution notices.
 
 WoW protocol research and server behavior are based on the public work of the TrinityCore
 and MaNGOS communities.


### PR DESCRIPTION
GitHub classified the published LICENSE as Other/NOASSERTION because project-specific notices preceded the standard license text. Keep LICENSE byte-for-byte identical to the official GNU GPLv3 text and move the existing project grant and attributions to NOTICE. README and CONTRIBUTING link to both documents.

The existing GPL-3.0-or-later grant and Cargo metadata remain unchanged. This is a publication verification fix for #671, within the authorized license-presentation update.

Validation at a96d5e0a: `cmp LICENSE /tmp/rustycore-gpl-3.0.txt`, `git diff --check`, and `VALIDATION_V2_CARGO_JOBS=1 ./tools/validation-v2 final --base origin/3.4.3` passed. Final manifest: `20260909T225928.686886Z-2-final.json`. Wiki sources are unchanged from the successful #671 build/deployment.
