### PR TITLE
Give the quest catalog set its own owner (#674)

### DIFF
--- a/crates/wow-world/src/handlers/loot/generation.rs
+++ b/crates/wow-world/src/handlers/loot/generation.rs
@@ -224,7 +224,7 @@ impl WorldSession {
     }
 
     pub(super) fn has_incomplete_quest_item_drop_for_item_like_cpp(&self, item_id: u32) -> bool {
-        let Some(quest_store) = &self.quest_store else {
+        let Some(quest_store) = &self.quests.store else {
             return false;
         };
 
@@ -275,7 +275,7 @@ impl WorldSession {
         item_id: u32,
         player_context: &RepresentedLootPlayerContext,
     ) -> bool {
-        let Some(quest_store) = &self.quest_store else {
+        let Some(quest_store) = &self.quests.store else {
             return false;
         };
 

--- a/crates/wow-world/src/handlers/loot/requests.rs
+++ b/crates/wow-world/src/handlers/loot/requests.rs
@@ -693,7 +693,7 @@ impl WorldSession {
     }
 
     fn has_incomplete_quest_objective_for_object_id_like_cpp(&self, item_object_id: i32) -> bool {
-        let Some(quest_store) = &self.quest_store else {
+        let Some(quest_store) = &self.quests.store else {
             return false;
         };
 
@@ -765,7 +765,7 @@ impl WorldSession {
         item_object_id: i32,
         player_context: &RepresentedLootPlayerContext,
     ) -> bool {
-        let Some(quest_store) = &self.quest_store else {
+        let Some(quest_store) = &self.quests.store else {
             return false;
         };
 
@@ -812,7 +812,7 @@ impl WorldSession {
         &self,
         objective_id: u32,
     ) -> Option<i32> {
-        let quest_store = self.quest_store.as_ref()?;
+        let quest_store = self.quests.store.as_ref()?;
 
         for status in self
             .player_quest_gameplay_snapshot_like_cpp()?
@@ -848,7 +848,7 @@ impl WorldSession {
         objective_id: u32,
         player_context: &RepresentedLootPlayerContext,
     ) -> Option<i32> {
-        let quest_store = self.quest_store.as_ref()?;
+        let quest_store = self.quests.store.as_ref()?;
 
         for (quest_id, objective_counts) in &player_context.active_quest_objective_counts {
             let Some(quest) = quest_store.get(*quest_id) else {

--- a/crates/wow-world/src/handlers/loot/sources.rs
+++ b/crates/wow-world/src/handlers/loot/sources.rs
@@ -801,8 +801,8 @@ impl WorldSession {
             return 0;
         }
 
-        self.quest_xp_store
-            .as_ref()
+        let xp_store = self.quests.xp_store.as_ref();
+        xp_store
             .map(|store| {
                 store.player_level_difficulty_xp_like_cpp(
                     self.player_level_like_cpp(),

--- a/crates/wow-world/src/handlers/misc/lfg.rs
+++ b/crates/wow-world/src/handlers/misc/lfg.rs
@@ -323,7 +323,7 @@ impl crate::session::WorldSession {
         dungeon_info: &mut LfgPlayerDungeonInfo,
         reward: &wow_data::LfgDungeonRewardLikeCpp,
     ) {
-        let Some(quest_store) = self.quest_store.as_ref() else {
+        let Some(quest_store) = self.quests.store.as_ref() else {
             return;
         };
         let Some(mut quest) = quest_store.get(reward.first_quest_id) else {

--- a/crates/wow-world/src/handlers/quest/eligibility.rs
+++ b/crates/wow-world/src/handlers/quest/eligibility.rs
@@ -45,7 +45,7 @@ impl WorldSession {
         source: RepresentedQuestGiverStatusSourceLikeCpp,
     ) -> u64 {
         self.get_represented_quest_giver_status_with_catalog_like_cpp(
-            self.quest_info_store.as_deref(),
+            self.quests.info_store.as_deref(),
             source,
         )
     }
@@ -55,7 +55,7 @@ impl WorldSession {
         quest_info: Option<&wow_data::progression_rewards::QuestInfoStore>,
         source: RepresentedQuestGiverStatusSourceLikeCpp,
     ) -> u64 {
-        let Some(store) = &self.quest_store else {
+        let Some(store) = &self.quests.store else {
             return quest_giver_status::NONE;
         };
 
@@ -170,9 +170,8 @@ impl WorldSession {
                 },
             )
             .collect();
-        let quest_objective_progress: Vec<_> = self
-            .quest_store
-            .as_ref()
+        let store = self.quests.store.as_ref();
+        let quest_objective_progress: Vec<_> = store
             .map(|store| {
                 recurrence
                     .statuses
@@ -351,7 +350,7 @@ impl WorldSession {
             return true;
         }
 
-        let Some(quest_store) = &self.quest_store else {
+        let Some(quest_store) = &self.quests.store else {
             return true;
         };
         let Some(recurrence) = self.player_quest_gameplay_snapshot_like_cpp() else {
@@ -434,7 +433,7 @@ impl WorldSession {
     ) -> bool {
         Self::represented_quest_dialog_classification_like_cpp(
             quest,
-            self.quest_info_store.as_deref(),
+            self.quests.info_store.as_deref(),
         )
         .is_important()
     }
@@ -642,7 +641,7 @@ impl WorldSession {
         // Blocks acceptance if the scalar dependent-previous list is not satisfied.
         // Per C++ SatisfyQuestDependentQuests (Player.cpp:15088-15092), this cluster runs
         // after SatisfyQuestReputation, not before Race/Class/Level.
-        if let Some(quest_store) = &self.quest_store {
+        if let Some(quest_store) = &self.quests.store {
             if represented_satisfy_quest_dependent_previous_quests_failed_like_cpp(
                 quest_store,
                 quest,

--- a/crates/wow-world/src/handlers/quest/handlers.rs
+++ b/crates/wow-world/src/handlers/quest/handlers.rs
@@ -284,7 +284,7 @@ impl WorldSession {
             return;
         };
 
-        let Some(quest_store) = self.quest_store.clone() else {
+        let Some(quest_store) = self.quests.store.clone() else {
             return;
         };
         let Some(quest) = quest_store.get(quest_id) else {
@@ -495,7 +495,7 @@ impl WorldSession {
         // Validate represented C++ source/relation before any quest-log mutation or DB save.
         // C++ HandleQuestgiverAcceptQuestOpcode closes gossip and clears sharing info on
         // failure; this represented slice intentionally models that as no packet/no mutation.
-        let quest_store = match &self.quest_store {
+        let quest_store = match &self.quests.store {
             Some(s) => Arc::clone(s),
             None => return,
         };
@@ -681,7 +681,7 @@ impl WorldSession {
 
         self.clear_represented_pending_quest_sharing_like_cpp();
 
-        let Some(quest_store) = &self.quest_store else {
+        let Some(quest_store) = &self.quests.store else {
             debug!(
                 account = self.account_id,
                 parsed_quest_id,
@@ -1060,7 +1060,7 @@ impl WorldSession {
             }
         };
 
-        let Some(quest_store) = self.quest_store.as_ref().map(Arc::clone) else {
+        let Some(quest_store) = self.quests.store.as_ref().map(Arc::clone) else {
             debug!(
                 account = self.account_id,
                 quest_id = packet.quest_id,
@@ -1098,7 +1098,7 @@ impl WorldSession {
             return;
         }
 
-        let Some(quest_pool_store) = self.quest_pool_store.as_ref().map(Arc::clone) else {
+        let Some(quest_pool_store) = self.quests.pool_store.as_ref().map(Arc::clone) else {
             self.record_represented_push_quest_to_party_outcome_like_cpp(
                 RepresentedPushQuestToPartyOutcomeLikeCpp {
                     sender_guid,
@@ -2111,7 +2111,7 @@ impl WorldSession {
         let quest_id: u32 = pkt.read_uint32().unwrap_or(0);
         let _guid = pkt.read_packed_guid(); // requester GUID (usually player)
 
-        let quest_store = match &self.quest_store {
+        let quest_store = match &self.quests.store {
             Some(s) => Arc::clone(s),
             None => {
                 self.send_packet(&QueryQuestInfoResponse {
@@ -2189,12 +2189,10 @@ impl WorldSession {
     /// - `WorldSession::HandleQueryQuestCompletionNPCs`, QueryHandler.cpp:252-278.
     /// - `QuestCompletionNPCResponse::Write`, QueryPackets.cpp:451-462.
     pub async fn handle_query_quest_completion_npcs(&mut self, query: QueryQuestCompletionNpcs) {
-        let quests = self
-            .quest_store
-            .as_deref()
-            .map_or_else(Vec::new, |quest_store| {
-                represented_quest_completion_npc_response_like_cpp(quest_store, &query.quest_ids)
-            });
+        let store = self.quests.store.as_deref();
+        let quests = store.map_or_else(Vec::new, |quest_store| {
+            represented_quest_completion_npc_response_like_cpp(quest_store, &query.quest_ids)
+        });
 
         self.send_packet(&QuestCompletionNpcResponse { quests });
     }
@@ -2274,7 +2272,7 @@ impl WorldSession {
             "Received QuestGiverRequestReward like C++"
         );
 
-        let quest_store = match &self.quest_store {
+        let quest_store = match &self.quests.store {
             Some(s) => Arc::clone(s),
             None => return,
         };
@@ -2410,7 +2408,7 @@ impl WorldSession {
             "Received QuestGiverCompleteQuest like C++"
         );
 
-        let quest_store = match &self.quest_store {
+        let quest_store = match &self.quests.store {
             Some(s) => Arc::clone(s),
             None => return,
         };
@@ -2579,7 +2577,7 @@ impl WorldSession {
             "Received QuestGiverChooseReward like C++"
         );
 
-        let quest_store = match &self.quest_store {
+        let quest_store = match &self.quests.store {
             Some(s) => Arc::clone(s),
             None => return,
         };

--- a/crates/wow-world/src/handlers/quest/objectives.rs
+++ b/crates/wow-world/src/handlers/quest/objectives.rs
@@ -333,7 +333,7 @@ impl WorldSession {
     ) -> Vec<u32> {
         use wow_packet::packets::quest::QuestUpdateComplete;
 
-        let Some(quest_store) = self.quest_store.clone() else {
+        let Some(quest_store) = self.quests.store.clone() else {
             return Vec::new();
         };
         let added_count = count;
@@ -751,7 +751,7 @@ impl WorldSession {
     /// move completed quests back to incomplete when the requirement is lost.
     pub(crate) fn apply_quest_item_removed_like_cpp(&mut self, entry_id: u32) -> Option<Vec<u32>> {
         self.invalidate_player_quest_status_authority_like_cpp();
-        let Some(quest_store) = self.quest_store.clone() else {
+        let Some(quest_store) = self.quests.store.clone() else {
             return Some(Vec::new());
         };
         let new_non_bank_item_count = self.represented_non_bank_item_count_like_cpp(entry_id)?;
@@ -790,7 +790,7 @@ impl WorldSession {
         count: u32,
     ) -> Vec<u32> {
         self.invalidate_player_quest_status_authority_like_cpp();
-        let Some(quest_store) = self.quest_store.clone() else {
+        let Some(quest_store) = self.quests.store.clone() else {
             return Vec::new();
         };
         self.mutate_player_quest_gameplay_like_cpp(|state| {
@@ -821,7 +821,7 @@ impl WorldSession {
         count: u32,
     ) -> Vec<u32> {
         self.invalidate_player_quest_status_authority_like_cpp();
-        let Some(quest_store) = self.quest_store.clone() else {
+        let Some(quest_store) = self.quests.store.clone() else {
             return Vec::new();
         };
         let Some(Some((quest_id, new_count))) =
@@ -1024,7 +1024,7 @@ impl WorldSession {
         let Some(_player_guid) = self.player_guid() else {
             return None;
         };
-        let Some(quest_store) = self.quest_store.clone() else {
+        let Some(quest_store) = self.quests.store.clone() else {
             return None;
         };
         let count_i32 = i32::try_from(count).unwrap_or(i32::MAX);

--- a/crates/wow-world/src/handlers/quest/persistence.rs
+++ b/crates/wow-world/src/handlers/quest/persistence.rs
@@ -65,10 +65,9 @@ impl WorldSession {
             .statuses
             .iter()
             .filter_map(|(quest_id, status)| {
+                let store = self.quests.store.as_ref();
                 if state.rewarded_quest_ids.contains(quest_id)
-                    && self
-                        .quest_store
-                        .as_ref()
+                    && store
                         .and_then(|store| store.get(*quest_id))
                         .is_some_and(|quest| !quest.is_repeatable())
                 {
@@ -92,7 +91,7 @@ impl WorldSession {
         post_move_non_bank_count: u32,
         added_count: u32,
     ) -> Vec<PlayerQuestStatus> {
-        let Some(quest_store) = self.quest_store.as_ref() else {
+        let Some(quest_store) = self.quests.store.as_ref() else {
             return Vec::new();
         };
         let Ok(entry_object_id) = i32::try_from(entry_id) else {
@@ -272,7 +271,7 @@ impl WorldSession {
                 .unwrap_or_default(),
             changed_quest_ids: Vec::new(),
         };
-        let Some(quest_store) = self.quest_store.as_ref() else {
+        let Some(quest_store) = self.quests.store.as_ref() else {
             return plan;
         };
         let post_removal_counts = post_removal_non_bank_counts
@@ -301,7 +300,7 @@ impl WorldSession {
         quest_log_item_id: u32,
         count: u32,
     ) -> bool {
-        let Some(quest_store) = self.quest_store.as_ref() else {
+        let Some(quest_store) = self.quests.store.as_ref() else {
             return false;
         };
         let Some(state) = self.player_quest_gameplay_snapshot_like_cpp() else {
@@ -350,9 +349,8 @@ impl WorldSession {
         statuses
             .iter()
             .map(|status| {
-                let objectives = self
-                    .quest_store
-                    .as_ref()
+                let store = self.quests.store.as_ref();
+                let objectives = store
                     .and_then(|store| store.get(status.quest_id))
                     .into_iter()
                     .flat_map(|quest| quest.objectives.iter())
@@ -418,7 +416,7 @@ impl WorldSession {
         quest_log_item_id: u32,
         count: u32,
     ) -> Option<QuestSourceItemBoundPersistencePlanLikeCpp> {
-        let quest_store = self.quest_store.as_ref()?;
+        let quest_store = self.quests.store.as_ref()?;
         let count_i32 = i32::try_from(count).unwrap_or(i32::MAX);
         let entry_object_id = i32::try_from(entry_id).unwrap_or(i32::MAX);
         let quest_log_object_id = i32::try_from(quest_log_item_id).unwrap_or(i32::MAX);
@@ -675,9 +673,8 @@ impl WorldSession {
                 // because the character DB status row has no persisted quest-log slot.
                 let slot = next_active_slot;
                 next_active_slot = next_active_slot.saturating_add(1);
-                let obj_count = self
-                    .quest_store
-                    .as_ref()
+                let store = self.quests.store.as_ref();
+                let obj_count = store
                     .and_then(|s| s.get(quest_id))
                     .map_or(0, |q| q.objectives.len());
                 if loaded_quests.statuses.contains_key(&quest_id) {
@@ -706,7 +703,8 @@ impl WorldSession {
                     let data = row.count.unwrap_or(0);
                     if let (Some(status), Some(quest)) = (
                         loaded_quests.statuses.get_mut(&quest_id),
-                        self.quest_store
+                        self.quests
+                            .store
                             .as_ref()
                             .and_then(|store| store.get(quest_id)),
                     ) {
@@ -803,11 +801,8 @@ impl WorldSession {
                 for row in daily_rows {
                     let quest_id = row.quest_id.unwrap_or(0);
                     let completed_time = row.completed_time.unwrap_or(0);
-                    if let Some(quest) = self
-                        .quest_store
-                        .as_ref()
-                        .and_then(|store| store.get(quest_id))
-                    {
+                    let store = self.quests.store.as_ref();
+                    if let Some(quest) = store.and_then(|store| store.get(quest_id)) {
                         loaded_last_daily_time = completed_time;
                         if quest.is_df_quest_like_cpp() {
                             loaded_df.insert(quest_id);
@@ -837,7 +832,8 @@ impl WorldSession {
                 for row in weekly_rows {
                     let quest_id = row.quest_id.unwrap_or(0);
                     if self
-                        .quest_store
+                        .quests
+                        .store
                         .as_ref()
                         .and_then(|store| store.get(quest_id))
                         .is_some()
@@ -864,7 +860,8 @@ impl WorldSession {
                 for row in monthly_rows {
                     let quest_id = row.quest_id.unwrap_or(0);
                     if self
-                        .quest_store
+                        .quests
+                        .store
                         .as_ref()
                         .and_then(|store| store.get(quest_id))
                         .is_some()
@@ -927,8 +924,8 @@ impl WorldSession {
             }
         };
 
-        let quest_store = self.quest_store.as_ref().map(Arc::clone);
-        let quest_v2_store = self.quest_v2_store.as_ref().map(Arc::clone);
+        let quest_store = self.quests.store.as_ref().map(Arc::clone);
+        let quest_v2_store = self.quests.v2_store.as_ref().map(Arc::clone);
         let seasonal_outcome = self.load_seasonal_quest_status_like_cpp(
             seasonal_rows,
             quest_store.as_deref(),

--- a/crates/wow-world/src/handlers/quest/rewards.rs
+++ b/crates/wow-world/src/handlers/quest/rewards.rs
@@ -873,7 +873,7 @@ impl WorldSession {
             return true;
         }
 
-        let Some(store) = &self.quest_package_item_store else {
+        let Some(store) = &self.quests.package_item_store else {
             return true;
         };
         let Ok(choice_item_id) = i32::try_from(choice.item_id) else {
@@ -1413,7 +1413,7 @@ impl WorldSession {
             }
         };
         let faction_store = self.faction_store().map(Arc::clone);
-        let quest_faction_reward_store = self.quest_faction_reward_store.as_ref().map(Arc::clone);
+        let quest_faction_reward_store = self.quests.faction_reward_store.as_ref().map(Arc::clone);
         let reputation_reward_rate_store = self.reputation_reward_rate_store().map(Arc::clone);
         let reputation_spillover_template_store =
             self.reputation_spillover_template_store().map(Arc::clone);
@@ -1854,7 +1854,7 @@ impl WorldSession {
             return false;
         }
 
-        let Some(store) = &self.quest_package_item_store else {
+        let Some(store) = &self.quests.package_item_store else {
             return false;
         };
         let Ok(choice_item_id) = i32::try_from(choice.item_id) else {
@@ -1954,7 +1954,7 @@ impl WorldSession {
             return true;
         }
 
-        let Some(store) = &self.quest_package_item_store else {
+        let Some(store) = &self.quests.package_item_store else {
             return true;
         };
         let Ok(choice_item_id) = i32::try_from(choice.item_id) else {

--- a/crates/wow-world/src/handlers/quest/state.rs
+++ b/crates/wow-world/src/handlers/quest/state.rs
@@ -171,10 +171,9 @@ impl WorldSession {
             .statuses
             .keys()
             .filter(|quest_id| {
+                let store = self.quests.store.as_ref();
                 state.rewarded_quest_ids.contains(quest_id)
-                    && self
-                        .quest_store
-                        .as_ref()
+                    && store
                         .and_then(|store| store.get(**quest_id))
                         .is_some_and(|quest| !quest.is_repeatable())
             })
@@ -222,7 +221,7 @@ impl WorldSession {
             return false;
         }
 
-        let Some(quest_store) = &self.quest_store else {
+        let Some(quest_store) = &self.quests.store else {
             debug!(
                 account = self.account_id,
                 quest_id, "QuestGiverCloseQuest: missing represented quest store"
@@ -385,10 +384,8 @@ impl WorldSession {
                     return (0, 0, 0, [0; 24]);
                 };
 
-                let quest = self
-                    .quest_store
-                    .as_ref()
-                    .and_then(|store| store.get(qs.quest_id));
+                let store = self.quests.store.as_ref();
+                let quest = store.and_then(|store| store.get(qs.quest_id));
                 let mut state_flags: u32 = match qs.status {
                     QUEST_STATUS_COMPLETE_LIKE_CPP => QUEST_STATE_COMPLETE_LIKE_CPP,
                     QUEST_STATUS_FAILED_LIKE_CPP => QUEST_STATE_FAIL_LIKE_CPP,

--- a/crates/wow-world/src/handlers/quest_tests/quest_7.rs
+++ b/crates/wow-world/src/handlers/quest_tests/quest_7.rs
@@ -237,7 +237,7 @@ fn save_to_db_quest_status_list_skips_rewarded_non_repeatable_active_duplicate_l
         quest_template(active_rewarded_quest_id),
         quest_template(active_quest_id),
     ]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
     add_active_quest_in_slot_with_status(
         &mut session,
         active_rewarded_quest_id,
@@ -267,7 +267,7 @@ fn quest_load_removes_active_rewarded_duplicate_and_compacts_slots_like_cpp() {
         quest_template(duplicate_quest_id),
         quest_template(active_quest_id),
     ]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
     add_active_quest_in_slot_with_status(
         &mut session,
         duplicate_quest_id,

--- a/crates/wow-world/src/handlers/spell/ops_2.rs
+++ b/crates/wow-world/src/handlers/spell/ops_2.rs
@@ -168,7 +168,7 @@ impl WorldSession {
         &self,
         item_object_id: i32,
     ) -> bool {
-        let Some(quest_store) = &self.quest_store else {
+        let Some(quest_store) = &self.quests.store else {
             return false;
         };
         let Some(quests) = self.player_quest_gameplay_snapshot_like_cpp() else {
@@ -209,7 +209,7 @@ impl WorldSession {
         &self,
         item_id: u32,
     ) -> bool {
-        let Some(quest_store) = &self.quest_store else {
+        let Some(quest_store) = &self.quests.store else {
             return false;
         };
         let Some(quests) = self.player_quest_gameplay_snapshot_like_cpp() else {
@@ -359,7 +359,7 @@ impl WorldSession {
         &self,
         objective_id: u32,
     ) -> Option<i32> {
-        let quest_store = self.quest_store.as_ref()?;
+        let quest_store = self.quests.store.as_ref()?;
         let quests = self.player_quest_gameplay_snapshot_like_cpp()?;
 
         for status in quests.statuses.values() {

--- a/crates/wow-world/src/lib.rs
+++ b/crates/wow-world/src/lib.rs
@@ -55,6 +55,7 @@ mod player_inventory_persistence_test_fixture;
 mod player_lifecycle_contract;
 #[cfg(test)]
 mod player_quest_persistence_test_fixture;
+mod quest_catalogs;
 mod spell_catalogs;
 #[cfg(test)]
 mod teleport_test_fixtures;

--- a/crates/wow-world/src/player_quest_persistence_projection.rs
+++ b/crates/wow-world/src/player_quest_persistence_projection.rs
@@ -13,7 +13,8 @@ impl WorldSession {
         status: &PlayerQuestStatus,
     ) -> wow_persistence::QuestStatusPersistenceLikeCpp {
         let objectives = self
-            .quest_store
+            .quests
+            .store
             .as_ref()
             .and_then(|store| store.get(status.quest_id))
             .map(|quest| {

--- a/crates/wow-world/src/quest_catalogs.rs
+++ b/crates/wow-world/src/quest_catalogs.rs
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 alseif0x
+// RustyCore — WoW WotLK 3.4.3 server in Rust
+// Based on TrinityCore protocol research (https://github.com/TrinityCore/TrinityCore)
+// Licensed under GPL v3 — https://www.gnu.org/licenses/gpl-3.0.html
+
+//! Quest template and quest-rule catalogs a session reads.
+//!
+//! Separated from `WorldSession` under #674: the session holds exactly one field
+//! of this type, so no slot is mirrored. The owner depends on `wow-data` stores
+//! only and performs no async work.
+
+use std::sync::Arc;
+
+#[derive(Default)]
+pub(crate) struct QuestCatalogsLikeCpp {
+    pub(crate) faction_reward_store:
+        Option<Arc<wow_data::progression_rewards::QuestFactionRewardStore>>,
+    pub(crate) info_store: Option<Arc<wow_data::progression_rewards::QuestInfoStore>>,
+    pub(crate) money_reward_store:
+        Option<Arc<wow_data::progression_rewards::QuestMoneyRewardStore>>,
+    pub(crate) package_item_store:
+        Option<Arc<wow_data::progression_rewards::QuestPackageItemStore>>,
+    pub(crate) pool_store: Option<Arc<wow_data::quest::QuestPoolStoreLikeCpp>>,
+    pub(crate) store: Option<Arc<wow_data::quest::QuestStore>>,
+    pub(crate) v2_store: Option<Arc<wow_data::progression_rewards::QuestV2Store>>,
+    pub(crate) xp_store: Option<Arc<wow_data::quest_xp::QuestXpStore>>,
+}

--- a/crates/wow-world/src/session/chat/operations.rs
+++ b/crates/wow-world/src/session/chat/operations.rs
@@ -228,7 +228,7 @@ impl WorldSession {
         &self,
         creature_entry: u32,
     ) -> Vec<ClientGossipText> {
-        let Some(quest_store) = self.quest_store.as_ref() else {
+        let Some(quest_store) = self.quests.store.as_ref() else {
             return Vec::new();
         };
 

--- a/crates/wow-world/src/session/driver/mod.rs
+++ b/crates/wow-world/src/session/driver/mod.rs
@@ -354,7 +354,8 @@ impl WorldSession {
                 .clone()
                 .unwrap_or(empty_catalogs.adventure_map_pois),
             quest_info: self
-                .quest_info_store
+                .quests
+                .info_store
                 .clone()
                 .unwrap_or(empty_catalogs.quest_info),
             battlemaster_lists: self

--- a/crates/wow-world/src/session/mod.rs
+++ b/crates/wow-world/src/session/mod.rs
@@ -6733,14 +6733,8 @@ pub struct WorldSession {
     #[cfg(test)]
     represented_glyphs_loaded_like_cpp: bool,
 
-    pub(crate) quest_faction_reward_store: Option<Arc<QuestFactionRewardStore>>,
-    pub(crate) quest_info_store: Option<Arc<QuestInfoStore>>,
-    pub(crate) quest_money_reward_store: Option<Arc<QuestMoneyRewardStore>>,
-    pub(crate) quest_package_item_store: Option<Arc<QuestPackageItemStore>>,
-    pub(crate) quest_pool_store: Option<Arc<wow_data::quest::QuestPoolStoreLikeCpp>>,
-    pub(crate) quest_store: Option<Arc<wow_data::quest::QuestStore>>,
-    pub(crate) quest_v2_store: Option<Arc<QuestV2Store>>,
-    pub(crate) quest_xp_store: Option<Arc<wow_data::quest_xp::QuestXpStore>>,
+    /// Quest template and quest-rule catalogs, owned by one type (#674).
+    pub(crate) quests: crate::quest_catalogs::QuestCatalogsLikeCpp,
     /// C++ `ObjectMgr::_questPOIStore`, loaded from `quest_poi` / `quest_poi_points`.
     pub(crate) quest_poi_store_like_cpp:
         Option<Arc<HashMap<i32, wow_packet::packets::query::QuestPoiData>>>,
@@ -7777,20 +7771,13 @@ impl WorldSession {
         connection.set_instance_endpoint([127, 0, 0, 1], 8086);
 
         Self {
+            quests: crate::quest_catalogs::QuestCatalogsLikeCpp::default(),
             chr: crate::chr_catalogs::ChrCatalogsLikeCpp::default(),
             creatures: crate::creature_catalogs::CreatureCatalogsLikeCpp::default(),
             factions: crate::faction_catalogs::FactionCatalogsLikeCpp::default(),
             gameobjects: crate::gameobject_catalogs::GameObjectCatalogsLikeCpp::default(),
             items: crate::item_catalogs::ItemCatalogsLikeCpp::default(),
             maps: crate::map_catalogs::MapCatalogsLikeCpp::default(),
-            quest_faction_reward_store: None,
-            quest_info_store: None,
-            quest_money_reward_store: None,
-            quest_package_item_store: None,
-            quest_pool_store: None,
-            quest_store: None,
-            quest_v2_store: None,
-            quest_xp_store: None,
             spell_catalogs: crate::spell_catalogs::SpellCatalogsLikeCpp::default(),
             account_id,
             battlenet_account_id: account_id,
@@ -9853,7 +9840,7 @@ impl WorldSession {
     }
 
     fn represented_has_quest_for_gameobject_like_cpp(&self, gameobject_entry: u32) -> bool {
-        let Some(store) = self.quest_store.as_ref() else {
+        let Some(store) = self.quests.store.as_ref() else {
             return false;
         };
         let Some(quests) = self.player_quest_gameplay_snapshot_like_cpp() else {
@@ -15923,7 +15910,7 @@ impl WorldSession {
         creature_guid: ObjectGuid,
         creature_entry: u32,
     ) -> bool {
-        let Some(quest_store) = self.quest_store.as_ref().map(Arc::clone) else {
+        let Some(quest_store) = self.quests.store.as_ref().map(Arc::clone) else {
             return false;
         };
 
@@ -16002,7 +15989,7 @@ impl WorldSession {
                 gossip_id: source.gossip_id,
             });
 
-        let Some(quest_store) = self.quest_store.as_ref().map(Arc::clone) else {
+        let Some(quest_store) = self.quests.store.as_ref().map(Arc::clone) else {
             return true;
         };
 

--- a/crates/wow-world/src/session/player_items/appearance.rs
+++ b/crates/wow-world/src/session/player_items/appearance.rs
@@ -357,7 +357,8 @@ impl WorldSession {
         let player_class_mask =
             player_class_mask_for_transmog_like_cpp(self.player_class_like_cpp());
         let package_item_ids = self
-            .quest_package_item_store
+            .quests
+            .package_item_store
             .as_ref()
             .map(|store| {
                 store

--- a/crates/wow-world/src/session/player_items/catalog.rs
+++ b/crates/wow-world/src/session/player_items/catalog.rs
@@ -242,7 +242,7 @@ impl WorldSession {
     }
     /// Set the QuestPackageItem store used by C++ quest package reward selection.
     pub fn set_quest_package_item_store(&mut self, store: Arc<QuestPackageItemStore>) {
-        self.quest_package_item_store = Some(store);
+        self.quests.package_item_store = Some(store);
     }
     #[cfg(test)]
     pub(crate) fn set_loot_item_store_test_seam_like_cpp(

--- a/crates/wow-world/src/session/player_items/items.rs
+++ b/crates/wow-world/src/session/player_items/items.rs
@@ -50,7 +50,7 @@ impl WorldSession {
         &self,
         item_id: u32,
     ) -> bool {
-        let Some(quest_store) = self.quest_store.as_ref() else {
+        let Some(quest_store) = self.quests.store.as_ref() else {
             return false;
         };
         let Some(quests) = self.player_quest_gameplay_snapshot_like_cpp() else {

--- a/crates/wow-world/src/session/quest/giver.rs
+++ b/crates/wow-world/src/session/quest/giver.rs
@@ -221,7 +221,7 @@ impl WorldSession {
         let mut completed_bit_skipped_zero_unique_bit = 0;
         let mut completed_bit_no_change_or_noop = 0;
         for quest_id in &removed_quest_ids {
-            let Some(quest_v2_store) = self.quest_v2_store.as_ref().map(Arc::clone) else {
+            let Some(quest_v2_store) = self.quests.v2_store.as_ref().map(Arc::clone) else {
                 completed_bit_skipped_no_quest_v2_store += 1;
                 continue;
             };
@@ -377,7 +377,7 @@ impl WorldSession {
         source_guid: ObjectGuid,
         quest_id: u32,
     ) -> bool {
-        let Some(quest_store) = self.quest_store.as_ref().map(Arc::clone) else {
+        let Some(quest_store) = self.quests.store.as_ref().map(Arc::clone) else {
             debug!(
                 account = self.account_id,
                 ?source_guid,

--- a/crates/wow-world/src/session/quest/objectives.rs
+++ b/crates/wow-world/src/session/quest/objectives.rs
@@ -10,7 +10,7 @@ impl WorldSession {
         &self,
         object_id: i32,
     ) -> bool {
-        let Some(quest_store) = self.quest_store.as_ref() else {
+        let Some(quest_store) = self.quests.store.as_ref() else {
             return false;
         };
         let Some(quests) = self.player_quest_gameplay_snapshot_like_cpp() else {
@@ -49,7 +49,7 @@ impl WorldSession {
         &self,
         quest_id: u32,
     ) -> Option<bool> {
-        self.quest_store.as_ref()?.get(quest_id).map(|quest| {
+        self.quests.store.as_ref()?.get(quest_id).map(|quest| {
             !quest.is_df_quest_like_cpp()
                 && !quest.is_daily_like_cpp()
                 && (!quest.is_repeatable()
@@ -71,7 +71,7 @@ impl WorldSession {
             QuestUpdateAddCredit, QuestUpdateAddPvpCredit, QuestUpdateComplete,
         };
 
-        let Some(store) = self.quest_store.clone() else {
+        let Some(store) = self.quests.store.clone() else {
             return;
         };
 
@@ -222,7 +222,7 @@ impl WorldSession {
         self.invalidate_player_quest_status_authority_like_cpp();
         use wow_packet::packets::quest::{QuestUpdateAddCreditSimple, QuestUpdateComplete};
 
-        let Some(store) = self.quest_store.clone() else {
+        let Some(store) = self.quests.store.clone() else {
             return;
         };
 
@@ -336,7 +336,7 @@ impl WorldSession {
         self.invalidate_player_quest_status_authority_like_cpp();
         use wow_packet::packets::quest::QuestUpdateComplete;
 
-        let Some(store) = self.quest_store.clone() else {
+        let Some(store) = self.quests.store.clone() else {
             return;
         };
 
@@ -466,7 +466,7 @@ impl WorldSession {
         self.invalidate_player_quest_status_authority_like_cpp();
         use wow_packet::packets::quest::QuestUpdateComplete;
 
-        let Some(store) = self.quest_store.clone() else {
+        let Some(store) = self.quests.store.clone() else {
             return;
         };
 
@@ -603,7 +603,7 @@ impl WorldSession {
         self.invalidate_player_quest_status_authority_like_cpp();
         use wow_packet::packets::quest::QuestUpdateComplete;
 
-        let Some(store) = self.quest_store.clone() else {
+        let Some(store) = self.quests.store.clone() else {
             return;
         };
         let Some(faction_store) = self.factions.store.as_ref() else {

--- a/crates/wow-world/src/session/quest/reset.rs
+++ b/crates/wow-world/src/session/quest/reset.rs
@@ -8,7 +8,7 @@ use super::*;
 impl WorldSession {
     /// Set the represented QuestPoolMgr active snapshot shared reference.
     pub fn set_quest_pool_store(&mut self, store: Arc<wow_data::quest::QuestPoolStoreLikeCpp>) {
-        self.quest_pool_store = Some(store);
+        self.quests.pool_store = Some(store);
     }
     #[cfg(test)]
     pub(crate) fn seasonal_quest_bucket_like_cpp(

--- a/crates/wow-world/src/session/quest/rewards.rs
+++ b/crates/wow-world/src/session/quest/rewards.rs
@@ -162,7 +162,7 @@ impl WorldSession {
     }
     /// Set the QuestFactionReward store used by C++ quest reputation reward lookup.
     pub fn set_quest_faction_reward_store(&mut self, store: Arc<QuestFactionRewardStore>) {
-        self.quest_faction_reward_store = Some(store);
+        self.quests.faction_reward_store = Some(store);
     }
     /// Represented C++ `Player::LearnQuestRewardedSpells`.
     ///
@@ -173,7 +173,7 @@ impl WorldSession {
     /// learned-spell side effect; full `CastSpell` runtime semantics remain in
     /// the spell-system roadmap.
     pub(crate) fn apply_represented_quest_rewarded_spells_like_cpp(&mut self) -> usize {
-        let Some(quest_store) = self.quest_store.clone() else {
+        let Some(quest_store) = self.quests.store.clone() else {
             return 0;
         };
 
@@ -309,7 +309,7 @@ impl WorldSession {
     }
     /// Set the QuestMoneyReward store (loaded from QuestMoneyReward.db2).
     pub fn set_quest_money_reward_store(&mut self, store: Arc<QuestMoneyRewardStore>) {
-        self.quest_money_reward_store = Some(store);
+        self.quests.money_reward_store = Some(store);
     }
     pub(in crate::session) fn set_loaded_quest_completed_bit_like_cpp(
         &mut self,
@@ -384,7 +384,7 @@ impl WorldSession {
         &self,
         quest: &wow_data::quest::QuestTemplate,
     ) -> u32 {
-        let Some(store) = &self.quest_money_reward_store else {
+        let Some(store) = &self.quests.money_reward_store else {
             return 0;
         };
         let quest_level = self.player_quest_level_like_cpp(quest).max(0) as u32;

--- a/crates/wow-world/src/session/quest/state.rs
+++ b/crates/wow-world/src/session/quest/state.rs
@@ -135,7 +135,7 @@ impl WorldSession {
         if !state.status_authority_complete {
             return false;
         }
-        let Some(quests) = self.quest_store.as_ref() else {
+        let Some(quests) = self.quests.store.as_ref() else {
             return state.rewarded_quest_rows.is_empty() && state.statuses.is_empty();
         };
 
@@ -170,7 +170,7 @@ impl WorldSession {
         &self,
     ) -> bool {
         const QUEST_FLAGS_EX_AUTO_PUSH_LIKE_CPP: u32 = 0x0400_0000;
-        self.quest_store.as_ref().is_some_and(|quests| {
+        self.quests.store.as_ref().is_some_and(|quests| {
             quests
                 .quests_like_cpp()
                 .all(|quest| quest.flags_ex & QUEST_FLAGS_EX_AUTO_PUSH_LIKE_CPP == 0)
@@ -199,15 +199,15 @@ impl WorldSession {
     /// Set the quest store shared reference.
     pub fn set_quest_store(&mut self, store: Arc<wow_data::quest::QuestStore>) {
         self.invalidate_canonical_player_spell_hit_aura_authority_like_cpp();
-        self.quest_store = Some(store);
+        self.quests.store = Some(store);
     }
     /// Set the QuestV2 store shared reference used for C++ quest unique-bit lookups.
     pub fn set_quest_v2_store(&mut self, store: Arc<QuestV2Store>) {
-        self.quest_v2_store = Some(store);
+        self.quests.v2_store = Some(store);
     }
     /// Set the QuestInfo store used by C++ Quest::GetQuestTag/IsImportant.
     pub fn set_quest_info_store(&mut self, store: Arc<QuestInfoStore>) {
-        self.quest_info_store = Some(store);
+        self.quests.info_store = Some(store);
     }
     /// Set C++ `CONFIG_QUEST_LOW_LEVEL_HIDE_DIFF`.
     pub fn set_quest_low_level_hide_diff_like_cpp(&mut self, value: u32) {
@@ -219,7 +219,7 @@ impl WorldSession {
     }
     /// Set the QuestXP store (loaded from QuestXP.db2).
     pub fn set_quest_xp_store(&mut self, store: Arc<wow_data::quest_xp::QuestXpStore>) {
-        self.quest_xp_store = Some(store);
+        self.quests.xp_store = Some(store);
     }
     pub fn set_min_quest_scaled_xp_ratio_like_cpp(&mut self, ratio: u32) {
         self.min_quest_scaled_xp_ratio_like_cpp = if ratio > 100 { 0 } else { ratio };
@@ -243,7 +243,7 @@ impl WorldSession {
         quest_level: i32,
         xp_multiplier: f32,
     ) -> u32 {
-        if let Some(store) = &self.quest_xp_store {
+        if let Some(store) = &self.quests.xp_store {
             store.calculate_xp(
                 quest_level,
                 self.player_level_like_cpp(),

--- a/crates/wow-world/src/session/spell_effects/effects_progress.rs
+++ b/crates/wow-world/src/session/spell_effects/effects_progress.rs
@@ -229,7 +229,8 @@ impl WorldSession {
         }
 
         let Some(quest) = self
-            .quest_store
+            .quests
+            .store
             .as_deref()
             .and_then(|store| store.get(quest_id))
             .cloned()
@@ -272,7 +273,8 @@ impl WorldSession {
                 return Ok(());
             }
             let quest_bit = self
-                .quest_v2_store
+                .quests
+                .v2_store
                 .as_deref()
                 .map(|store| store.get_quest_unique_bit_flag_like_cpp(quest_id))
                 .unwrap_or(0);

--- a/crates/wow-world/src/session/tests/scenarios_quest_1.rs
+++ b/crates/wow-world/src/session/tests/scenarios_quest_1.rs
@@ -633,7 +633,7 @@ fn questgiver_quest_list_leaves_level_fields_zero_like_cpp() {
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([first, second]);
     assert!(quest_store.insert_gameobject_starter_relation_like_cpp(777, 9_001));
     assert!(quest_store.insert_gameobject_starter_relation_like_cpp(777, 9_002));
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
 
     assert!(session.use_represented_gameobject_questgiver_like_cpp(
         gameobject_guid,
@@ -737,7 +737,7 @@ async fn quest_reward_money_crossing_cap_leaves_balance_unchanged_like_cpp() {
     quest.reward_money_difficulty = 2;
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([quest]);
     quest_store.ender_quests.insert(792, vec![quest_id]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
     session.set_player_gold_like_cpp(MAX_MONEY_AMOUNT - 1);
     session
         .mutate_player_quest_gameplay_like_cpp(|quests| {
@@ -782,7 +782,7 @@ async fn quest_giver_choose_reward_missing_source_rejects_before_mutation_like_c
     session.set_player_gold_like_cpp(5);
     let mut quest = test_quest_template(9_224);
     quest.reward_money_difficulty = 37;
-    session.quest_store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
+    session.quests.store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
         [quest],
     )));
     session.player_quests.insert(
@@ -825,7 +825,7 @@ async fn quest_giver_choose_reward_auto_complete_player_source_is_not_blocked_li
     let mut quest = test_quest_template(9_226);
     quest.flags = crate::handlers::quest::QUEST_FLAGS_AUTO_COMPLETE_LIKE_CPP;
     quest.reward_money_difficulty = 37;
-    session.quest_store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
+    session.quests.store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
         [quest],
     )));
     session.player_quests.insert(

--- a/crates/wow-world/src/session/tests/scenarios_quest_2.rs
+++ b/crates/wow-world/src/session/tests/scenarios_quest_2.rs
@@ -12,7 +12,7 @@ async fn quest_giver_reward_daily_flag_is_not_auto_complete_like_cpp() {
     session.set_player_guid(Some(player_guid));
     let mut quest = test_quest_template(9_219);
     quest.flags = 0x0000_1000;
-    session.quest_store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
+    session.quests.store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
         [quest],
     )));
     session.player_quests.insert(
@@ -48,7 +48,7 @@ async fn quest_giver_complete_daily_flag_requires_involved_source_like_cpp() {
     session.set_player_guid(Some(player_guid));
     let mut quest = test_quest_template(9_220);
     quest.flags = 0x0000_1000;
-    session.quest_store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
+    session.quests.store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
         [quest],
     )));
     session.player_quests.insert(
@@ -86,7 +86,7 @@ async fn quest_giver_complete_auto_complete_requires_player_guid_like_cpp() {
     session.set_player_guid(Some(player_guid));
     let mut quest = test_quest_template(9_218);
     quest.flags = crate::handlers::quest::QUEST_FLAGS_AUTO_COMPLETE_LIKE_CPP;
-    session.quest_store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
+    session.quests.store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
         [quest],
     )));
     session.player_quests.insert(
@@ -153,7 +153,7 @@ fn quest_giver_query_rewarded_nonrepeatable_complete_ender_is_not_completable_li
     let mut quest_store =
         wow_data::quest::QuestStore::from_quests_like_cpp([test_quest_template(9_204)]);
     quest_store.ender_quests.insert(778, vec![9_204]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
     assert!(
         session
             .mutate_player_quest_gameplay_like_cpp(|quests| {
@@ -191,7 +191,7 @@ fn quest_giver_query_unsupported_or_missing_source_sends_no_packet_like_cpp() {
     let (mut session, _pkt_tx, send_rx) = make_session();
     let canonical = shared_canonical_map_manager();
     session.set_canonical_map_manager(canonical);
-    session.quest_store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
+    session.quests.store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
         [test_quest_template(9_207)],
     )));
     let missing_guid = ObjectGuid::create_world_object(HighGuid::GameObject, 0, 1, 571, 0, 781, 28);

--- a/crates/wow-world/src/session/tests/scenarios_world_entities_15.rs
+++ b/crates/wow-world/src/session/tests/scenarios_world_entities_15.rs
@@ -667,7 +667,7 @@ fn gameobject_use_questgiver_single_gameobject_starter_auto_opens_quest_details_
     quest.log_title = "GO starter".into();
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([quest]);
     assert!(quest_store.insert_gameobject_starter_relation_like_cpp(777, 9_001));
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
 
     assert!(session.use_represented_gameobject_questgiver_like_cpp(
         gameobject_guid,
@@ -706,7 +706,7 @@ fn gameobject_use_questgiver_ender_relation_precedes_starter_like_cpp() {
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([ender, starter]);
     assert!(quest_store.insert_gameobject_ender_relation_like_cpp(777, 9_001));
     assert!(quest_store.insert_gameobject_starter_relation_like_cpp(777, 9_002));
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
     session.player_quests.insert(
         9_001,
         crate::handlers::quest::PlayerQuestStatus {
@@ -757,7 +757,7 @@ fn quest_giver_query_gameobject_inactive_ender_falls_through_to_same_starter_lik
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([quest]);
     assert!(quest_store.insert_gameobject_ender_relation_like_cpp(778, 9_004));
     assert!(quest_store.insert_gameobject_starter_relation_like_cpp(778, 9_004));
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
 
     assert!(session.send_represented_quest_giver_query_quest_like_cpp(source_guid, 9_004));
 
@@ -778,7 +778,7 @@ fn gameobject_use_questgiver_single_incomplete_ender_auto_opens_request_items_li
     ender.log_title = "GO incomplete ender".into();
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([ender]);
     assert!(quest_store.insert_gameobject_ender_relation_like_cpp(777, 9_003));
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
     session.player_quests.insert(
         9_003,
         crate::handlers::quest::PlayerQuestStatus {
@@ -824,7 +824,7 @@ fn gameobject_use_questgiver_without_gameobject_relations_keeps_only_gossip_like
     let mut quest_store =
         wow_data::quest::QuestStore::from_quests_like_cpp([test_quest_template(9_001)]);
     quest_store.starter_quests.insert(777, vec![9_001]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
 
     assert!(session.use_represented_gameobject_questgiver_like_cpp(
         gameobject_guid,
@@ -853,7 +853,7 @@ fn creature_questgiver_single_starter_auto_opens_quest_details_like_cpp() {
     quest.log_title = "Creature starter".into();
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([quest]);
     quest_store.starter_quests.insert(777, vec![9_101]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
 
     assert!(session.use_represented_creature_questgiver_like_cpp(creature_guid, 777));
 

--- a/crates/wow-world/src/session/tests/scenarios_world_entities_16.rs
+++ b/crates/wow-world/src/session/tests/scenarios_world_entities_16.rs
@@ -13,7 +13,7 @@ fn creature_questgiver_single_complete_ender_auto_opens_request_items_can_comple
     quest.log_title = "Creature complete ender".into();
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([quest]);
     quest_store.ender_quests.insert(777, vec![9_103]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
     session.player_quests.insert(
         9_103,
         crate::handlers::quest::PlayerQuestStatus {
@@ -57,7 +57,7 @@ fn creature_questgiver_ender_relation_precedes_starter_like_cpp() {
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([ender, starter]);
     quest_store.ender_quests.insert(777, vec![9_101]);
     quest_store.starter_quests.insert(777, vec![9_102]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
     session.player_quests.insert(
         9_101,
         crate::handlers::quest::PlayerQuestStatus {
@@ -106,7 +106,7 @@ fn quest_giver_query_creature_inactive_ender_falls_through_to_same_starter_like_
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([quest]);
     quest_store.ender_quests.insert(779, vec![9_104]);
     quest_store.starter_quests.insert(779, vec![9_104]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
 
     assert!(session.send_represented_quest_giver_query_quest_like_cpp(source_guid, 9_104));
 
@@ -139,7 +139,7 @@ fn quest_giver_query_creature_inactive_ender_without_starter_rejects_like_cpp() 
     let mut quest_store =
         wow_data::quest::QuestStore::from_quests_like_cpp([test_quest_template(9_105)]);
     quest_store.ender_quests.insert(780, vec![9_105]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
 
     assert!(!session.send_represented_quest_giver_query_quest_like_cpp(source_guid, 9_105));
     assert!(send_rx.try_recv().is_err());
@@ -152,7 +152,7 @@ fn creature_questgiver_without_creature_relations_sends_nothing_like_cpp() {
     let mut quest_store =
         wow_data::quest::QuestStore::from_quests_like_cpp([test_quest_template(9_101)]);
     assert!(quest_store.insert_gameobject_starter_relation_like_cpp(777, 9_101));
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
 
     assert!(!session.use_represented_creature_questgiver_like_cpp(creature_guid, 777));
     assert!(send_rx.try_recv().is_err());
@@ -497,7 +497,7 @@ async fn quest_giver_choose_reward_creature_ender_source_allows_reward_like_cpp(
     quest.reward_money_difficulty = 37;
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([quest]);
     quest_store.ender_quests.insert(792, vec![9_223]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
     session.set_player_gold_like_cpp(5);
     session
         .mutate_player_quest_gameplay_like_cpp(|quests| {
@@ -559,7 +559,7 @@ async fn quest_giver_choose_reward_gameobject_no_relation_rejects_like_cpp() {
     );
     let mut quest = test_quest_template(9_225);
     quest.reward_money_difficulty = 37;
-    session.quest_store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
+    session.quests.store = Some(Arc::new(wow_data::quest::QuestStore::from_quests_like_cpp(
         [quest],
     )));
     session.player_quests.insert(
@@ -617,7 +617,7 @@ fn quest_giver_query_creature_starter_relation_allows_matching_details_like_cpp(
     let other_quest = test_quest_template(9_202);
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([quest, other_quest]);
     quest_store.starter_quests.insert(777, vec![9_201]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
 
     assert!(session.send_represented_quest_giver_query_quest_like_cpp(source_guid, 9_201));
     let bytes = send_rx.try_recv().unwrap();
@@ -652,7 +652,7 @@ fn quest_giver_query_creature_ender_relation_allows_request_items_like_cpp() {
     let mut quest_store =
         wow_data::quest::QuestStore::from_quests_like_cpp([test_quest_template(9_203)]);
     quest_store.ender_quests.insert(778, vec![9_203]);
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
     assert!(
         session
             .mutate_player_quest_gameplay_like_cpp(|quests| {
@@ -711,7 +711,7 @@ fn quest_giver_query_gameobject_starter_relation_allows_matching_details_like_cp
     let other_quest = test_quest_template(9_205);
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([quest, other_quest]);
     assert!(quest_store.insert_gameobject_starter_relation_like_cpp(779, 9_204));
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
 
     assert!(session.send_represented_quest_giver_query_quest_like_cpp(source_guid, 9_204));
     let bytes = send_rx.try_recv().unwrap();
@@ -738,7 +738,7 @@ fn quest_giver_query_gameobject_without_interaction_rejects_like_cpp() {
     quest.quest_type = 2;
     let mut quest_store = wow_data::quest::QuestStore::from_quests_like_cpp([quest]);
     assert!(quest_store.insert_gameobject_starter_relation_like_cpp(779, 9_204));
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
 
     assert!(
         !session.send_represented_quest_giver_query_quest_like_cpp(source_guid, 9_204),
@@ -765,7 +765,7 @@ fn quest_giver_query_gameobject_ender_relation_allows_request_items_like_cpp() {
     let mut quest_store =
         wow_data::quest::QuestStore::from_quests_like_cpp([test_quest_template(9_206)]);
     assert!(quest_store.insert_gameobject_ender_relation_like_cpp(780, 9_206));
-    session.quest_store = Some(Arc::new(quest_store));
+    session.quests.store = Some(Arc::new(quest_store));
     session.player_quests.insert(
         9_206,
         crate::handlers::quest::PlayerQuestStatus {

--- a/crates/wow-world/src/session/world_entities/gameobject_use_scripted.rs
+++ b/crates/wow-world/src/session/world_entities/gameobject_use_scripted.rs
@@ -462,7 +462,8 @@ impl WorldSession {
 
         if source.quest_id != 0
             && self
-                .quest_store
+                .quests
+                .store
                 .as_ref()
                 .is_some_and(|store| store.get(source.quest_id).is_some())
             && self

--- a/tools/architecture/runtime-ownership-ledger.json
+++ b/tools/architecture/runtime-ownership-ledger.json
@@ -38,7 +38,7 @@
       "member_key": "name",
       "zero_gaps": true,
       "zero_overlap": true,
-      "expected_field_count": 655,
+      "expected_field_count": 648,
       "validation": "Compare the sorted AST names with the sorted concatenation of every family.field_names; reject a missing name, duplicate name, stale name, family count mismatch, or total count mismatch."
     },
     "families": [
@@ -632,7 +632,7 @@
       },
       {
         "id": "immutable_catalogs_configuration_and_services",
-        "expected_field_count": 77,
+        "expected_field_count": 70,
         "field_names": [
           "access_requirement_store",
           "area_table_store",
@@ -677,15 +677,8 @@
           "phase_store",
           "player_condition_store",
           "pvp_item_store",
-          "quest_faction_reward_store",
-          "quest_info_store",
-          "quest_money_reward_store",
-          "quest_package_item_store",
           "quest_poi_store_like_cpp",
-          "quest_pool_store",
-          "quest_store",
-          "quest_v2_store",
-          "quest_xp_store",
+          "quests",
           "rand_prop_points_store",
           "reputation_rates",
           "reputation_reward_rate_store",
@@ -712,7 +705,7 @@
           "waypoint_path_resolver_like_cpp",
           "world_safe_loc_store_like_cpp"
         ],
-        "current_storage": "#670 gave six more catalog domains their own owners - item, creature, map, character, faction and gameobject - so 32 further slots left this struct and the session holds one field per owner. The quest cluster stayed: routing its accesses grows the handlers/quest hotspot, so it needs a delivery that owns those handlers too. The 36 spell and aura catalog slots left this struct under #668: they are now owned by crates/wow-world/src/spell_catalogs.rs (SpellCatalogsLikeCpp), and WorldSession holds exactly one field of that type, so no store slot is mirrored here. The remaining names are the other immutable catalogs, configuration and service handles still held directly. 132 production immutable catalog/configuration/service fields remain on WorldSession. The unused DungeonEncounter Session dependency is deleted; startup loading remains. TraitNodeEntry is required in process-owned PlayerBootstrap and borrowed by login and teleport trait loading, with no Session field, accessor or fixture mirror. The gameobject lifecycle catalog identifier is reconciled to its actual _like_cpp name. Grid-load, hotfix, glyph and talent-tab catalogs are borrowed by their consumers. Fifty former catalog fixture fields are listed only under test_only_fixtures. The remaining production catalog bag is not an approved terminal boundary.",
+        "current_storage": "#674 completed the catalog extraction the previous deliveries began: the eight quest catalog slots now live in crates/wow-world/src/quest_catalogs.rs, and the chains that rustfmt wrapped in handlers/quest were restructured to bind the store to a local, so that hotspot stayed at its baseline. #670 gave six more catalog domains their own owners - item, creature, map, character, faction and gameobject - so 32 further slots left this struct and the session holds one field per owner. The quest cluster stayed: routing its accesses grows the handlers/quest hotspot, so it needs a delivery that owns those handlers too. The 36 spell and aura catalog slots left this struct under #668: they are now owned by crates/wow-world/src/spell_catalogs.rs (SpellCatalogsLikeCpp), and WorldSession holds exactly one field of that type, so no store slot is mirrored here. The remaining names are the other immutable catalogs, configuration and service handles still held directly. 132 production immutable catalog/configuration/service fields remain on WorldSession. The unused DungeonEncounter Session dependency is deleted; startup loading remains. TraitNodeEntry is required in process-owned PlayerBootstrap and borrowed by login and teleport trait loading, with no Session field, accessor or fixture mirror. The gameobject lifecycle catalog identifier is reconciled to its actual _like_cpp name. Grid-load, hotfix, glyph and talent-tab catalogs are borrowed by their consumers. Fifty former catalog fixture fields are listed only under test_only_fixtures. The remaining production catalog bag is not an approved terminal boundary.",
         "sole_writer": "world-server bootstrap constructs the process-wide value; create_session/setters assign the Session handle once. Runtime code should read but not mutate immutable catalogs.",
         "readers": "Handlers and gameplay helpers across wow-world.",
         "clock_lifetime": "Mostly process lifetime; a Session retains Arc handles for its connection lifetime. Generators and mutable services retain their own process-wide owner.",
@@ -983,9 +976,9 @@
         "review": "docs/architecture/session-578-checkpoint.md; current exact membership, not terminal ownership acceptance."
       }
     ],
-    "expected_field_count": 655,
-    "expected_unique_field_count": 655,
-    "expected_production_field_count": 228,
+    "expected_field_count": 648,
+    "expected_unique_field_count": 648,
+    "expected_production_field_count": 221,
     "expected_test_fixture_field_count": 427
   },
   "inventories": {
@@ -1388,9 +1381,9 @@
       "entries": [
         {
           "path": "crates/wow-world/src/session/mod.rs",
-          "production_lines": 84186,
+          "production_lines": 84178,
           "test_lines": 109114,
-          "total_lines": 193300,
+          "total_lines": 193292,
           "owner": "wow-world WorldSession/application monolith.",
           "latest_growth_review": "2026-09-09 #599: the represented world-entity responsibility - creature, gameobject, aggro and spawn - leaves the Session root for 18 bounded session/world_entities submodules. The physical root drops 6,767 lines, from 66,808 to 60,041, and its ceiling is tightened to that figure. Logical production rises 25 lines because each of the 18 new files carries a module header and an impl wrapper; the methods themselves are unchanged, with an identical impl surface of 2,149 methods before and after and 37 visibilities widened from private to pub(in crate::session). As in #597, logical totals barely move because the new modules are reviewed private descendants of the same owner: this makes the responsibility navigable and separately ownable, ahead of the semantic extraction. | 2026-09-09 #597: the represented item and inventory family leaves the Session root for 18 bounded session/player_items submodules. The physical root drops 8,653 lines, from 75,841 to 67,187, and its ceiling is tightened to that figure. Logical totals barely move because the new modules are reviewed private descendants of this same owner: that is the point - this delivery makes the responsibility navigable and separately ownable, it does not yet remove it from the Session tree. The move is method-for-method with an identical impl surface of 3,761 associated items before and after, 52 visibilities widened from private to pub(in crate::session) and nothing made public. Semantic extraction behind a narrow application follows. | 2026-09-08 #589: +1308 production/+683 test lines for the represented Player cast-request lifecycle. Production growth is the private session/player_cast adapters (identity, state, checks, power, publication, wire), 1543 lines that concentrate the cast responsibility in one owner while handlers/spell.rs shrinks 455 lines and the Session root itself shrinks 267; the orchestration proper lives outside Session in the private wow-world::player_cast application. Test growth is the bounded session/tests/player_cast_lifecycle.rs module. The 1015-line player spell-hit source authority suite moved from session_tests.rs into session/tests/player_spell_hit_source.rs: net-neutral for this logical scope and a real reduction of the physical file, whose ceiling drops from 95703 to 94691. No new WorldSession field, Player mirror, clock, task or lock; one new SessionCommand variant reuses the existing bounded durable rail from #588. This is cast lifecycle adaptation, not retirement of remaining gameplay ownership; the #584 C2/C4 exits remain. Campaign follow-up: +3 production/+169 test lines. Two cast lifecycle scenarios cover the C++ Start/Go flag assembly and the residence fence over a server-triggered cast, and the three spell-click scenarios install and adopt a canonical Player like login does. | 2026-09-08 #588: +128 production/+568 test lines for the map-selected visibility adapter, retained mailbox slot/order and directory delivery; no WorldSession field, Player mirror or new lock/task. Ten bounded Session tests cover ACK, current client ledger, backpressure, committed-prefix order and stale consumers. Session root shrinks 24 physical lines. This is necessary protocol/lifecycle adaptation, not retirement of remaining gameplay ownership; #584 C2/C4 exits remain. PR #586 writer-order repair: +25 production/+111 test lines for interruptible far-transfer publication (immediate and delayed), instance-to-realm logout fencing and cancellation/failure coverage. Four existing update methods become async; no added field/task/lock/mirror. Tests use bounded existing modules; root +16 physical lines retains its #584:C4 split exit. 2026-09-07 final QA: +7 production lines preserve loaded canonical reputation on repeated same-race/class identity hydration; no field, API, lock or owner added. 2026-09-07 #585 above integrated 59f5bced: +563 production/+1 fixture lines for finalization extraction, then +9 production/+28 fixture lines for canonical far-destination orientation normalization. Fresh paired logout capture then requires realm publication: +1 production separator/+60 test lines in lifecycle/finalization.rs for the two-route backpressure/closed-realm regression, with unchanged send_async semantics and no new method, field, clock, lock or recovery owner. Account/offline/buyback adapters moved from character into private lifecycle modules; finite policy lives outside Session in crate::finalization. One task-owned ledger retains progress and recovery input. Physical new modules remain below 500 lines; root physical ceiling unchanged. Remaining Session authority stays under #584. See session-finalization-585.md.",
           "open_retirement_issues": [

--- a/tools/architecture/session-ownership-policy.json
+++ b/tools/architecture/session-ownership-policy.json
@@ -2524,22 +2524,8 @@
           "source_class": "production"
         },
         {
-          "name": "quest_faction_reward_store",
-          "type": "Option < Arc < QuestFactionRewardStore > >",
-          "visibility": "pub (crate)",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
           "name": "quest_high_level_hide_diff_like_cpp",
           "type": "u32",
-          "visibility": "pub (crate)",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "quest_info_store",
-          "type": "Option < Arc < QuestInfoStore > >",
           "visibility": "pub (crate)",
           "cfg": [],
           "source_class": "production"
@@ -2552,20 +2538,6 @@
           "source_class": "production"
         },
         {
-          "name": "quest_money_reward_store",
-          "type": "Option < Arc < QuestMoneyRewardStore > >",
-          "visibility": "pub (crate)",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "quest_package_item_store",
-          "type": "Option < Arc < QuestPackageItemStore > >",
-          "visibility": "pub (crate)",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
           "name": "quest_poi_store_like_cpp",
           "type": "Option < Arc < HashMap < i32 , wow_packet :: packets :: query :: QuestPoiData > > >",
           "visibility": "pub (crate)",
@@ -2573,29 +2545,8 @@
           "source_class": "production"
         },
         {
-          "name": "quest_pool_store",
-          "type": "Option < Arc < wow_data :: quest :: QuestPoolStoreLikeCpp > >",
-          "visibility": "pub (crate)",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "quest_store",
-          "type": "Option < Arc < wow_data :: quest :: QuestStore > >",
-          "visibility": "pub (crate)",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "quest_v2_store",
-          "type": "Option < Arc < QuestV2Store > >",
-          "visibility": "pub (crate)",
-          "cfg": [],
-          "source_class": "production"
-        },
-        {
-          "name": "quest_xp_store",
-          "type": "Option < Arc < wow_data :: quest_xp :: QuestXpStore > >",
+          "name": "quests",
+          "type": "crate :: quest_catalogs :: QuestCatalogsLikeCpp",
           "visibility": "pub (crate)",
           "cfg": [],
           "source_class": "production"
@@ -74535,7 +74486,7 @@
               "multiplicity": 1
             }
           ],
-          "fingerprint": "signature=struct::WorldSession|surface=fnv1a64x2:871a192d435ff020ffb64bdd10e17dfb:len=92442|evidence=fnv1a64x2:2e6cfac122e1f70b6b6193924d25bd6c:len=187",
+          "fingerprint": "signature=struct::WorldSession|surface=fnv1a64x2:c4a35f6a685d1bf886ea343b62a9dfbb:len=91951|evidence=fnv1a64x2:2e6cfac122e1f70b6b6193924d25bd6c:len=187",
           "cfg": [],
           "multiplicity": 1
         },


### PR DESCRIPTION
Third semantic vertical, taking the cluster #670 deferred. The eight quest catalog slots - store, pool, xp, info, v2, package item, money reward and faction reward - now live in `crates/wow-world/src/quest_catalogs.rs` with the redundant `quest_` prefix stripped, and `WorldSession` holds one `quests` field.

`WorldSession` fields 655 to 648 (production 228 to 221); associated items unchanged at 3,745, registry accesses at 594 and bridge accesses at 65, with nothing added or removed.

## Why it needed its own delivery

#670 reverted this cluster because routing `self.quest_store` to `self.quests.store` makes the chain long enough that rustfmt splits it, and 72 such accesses grew the `handlers/quest` hotspot by 8 production lines - a *different* curated owner from the one being reduced. Re-joining the split by hand does not survive `cargo fmt`.

The fix is to restructure rather than reformat: nine chains now bind the store to a local first, which removes the wrap and costs fewer lines than the original chain. `handlers/quest` ends at its baseline and `handlers/loot` at its own, while the session hotspot keeps the reduction from #670.

That is the third measurement rule this track has produced: **an extraction reduces an owner only when the state moves, the façade moves with it, and the call sites that wrap are restructured instead of merely renamed.**

## Evidence

- 3,822 `wow-world` lib tests pass unchanged.
- Workspace build clean; architecture check, self-test, physical ratchet, hotspot ratchet and `session-ownership-check check --syntax-only` pass, the last reporting 221 + 427 fields and 3,745 items.
- `./tools/validation-v2 final --base origin/3.4.3` passed at a0f0dcb9 (clean tree, aarch64 host).
- The ledger's responsibility families keep exact field membership and record where the slots went.

With this delivery the catalog extraction is complete across all seven domains: spell (#668), item, creature, map, character, faction, gameobject (#670) and quest (#674). No quest rule, reward, objective or catalog content changes; no handler is re-registered; no new crate edge. This closes neither #133 nor #584.

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)
