### PR TITLE
Move the player and map owners' receiver-free rules out (#678)

### DIFF
--- a/crates/wow-entities/src/lib.rs
+++ b/crates/wow-entities/src/lib.rs
@@ -18,6 +18,7 @@ mod object_accessor;
 mod pet;
 mod player;
 mod player_gameplay_state;
+pub mod player_rules;
 mod scene_object;
 mod spell_cast;
 mod totem;

--- a/crates/wow-entities/src/player/collections.rs
+++ b/crates/wow-entities/src/player/collections.rs
@@ -6,6 +6,7 @@
 //! Account collections: mounts, toys, heirlooms and appearances.
 
 use super::*;
+use crate::player_rules::set_dynamic_update_mask_index;
 
 impl Player {
     pub fn summoned_battle_pet_guid_like_cpp(&self) -> Option<ObjectGuid> {
@@ -45,11 +46,8 @@ impl Player {
         let index = self.active_data.heirlooms.len();
         self.active_data.heirlooms.push(item_id);
         self.active_data.heirloom_flags.push(flags);
-        Self::set_dynamic_update_mask_index(&mut self.active_data.heirlooms_update_mask, index);
-        Self::set_dynamic_update_mask_index(
-            &mut self.active_data.heirloom_flags_update_mask,
-            index,
-        );
+        set_dynamic_update_mask_index(&mut self.active_data.heirlooms_update_mask, index);
+        set_dynamic_update_mask_index(&mut self.active_data.heirloom_flags_update_mask, index);
         self.mark_active_player_data(ACTIVE_PLAYER_DATA_HEIRLOOMS_BIT);
         self.mark_active_player_data(ACTIVE_PLAYER_DATA_HEIRLOOM_FLAGS_BIT);
         index
@@ -62,7 +60,7 @@ impl Player {
         };
 
         *slot = item_id;
-        Self::set_dynamic_update_mask_index(&mut self.active_data.heirlooms_update_mask, index);
+        set_dynamic_update_mask_index(&mut self.active_data.heirlooms_update_mask, index);
         self.mark_active_player_data(ACTIVE_PLAYER_DATA_HEIRLOOMS_BIT);
         true
     }
@@ -74,10 +72,7 @@ impl Player {
         };
 
         *slot = flags;
-        Self::set_dynamic_update_mask_index(
-            &mut self.active_data.heirloom_flags_update_mask,
-            index,
-        );
+        set_dynamic_update_mask_index(&mut self.active_data.heirloom_flags_update_mask, index);
         self.mark_active_player_data(ACTIVE_PLAYER_DATA_HEIRLOOM_FLAGS_BIT);
         true
     }
@@ -94,7 +89,7 @@ impl Player {
     pub fn add_toy_like_cpp(&mut self, item_id: i32) -> usize {
         let index = self.active_data.toys.len();
         self.active_data.toys.push(item_id);
-        Self::set_dynamic_update_mask_index(&mut self.active_data.toys_update_mask, index);
+        set_dynamic_update_mask_index(&mut self.active_data.toys_update_mask, index);
         self.mark_active_player_data(ACTIVE_PLAYER_DATA_TOYS_BIT);
         index
     }

--- a/crates/wow-entities/src/player/items/equipment.rs
+++ b/crates/wow-entities/src/player/items/equipment.rs
@@ -6,6 +6,7 @@
 //! Equipment slots, transmogrification and durability.
 
 use super::super::*;
+use crate::player_rules::set_dynamic_update_mask_index;
 
 impl Player {
     pub fn find_equip_slot(&self, args: FindEquipSlotArgs<'_>) -> u8 {
@@ -481,7 +482,7 @@ impl Player {
     pub fn add_transmog_block_like_cpp(&mut self, block_value: u32) -> usize {
         let index = self.active_data.transmog.len();
         self.active_data.transmog.push(block_value);
-        Self::set_dynamic_update_mask_index(&mut self.active_data.transmog_update_mask, index);
+        set_dynamic_update_mask_index(&mut self.active_data.transmog_update_mask, index);
         self.mark_active_player_data(ACTIVE_PLAYER_DATA_TRANSMOG_BIT);
         index
     }
@@ -497,7 +498,7 @@ impl Player {
         }
 
         *block = new_block;
-        Self::set_dynamic_update_mask_index(&mut self.active_data.transmog_update_mask, slot);
+        set_dynamic_update_mask_index(&mut self.active_data.transmog_update_mask, slot);
         self.mark_active_player_data(ACTIVE_PLAYER_DATA_TRANSMOG_BIT);
         true
     }
@@ -512,7 +513,7 @@ impl Player {
         self.active_data
             .conditional_transmog
             .push(item_modified_appearance_id as i32);
-        Self::set_dynamic_update_mask_index(
+        set_dynamic_update_mask_index(
             &mut self.active_data.conditional_transmog_update_mask,
             index,
         );
@@ -535,7 +536,7 @@ impl Player {
         };
 
         self.active_data.conditional_transmog.remove(index);
-        Self::set_dynamic_update_mask_index(
+        set_dynamic_update_mask_index(
             &mut self.active_data.conditional_transmog_update_mask,
             index,
         );
@@ -545,13 +546,5 @@ impl Player {
 
     pub fn conditional_transmog_like_cpp(&self) -> &[i32] {
         &self.active_data.conditional_transmog
-    }
-
-    pub const fn is_use_equipped_weapon(
-        mainhand: bool,
-        is_in_feral_form: bool,
-        is_disarmed: bool,
-    ) -> bool {
-        !is_in_feral_form && (!mainhand || !is_disarmed)
     }
 }

--- a/crates/wow-entities/src/player/mod.rs
+++ b/crates/wow-entities/src/player/mod.rs
@@ -4272,20 +4272,6 @@ impl Player {
                 && template.subclass_id != ItemSubClassWeapon::Wand as u32)
     }
 
-    pub fn is_using_two_handed_weapon_in_one_hand_template(
-        main_template: Option<&ItemStorageTemplate>,
-        off_template: Option<&ItemStorageTemplate>,
-    ) -> bool {
-        if off_template
-            .is_some_and(|template| template.inventory_type == InventoryType::Weapon2Hand)
-        {
-            return true;
-        }
-
-        main_template.is_some_and(|template| template.inventory_type == InventoryType::Weapon2Hand)
-            && off_template.is_some()
-    }
-
     pub fn check_titan_grip_penalty_action(
         &self,
         using_two_handed_weapon_in_one_hand: bool,
@@ -4449,16 +4435,6 @@ impl Player {
         self.active_player_data_changes.set(parent_bit);
         self.active_player_data_changes
             .set(first_element_bit + index);
-    }
-
-    fn set_dynamic_update_mask_index(mask: &mut Option<Vec<u32>>, index: usize) {
-        let block = index / 32;
-        let bit = index % 32;
-        let blocks = mask.get_or_insert_with(Vec::new);
-        if blocks.len() <= block {
-            blocks.resize(block + 1, 0);
-        }
-        blocks[block] |= 1 << bit;
     }
 }
 
@@ -4902,3 +4878,4 @@ fn can_take_more_similar_ok() -> CanTakeMoreSimilarItemsOutcome {
 #[cfg(test)]
 #[path = "../player_tests.rs"]
 mod tests;
+pub(crate) use crate::player_rules::*;

--- a/crates/wow-entities/src/player_rules.rs
+++ b/crates/wow-entities/src/player_rules.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 alseif0x
+// RustyCore — WoW WotLK 3.4.3 server in Rust
+// Based on TrinityCore protocol research (https://github.com/TrinityCore/TrinityCore)
+// Licensed under GPL v3 — https://www.gnu.org/licenses/gpl-3.0.html
+
+//! Player rules that read no player state.
+//!
+//! Moved out of the owner under #678. Every one was already receiver-free,
+//! so it cannot read or write the owner's state: these are rules, not owner
+//! behaviour. Bodies and signatures are unchanged.
+
+use crate::*;
+use wow_constants::item::InventoryType;
+
+pub(crate) const fn is_use_equipped_weapon(
+    mainhand: bool,
+    is_in_feral_form: bool,
+    is_disarmed: bool,
+) -> bool {
+    !is_in_feral_form && (!mainhand || !is_disarmed)
+}
+
+pub fn is_using_two_handed_weapon_in_one_hand_template(
+    main_template: Option<&ItemStorageTemplate>,
+    off_template: Option<&ItemStorageTemplate>,
+) -> bool {
+    if off_template.is_some_and(|template| template.inventory_type == InventoryType::Weapon2Hand) {
+        return true;
+    }
+
+    main_template.is_some_and(|template| template.inventory_type == InventoryType::Weapon2Hand)
+        && off_template.is_some()
+}
+
+pub(crate) fn set_dynamic_update_mask_index(mask: &mut Option<Vec<u32>>, index: usize) {
+    let block = index / 32;
+    let bit = index % 32;
+    let blocks = mask.get_or_insert_with(Vec::new);
+    if blocks.len() <= block {
+        blocks.resize(block + 1, 0);
+    }
+    blocks[block] |= 1 << bit;
+}

--- a/crates/wow-entities/src/player_tests/item_7.rs
+++ b/crates/wow-entities/src/player_tests/item_7.rs
@@ -116,9 +116,9 @@ fn titan_grip_and_equipped_weapon_helpers_match_cpp_representable_rules() {
         ..ItemStorageTemplate::regular_item(2004, 1)
     };
 
-    assert!(Player::is_use_equipped_weapon(false, false, true));
-    assert!(!Player::is_use_equipped_weapon(true, false, true));
-    assert!(!Player::is_use_equipped_weapon(false, true, false));
+    assert!(is_use_equipped_weapon(false, false, true));
+    assert!(!is_use_equipped_weapon(true, false, true));
+    assert!(!is_use_equipped_weapon(false, true, false));
 
     assert!(!player.can_titan_grip());
     assert_eq!(player.titan_grip_penalty_spell_id(), 0);
@@ -134,19 +134,19 @@ fn titan_grip_and_equipped_weapon_helpers_match_cpp_representable_rules() {
     assert_eq!(player.titan_grip_penalty_spell_id(), 49152);
     assert!(!player.is_two_hand_used_template(Some(&two_hand)));
 
-    assert!(Player::is_using_two_handed_weapon_in_one_hand_template(
+    assert!(is_using_two_handed_weapon_in_one_hand_template(
         Some(&one_hand),
         Some(&two_hand),
     ));
-    assert!(Player::is_using_two_handed_weapon_in_one_hand_template(
+    assert!(is_using_two_handed_weapon_in_one_hand_template(
         Some(&two_hand),
         Some(&one_hand),
     ));
-    assert!(!Player::is_using_two_handed_weapon_in_one_hand_template(
+    assert!(!is_using_two_handed_weapon_in_one_hand_template(
         Some(&two_hand),
         None,
     ));
-    assert!(!Player::is_using_two_handed_weapon_in_one_hand_template(
+    assert!(!is_using_two_handed_weapon_in_one_hand_template(
         Some(&one_hand),
         Some(&one_hand),
     ));

--- a/crates/wow-map/src/lib.rs
+++ b/crates/wow-map/src/lib.rs
@@ -5,6 +5,7 @@ pub mod grid_map;
 pub mod grid_unload;
 pub mod manager;
 pub mod map;
+pub(crate) mod map_rules;
 pub mod object_grid_loader;
 pub mod personal_phase;
 pub mod pool;

--- a/crates/wow-map/src/map/entity_world.rs
+++ b/crates/wow-map/src/map/entity_world.rs
@@ -12,6 +12,7 @@
 //! new dependency on `HashMap` while borrowed-record APIs are retired ahead of
 //! the selected `hecs` backend.
 
+use crate::map_rules::snapshot_from_creature;
 use std::collections::HashMap;
 use std::collections::hash_map::{Iter, Values};
 
@@ -26,24 +27,6 @@ pub(super) struct EntityWorld {
 }
 
 impl EntityWorld {
-    fn snapshot_from_creature(
-        guid: ObjectGuid,
-        creature: &Creature,
-    ) -> CreatureTransformVitalsSnapshotLikeCpp {
-        let world = creature.unit().world();
-        CreatureTransformVitalsSnapshotLikeCpp {
-            guid,
-            map_id: world.map_id(),
-            instance_id: world.instance_id(),
-            position: world.position(),
-            combat_reach: world.combat_reach(),
-            health: creature.current_health(),
-            max_health: creature.max_health(),
-            is_alive: creature.is_alive(),
-            is_in_world: world.object().is_in_world(),
-        }
-    }
-
     pub(super) fn get(&self, guid: &ObjectGuid) -> Option<&MapObjectRecord> {
         self.records_by_guid.get(guid)
     }
@@ -84,9 +67,7 @@ impl EntityWorld {
         &self,
         guid: ObjectGuid,
     ) -> Option<CreatureTransformVitalsSnapshotLikeCpp> {
-        self.with_creature(guid, |creature| {
-            Self::snapshot_from_creature(guid, creature)
-        })
+        self.with_creature(guid, |creature| snapshot_from_creature(guid, creature))
     }
 
     pub(super) fn creature_transform_vitals_lookups(

--- a/crates/wow-map/src/map/game_object.rs
+++ b/crates/wow-map/src/map/game_object.rs
@@ -6,6 +6,10 @@
 //! GameObject, transport, scene object and area-trigger lifecycle.
 
 use super::*;
+use crate::map_rules::{
+    gameobject_is_spawned_like_cpp, map_record_is_unit_like_gameobject_owner_like_cpp,
+    map_record_unit_like_cpp, map_record_unit_mut_like_cpp,
+};
 
 impl<Terrain, Lifecycle> Map<Terrain, Lifecycle>
 where
@@ -1283,7 +1287,7 @@ where
                 continue;
             }
             fallback_guid.get_or_insert(guid);
-            if Self::gameobject_is_spawned_like_cpp(gameobject) {
+            if gameobject_is_spawned_like_cpp(gameobject) {
                 spawned_guid = Some(guid);
                 break;
             }
@@ -1294,25 +1298,10 @@ where
             .and_then(|guid| self.map_object_record(guid)?.game_object())
     }
 
-    fn gameobject_is_spawned_like_cpp(gameobject: &GameObject) -> bool {
-        gameobject.respawn_delay_time() == 0
-            || (gameobject.respawn_time() > 0 && !gameobject.spawned_by_default())
-            || (gameobject.respawn_time() == 0 && gameobject.spawned_by_default())
-    }
-
     pub fn get_area_trigger_by_spawn_id_like_cpp(&self, spawn_id: SpawnId) -> Option<&AreaTrigger> {
         self.area_trigger_spawn_id_store_guids_like_cpp(spawn_id)
             .into_iter()
             .find_map(|guid| self.map_object_record(guid)?.area_trigger())
-    }
-
-    pub(super) fn map_record_is_unit_like_gameobject_owner_like_cpp(
-        record: &MapObjectRecord,
-    ) -> bool {
-        matches!(
-            record.kind(),
-            AccessorObjectKind::Player | AccessorObjectKind::Creature | AccessorObjectKind::Pet
-        ) && (record.player().is_some() || record.creature().is_some() || record.pet().is_some())
     }
 
     /// Bounded map-owned representation of C++ `Unit::AddGameObject(GameObject*)`.
@@ -1336,7 +1325,7 @@ where
     ) -> GameObjectAddToOwnerOutcomeLikeCpp {
         let owner_found_as_unit_like = self
             .map_object_record(owner_guid)
-            .is_some_and(Self::map_record_is_unit_like_gameobject_owner_like_cpp);
+            .is_some_and(map_record_is_unit_like_gameobject_owner_like_cpp);
         let (gameobject_found, owner_guid_before) = self
             .map_object_record(guid)
             .filter(|record| record.kind() == AccessorObjectKind::GameObject)
@@ -1351,7 +1340,7 @@ where
 
         if owner_found_as_unit_like && gameobject_owner_empty_before {
             if let Some(record) = self.entity_world.get_mut(&owner_guid) {
-                if let Some(owner) = Self::map_record_unit_mut_like_cpp(record) {
+                if let Some(owner) = map_record_unit_mut_like_cpp(record) {
                     owner
                         .subsystems_mut()
                         .control
@@ -1442,7 +1431,7 @@ where
             if let Some(owner) = self
                 .entity_world
                 .get_mut(&owner_guid)
-                .and_then(Self::map_record_unit_mut_like_cpp)
+                .and_then(map_record_unit_mut_like_cpp)
             {
                 if let Some(previous) = owner
                     .subsystems()
@@ -1528,7 +1517,7 @@ where
         }
         let summoner_is_player = summoner_record.kind() == AccessorObjectKind::Player;
         let summoner_is_unit_like =
-            Self::map_record_is_unit_like_gameobject_owner_like_cpp(summoner_record);
+            map_record_is_unit_like_gameobject_owner_like_cpp(summoner_record);
         let should_add_to_owner = summoner_is_player
             || (summoner_is_unit_like
                 && summon_type == GameObjectSummonTypeLikeCpp::TimedOrCorpseDespawn);
@@ -1603,7 +1592,7 @@ where
             let mut registered_owned_gameobject = false;
             let mut creature_ai_callback_represented = false;
             if let Some(record) = self.entity_world.get_mut(&summoner_guid) {
-                if let Some(owner) = Self::map_record_unit_mut_like_cpp(record) {
+                if let Some(owner) = map_record_unit_mut_like_cpp(record) {
                     owner
                         .subsystems_mut()
                         .control
@@ -1703,10 +1692,10 @@ where
     ) -> GameObjectPrepareOwnerSlotForSummonOutcomeLikeCpp {
         let owner_found_as_unit_like = self
             .map_object_record(owner_guid)
-            .is_some_and(Self::map_record_is_unit_like_gameobject_owner_like_cpp);
+            .is_some_and(map_record_is_unit_like_gameobject_owner_like_cpp);
         let slot_guid_before = self
             .map_object_record(owner_guid)
-            .and_then(Self::map_record_unit_like_cpp)
+            .and_then(map_record_unit_like_cpp)
             .and_then(|owner| {
                 owner
                     .subsystems()
@@ -1765,7 +1754,7 @@ where
             if let Some(owner) = self
                 .entity_world
                 .get_mut(&owner_guid)
-                .and_then(Self::map_record_unit_mut_like_cpp)
+                .and_then(map_record_unit_mut_like_cpp)
             {
                 slot_cleared = owner
                     .subsystems_mut()
@@ -1819,7 +1808,7 @@ where
         let template_entry = template.entry;
         let Some(owner) = self
             .map_object_record(owner_guid)
-            .and_then(Self::map_record_unit_like_cpp)
+            .and_then(map_record_unit_like_cpp)
         else {
             return GameObjectSummonObjectForOwnerSlotOutcomeLikeCpp {
                 owner_guid,
@@ -1927,7 +1916,7 @@ where
         let mut registered_owned_gameobject = false;
         let mut creature_ai_callback_represented = false;
         if let Some(record) = self.entity_world.get_mut(&owner_guid) {
-            if let Some(owner) = Self::map_record_unit_mut_like_cpp(record) {
+            if let Some(owner) = map_record_unit_mut_like_cpp(record) {
                 owner
                     .subsystems_mut()
                     .control
@@ -1984,7 +1973,7 @@ where
             if let Some(owner) = self
                 .entity_world
                 .get_mut(&owner_guid)
-                .and_then(Self::map_record_unit_mut_like_cpp)
+                .and_then(map_record_unit_mut_like_cpp)
             {
                 if let Some(previous) = owner
                     .subsystems()

--- a/crates/wow-map/src/map/mod.rs
+++ b/crates/wow-map/src/map/mod.rs
@@ -21,6 +21,10 @@ mod storage;
 mod update;
 mod visibility;
 
+use crate::map_rules::{
+    decrement_pool_counter_like_cpp, map_record_unit_mut_like_cpp,
+    player_set_viewpoint_outcome_like_cpp, remove_spawn_id_index_entry_like_cpp,
+};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -618,12 +622,12 @@ impl SpawnedPoolDataLikeCpp {
         match object_type {
             SpawnObjectType::Creature => {
                 self.spawned_creatures.remove(&spawn_id);
-                Self::decrement_pool_counter_like_cpp(&mut self.spawned_pools, pool_id);
+                decrement_pool_counter_like_cpp(&mut self.spawned_pools, pool_id);
                 Ok(())
             }
             SpawnObjectType::GameObject => {
                 self.spawned_gameobjects.remove(&spawn_id);
-                Self::decrement_pool_counter_like_cpp(&mut self.spawned_pools, pool_id);
+                decrement_pool_counter_like_cpp(&mut self.spawned_pools, pool_id);
                 Ok(())
             }
             SpawnObjectType::AreaTrigger => Err(
@@ -639,7 +643,7 @@ impl SpawnedPoolDataLikeCpp {
 
     pub fn remove_pool_spawn_like_cpp(&mut self, sub_pool_id: u32, pool_id: u32) {
         self.spawned_pools.remove(&sub_pool_id);
-        Self::decrement_pool_counter_like_cpp(&mut self.spawned_pools, pool_id);
+        decrement_pool_counter_like_cpp(&mut self.spawned_pools, pool_id);
     }
 
     pub fn spawned_objects_like_cpp(&self) -> Vec<(SpawnObjectType, SpawnId)> {
@@ -657,13 +661,6 @@ impl SpawnedPoolDataLikeCpp {
             .collect::<Vec<_>>();
         spawned.sort_unstable();
         spawned
-    }
-
-    fn decrement_pool_counter_like_cpp(spawned_pools: &mut HashMap<u32, u32>, pool_id: u32) {
-        let counter = spawned_pools.entry(pool_id).or_insert(0);
-        if *counter > 0 {
-            *counter -= 1;
-        }
     }
 }
 
@@ -2576,44 +2573,6 @@ where
         self.set_world_object_like_cpp(request.unit_guid, request.on)
     }
 
-    fn player_set_viewpoint_outcome_like_cpp(
-        player_guid: ObjectGuid,
-        target_guid: ObjectGuid,
-        apply: bool,
-        status: PlayerSetViewpointStatusLikeCpp,
-        set_world_object: Option<SetWorldObjectOutcomeLikeCpp>,
-        update_visibility_requested: bool,
-        set_seer_requested: bool,
-    ) -> PlayerSetViewpointOutcomeLikeCpp {
-        PlayerSetViewpointOutcomeLikeCpp {
-            player_guid,
-            target_guid,
-            apply,
-            status,
-            set_world_object,
-            update_visibility_requested,
-            set_seer_requested,
-        }
-    }
-
-    fn map_record_unit_mut_like_cpp(record: &mut MapObjectRecord) -> Option<&mut Unit> {
-        match record.kind() {
-            AccessorObjectKind::Player => record.player_mut().map(Player::unit_mut),
-            AccessorObjectKind::Creature => record.creature_mut().map(Creature::unit_mut),
-            AccessorObjectKind::Pet => record.pet_mut().map(|pet| pet.creature_mut().unit_mut()),
-            _ => None,
-        }
-    }
-
-    fn map_record_unit_like_cpp(record: &MapObjectRecord) -> Option<&Unit> {
-        match record.kind() {
-            AccessorObjectKind::Player => record.player().map(Player::unit),
-            AccessorObjectKind::Creature => record.creature().map(Creature::unit),
-            AccessorObjectKind::Pet => record.pet().map(|pet| pet.creature().unit()),
-            _ => None,
-        }
-    }
-
     /// Bounded map-owned seam for the Unit-target shared-vision branch of C++
     /// `Player::SetViewpoint(WorldObject* target, bool apply)`.
     ///
@@ -2640,7 +2599,7 @@ where
         vehicle_base_guid: Option<ObjectGuid>,
     ) -> PlayerSetViewpointOutcomeLikeCpp {
         let Some(player) = self.get_typed_player(player_guid) else {
-            return Self::player_set_viewpoint_outcome_like_cpp(
+            return player_set_viewpoint_outcome_like_cpp(
                 player_guid,
                 target_guid,
                 apply,
@@ -2654,7 +2613,7 @@ where
         let current_farsight = player.active_data().farsight_object;
         if apply {
             if !current_farsight.is_empty() {
-                return Self::player_set_viewpoint_outcome_like_cpp(
+                return player_set_viewpoint_outcome_like_cpp(
                     player_guid,
                     target_guid,
                     apply,
@@ -2665,7 +2624,7 @@ where
                 );
             }
         } else if current_farsight != target_guid {
-            return Self::player_set_viewpoint_outcome_like_cpp(
+            return player_set_viewpoint_outcome_like_cpp(
                 player_guid,
                 target_guid,
                 apply,
@@ -2677,7 +2636,7 @@ where
         }
 
         let Some(target_record) = self.map_object_record(target_guid) else {
-            return Self::player_set_viewpoint_outcome_like_cpp(
+            return player_set_viewpoint_outcome_like_cpp(
                 player_guid,
                 target_guid,
                 apply,
@@ -2691,7 +2650,7 @@ where
             target_record.kind(),
             AccessorObjectKind::Creature | AccessorObjectKind::Pet
         ) {
-            return Self::player_set_viewpoint_outcome_like_cpp(
+            return player_set_viewpoint_outcome_like_cpp(
                 player_guid,
                 target_guid,
                 apply,
@@ -2705,7 +2664,7 @@ where
         let vehicle_base_skip = vehicle_base_guid == Some(target_guid);
         if !vehicle_base_skip {
             let Some(target_record) = self.entity_world.get_mut(&target_guid) else {
-                return Self::player_set_viewpoint_outcome_like_cpp(
+                return player_set_viewpoint_outcome_like_cpp(
                     player_guid,
                     target_guid,
                     apply,
@@ -2715,8 +2674,8 @@ where
                     false,
                 );
             };
-            if Self::map_record_unit_mut_like_cpp(target_record).is_none() {
-                return Self::player_set_viewpoint_outcome_like_cpp(
+            if map_record_unit_mut_like_cpp(target_record).is_none() {
+                return player_set_viewpoint_outcome_like_cpp(
                     player_guid,
                     target_guid,
                     apply,
@@ -2729,7 +2688,7 @@ where
         }
 
         let Some(player) = self.get_typed_player_mut(player_guid) else {
-            return Self::player_set_viewpoint_outcome_like_cpp(
+            return player_set_viewpoint_outcome_like_cpp(
                 player_guid,
                 target_guid,
                 apply,
@@ -2746,7 +2705,7 @@ where
         });
 
         if vehicle_base_skip {
-            return Self::player_set_viewpoint_outcome_like_cpp(
+            return player_set_viewpoint_outcome_like_cpp(
                 player_guid,
                 target_guid,
                 apply,
@@ -2763,7 +2722,7 @@ where
 
         let request = {
             let Some(target_record) = self.entity_world.get_mut(&target_guid) else {
-                return Self::player_set_viewpoint_outcome_like_cpp(
+                return player_set_viewpoint_outcome_like_cpp(
                     player_guid,
                     target_guid,
                     apply,
@@ -2773,8 +2732,8 @@ where
                     false,
                 );
             };
-            let Some(target_unit) = Self::map_record_unit_mut_like_cpp(target_record) else {
-                return Self::player_set_viewpoint_outcome_like_cpp(
+            let Some(target_unit) = map_record_unit_mut_like_cpp(target_record) else {
+                return player_set_viewpoint_outcome_like_cpp(
                     player_guid,
                     target_guid,
                     apply,
@@ -2795,7 +2754,7 @@ where
             self.apply_unit_shared_vision_set_world_object_request_like_cpp(request)
         });
 
-        Self::player_set_viewpoint_outcome_like_cpp(
+        player_set_viewpoint_outcome_like_cpp(
             player_guid,
             target_guid,
             apply,
@@ -3022,7 +2981,7 @@ where
                 }
             };
         let player_outcome = |player_guid, status| {
-            Self::player_set_viewpoint_outcome_like_cpp(
+            player_set_viewpoint_outcome_like_cpp(
                 player_guid,
                 dynamic_object_guid,
                 apply,
@@ -3074,7 +3033,7 @@ where
             if current_farsight.is_empty() {
                 if let Some(player) = self.get_typed_player_mut(player_guid) {
                     player.set_farsight_object_like_cpp(dynamic_object_guid);
-                    Self::player_set_viewpoint_outcome_like_cpp(
+                    player_set_viewpoint_outcome_like_cpp(
                         player_guid,
                         dynamic_object_guid,
                         apply,
@@ -3095,7 +3054,7 @@ where
         } else if current_farsight == dynamic_object_guid {
             if let Some(player) = self.get_typed_player_mut(player_guid) {
                 player.set_farsight_object_like_cpp(ObjectGuid::EMPTY);
-                Self::player_set_viewpoint_outcome_like_cpp(
+                player_set_viewpoint_outcome_like_cpp(
                     player_guid,
                     dynamic_object_guid,
                     apply,
@@ -3309,7 +3268,7 @@ where
 
     fn unindex_map_object_record_by_spawn_id_like_cpp(&mut self, record: &MapObjectRecord) {
         if let Some(creature) = record.creature() {
-            Self::remove_spawn_id_index_entry_like_cpp(
+            remove_spawn_id_index_entry_like_cpp(
                 &mut self.creatures_by_spawn_id,
                 creature.spawn_id(),
                 creature.guid(),
@@ -3318,7 +3277,7 @@ where
         }
 
         if let Some(gameobject) = record.game_object() {
-            Self::remove_spawn_id_index_entry_like_cpp(
+            remove_spawn_id_index_entry_like_cpp(
                 &mut self.gameobjects_by_spawn_id,
                 gameobject.spawn_id(),
                 gameobject.world().guid(),
@@ -3327,7 +3286,7 @@ where
         }
 
         if let Some(area_trigger) = record.area_trigger() {
-            Self::remove_spawn_id_index_entry_like_cpp(
+            remove_spawn_id_index_entry_like_cpp(
                 &mut self.area_triggers_by_spawn_id,
                 area_trigger.spawn_id(),
                 area_trigger.world().guid(),

--- a/crates/wow-map/src/map/relocation.rs
+++ b/crates/wow-map/src/map/relocation.rs
@@ -6,6 +6,10 @@
 //! Object relocation and grid/cell transitions.
 
 use super::*;
+use crate::map_rules::{
+    map_record_is_unit_like_gameobject_owner_like_cpp, map_record_unit_like_cpp,
+    map_record_unit_mut_like_cpp, player_set_viewpoint_outcome_like_cpp,
+};
 
 impl<Terrain, Lifecycle> Map<Terrain, Lifecycle>
 where
@@ -372,23 +376,6 @@ where
         self.objects_to_remove.insert(guid);
     }
 
-    pub(super) fn remove_spawn_id_index_entry_like_cpp(
-        index: &mut HashMap<SpawnId, HashSet<ObjectGuid>>,
-        spawn_id: SpawnId,
-        guid: ObjectGuid,
-    ) {
-        if spawn_id == 0 {
-            return;
-        }
-
-        if let Some(guids) = index.get_mut(&spawn_id) {
-            guids.remove(&guid);
-            if guids.is_empty() {
-                index.remove(&spawn_id);
-            }
-        }
-    }
-
     fn remove_creature_from_formation_like_cpp(
         &mut self,
         guid: ObjectGuid,
@@ -515,10 +502,10 @@ where
     ) -> UnitRemoveGameObjectsBySpellOutcomeLikeCpp {
         let owner_found_as_unit_like = self
             .map_object_record(owner_guid)
-            .is_some_and(Self::map_record_is_unit_like_gameobject_owner_like_cpp);
+            .is_some_and(map_record_is_unit_like_gameobject_owner_like_cpp);
         let owned_guids_before = self
             .map_object_record(owner_guid)
-            .and_then(Self::map_record_unit_like_cpp)
+            .and_then(map_record_unit_like_cpp)
             .map(|owner| owner.subsystems().control.owned_gameobjects.clone())
             .unwrap_or_default();
 
@@ -556,7 +543,7 @@ where
         if let Some(owner) = self
             .entity_world
             .get_mut(&owner_guid)
-            .and_then(Self::map_record_unit_mut_like_cpp)
+            .and_then(map_record_unit_mut_like_cpp)
         {
             let before = owner.subsystems().control.owned_gameobjects.len();
             owner
@@ -621,7 +608,7 @@ where
         let owner_found_as_unit_like = !owner_guid_before.is_empty()
             && self
                 .map_object_record(owner_guid_before)
-                .is_some_and(Self::map_record_is_unit_like_gameobject_owner_like_cpp);
+                .is_some_and(map_record_is_unit_like_gameobject_owner_like_cpp);
         let cleared_owner = !owner_guid_before.is_empty();
 
         if cleared_owner {
@@ -666,7 +653,7 @@ where
                             .unwrap_or(false),
                         _ => false,
                     };
-                    let Some(owner) = Self::map_record_unit_mut_like_cpp(record) else {
+                    let Some(owner) = map_record_unit_mut_like_cpp(record) else {
                         return (false, false, 0, creature_ai_callback_represented);
                     };
                     let subsystems = owner.subsystems_mut();
@@ -877,7 +864,7 @@ where
                 let player_set_viewpoint = match self.get_typed_player_mut(player_guid) {
                     Some(player) if player.active_data().farsight_object == viewpoint_guid => {
                         player.set_farsight_object_like_cpp(ObjectGuid::EMPTY);
-                        Self::player_set_viewpoint_outcome_like_cpp(
+                        player_set_viewpoint_outcome_like_cpp(
                             player_guid,
                             viewpoint_guid,
                             false,
@@ -887,7 +874,7 @@ where
                             true,
                         )
                     }
-                    Some(_) => Self::player_set_viewpoint_outcome_like_cpp(
+                    Some(_) => player_set_viewpoint_outcome_like_cpp(
                         player_guid,
                         viewpoint_guid,
                         false,
@@ -896,7 +883,7 @@ where
                         false,
                         false,
                     ),
-                    None => Self::player_set_viewpoint_outcome_like_cpp(
+                    None => player_set_viewpoint_outcome_like_cpp(
                         player_guid,
                         viewpoint_guid,
                         false,
@@ -918,7 +905,7 @@ where
                 let player_set_viewpoint = match self.get_typed_player_mut(player_guid) {
                     Some(player) if player.active_data().farsight_object == viewpoint_guid => {
                         player.set_farsight_object_like_cpp(ObjectGuid::EMPTY);
-                        Self::player_set_viewpoint_outcome_like_cpp(
+                        player_set_viewpoint_outcome_like_cpp(
                             player_guid,
                             viewpoint_guid,
                             false,
@@ -928,7 +915,7 @@ where
                             true,
                         )
                     }
-                    _ => Self::player_set_viewpoint_outcome_like_cpp(
+                    _ => player_set_viewpoint_outcome_like_cpp(
                         player_guid,
                         viewpoint_guid,
                         false,

--- a/crates/wow-map/src/map/storage.rs
+++ b/crates/wow-map/src/map/storage.rs
@@ -6,6 +6,7 @@
 //! Grid and cell storage, terrain loading and object lookup.
 
 use super::*;
+use crate::map_rules::ensure_map_guid_sequence_source_like_cpp;
 
 impl<Terrain, Lifecycle> Map<Terrain, Lifecycle>
 where
@@ -141,7 +142,7 @@ where
         &mut self,
         high: HighGuid,
     ) -> Result<i64, MapGuidSequenceErrorLikeCpp> {
-        Self::ensure_map_guid_sequence_source_like_cpp(high)?;
+        ensure_map_guid_sequence_source_like_cpp(high)?;
         Ok(self
             .guid_sequence_generator_like_cpp(high)
             .generator
@@ -152,7 +153,7 @@ where
         &mut self,
         high: HighGuid,
     ) -> Result<i64, MapGuidSequenceErrorLikeCpp> {
-        Self::ensure_map_guid_sequence_source_like_cpp(high)?;
+        ensure_map_guid_sequence_source_like_cpp(high)?;
         Ok(self
             .guid_sequence_generator_like_cpp(high)
             .generator
@@ -164,7 +165,7 @@ where
         high: HighGuid,
         next: i64,
     ) -> Result<(), MapGuidSequenceErrorLikeCpp> {
-        Self::ensure_map_guid_sequence_source_like_cpp(high)?;
+        ensure_map_guid_sequence_source_like_cpp(high)?;
         self.guid_sequence_generator_like_cpp(high)
             .generator
             .set(next);
@@ -178,36 +179,6 @@ where
         self.guid_generators
             .entry(high)
             .or_insert_with(|| MapGuidSequenceGeneratorLikeCpp::new(high))
-    }
-
-    fn ensure_map_guid_sequence_source_like_cpp(
-        high: HighGuid,
-    ) -> Result<(), MapGuidSequenceErrorLikeCpp> {
-        match high {
-            HighGuid::WorldTransaction
-            | HighGuid::StaticDoor
-            | HighGuid::Transport
-            | HighGuid::Conversation
-            | HighGuid::Creature
-            | HighGuid::Vehicle
-            | HighGuid::Pet
-            | HighGuid::GameObject
-            | HighGuid::DynamicObject
-            | HighGuid::AreaTrigger
-            | HighGuid::Corpse
-            | HighGuid::LootObject
-            | HighGuid::SceneObject
-            | HighGuid::Scenario
-            | HighGuid::AIGroup
-            | HighGuid::DynamicDoor
-            | HighGuid::Vignette
-            | HighGuid::CallForHelp
-            | HighGuid::AIResource
-            | HighGuid::AILock
-            | HighGuid::AILockTicket
-            | HighGuid::Cast => Ok(()),
-            _ => Err(MapGuidSequenceErrorLikeCpp::UnsupportedSequenceSource { high }),
-        }
     }
 
     pub const fn grid_expiry_ms(&self) -> i64 {

--- a/crates/wow-map/src/map_rules.rs
+++ b/crates/wow-map/src/map_rules.rs
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 alseif0x
+// RustyCore — WoW WotLK 3.4.3 server in Rust
+// Based on TrinityCore protocol research (https://github.com/TrinityCore/TrinityCore)
+// Licensed under GPL v3 — https://www.gnu.org/licenses/gpl-3.0.html
+
+//! Map rules that read no map state.
+//!
+//! Moved out of the owner under #678. Every one was already receiver-free,
+//! so it cannot read or write the owner's state: these are rules, not owner
+//! behaviour. Bodies and signatures are unchanged.
+
+use crate::map::*;
+use crate::spawn::SpawnId;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use wow_core::ObjectGuid;
+use wow_core::guid::HighGuid;
+use wow_entities::AccessorObjectKind;
+use wow_entities::Creature;
+use wow_entities::GameObject;
+use wow_entities::MapObjectRecord;
+use wow_entities::Player;
+use wow_entities::Unit;
+
+pub(crate) fn decrement_pool_counter_like_cpp(spawned_pools: &mut HashMap<u32, u32>, pool_id: u32) {
+    let counter = spawned_pools.entry(pool_id).or_insert(0);
+    if *counter > 0 {
+        *counter -= 1;
+    }
+}
+
+pub(crate) fn ensure_map_guid_sequence_source_like_cpp(
+    high: HighGuid,
+) -> Result<(), MapGuidSequenceErrorLikeCpp> {
+    match high {
+        HighGuid::WorldTransaction
+        | HighGuid::StaticDoor
+        | HighGuid::Transport
+        | HighGuid::Conversation
+        | HighGuid::Creature
+        | HighGuid::Vehicle
+        | HighGuid::Pet
+        | HighGuid::GameObject
+        | HighGuid::DynamicObject
+        | HighGuid::AreaTrigger
+        | HighGuid::Corpse
+        | HighGuid::LootObject
+        | HighGuid::SceneObject
+        | HighGuid::Scenario
+        | HighGuid::AIGroup
+        | HighGuid::DynamicDoor
+        | HighGuid::Vignette
+        | HighGuid::CallForHelp
+        | HighGuid::AIResource
+        | HighGuid::AILock
+        | HighGuid::AILockTicket
+        | HighGuid::Cast => Ok(()),
+        _ => Err(MapGuidSequenceErrorLikeCpp::UnsupportedSequenceSource { high }),
+    }
+}
+
+pub(crate) fn gameobject_is_spawned_like_cpp(gameobject: &GameObject) -> bool {
+    gameobject.respawn_delay_time() == 0
+        || (gameobject.respawn_time() > 0 && !gameobject.spawned_by_default())
+        || (gameobject.respawn_time() == 0 && gameobject.spawned_by_default())
+}
+
+pub(crate) fn map_record_is_unit_like_gameobject_owner_like_cpp(record: &MapObjectRecord) -> bool {
+    matches!(
+        record.kind(),
+        AccessorObjectKind::Player | AccessorObjectKind::Creature | AccessorObjectKind::Pet
+    ) && (record.player().is_some() || record.creature().is_some() || record.pet().is_some())
+}
+
+pub(crate) fn map_record_unit_like_cpp(record: &MapObjectRecord) -> Option<&Unit> {
+    match record.kind() {
+        AccessorObjectKind::Player => record.player().map(Player::unit),
+        AccessorObjectKind::Creature => record.creature().map(Creature::unit),
+        AccessorObjectKind::Pet => record.pet().map(|pet| pet.creature().unit()),
+        _ => None,
+    }
+}
+
+pub(crate) fn map_record_unit_mut_like_cpp(record: &mut MapObjectRecord) -> Option<&mut Unit> {
+    match record.kind() {
+        AccessorObjectKind::Player => record.player_mut().map(Player::unit_mut),
+        AccessorObjectKind::Creature => record.creature_mut().map(Creature::unit_mut),
+        AccessorObjectKind::Pet => record.pet_mut().map(|pet| pet.creature_mut().unit_mut()),
+        _ => None,
+    }
+}
+
+pub(crate) fn player_set_viewpoint_outcome_like_cpp(
+    player_guid: ObjectGuid,
+    target_guid: ObjectGuid,
+    apply: bool,
+    status: PlayerSetViewpointStatusLikeCpp,
+    set_world_object: Option<SetWorldObjectOutcomeLikeCpp>,
+    update_visibility_requested: bool,
+    set_seer_requested: bool,
+) -> PlayerSetViewpointOutcomeLikeCpp {
+    PlayerSetViewpointOutcomeLikeCpp {
+        player_guid,
+        target_guid,
+        apply,
+        status,
+        set_world_object,
+        update_visibility_requested,
+        set_seer_requested,
+    }
+}
+
+pub(crate) fn remove_spawn_id_index_entry_like_cpp(
+    index: &mut HashMap<SpawnId, HashSet<ObjectGuid>>,
+    spawn_id: SpawnId,
+    guid: ObjectGuid,
+) {
+    if spawn_id == 0 {
+        return;
+    }
+
+    if let Some(guids) = index.get_mut(&spawn_id) {
+        guids.remove(&guid);
+        if guids.is_empty() {
+            index.remove(&spawn_id);
+        }
+    }
+}
+
+pub(crate) fn snapshot_from_creature(
+    guid: ObjectGuid,
+    creature: &Creature,
+) -> CreatureTransformVitalsSnapshotLikeCpp {
+    let world = creature.unit().world();
+    CreatureTransformVitalsSnapshotLikeCpp {
+        guid,
+        map_id: world.map_id(),
+        instance_id: world.instance_id(),
+        position: world.position(),
+        combat_reach: world.combat_reach(),
+        health: creature.current_health(),
+        max_health: creature.max_health(),
+        is_alive: creature.is_alive(),
+        is_in_world: world.object().is_in_world(),
+    }
+}

--- a/crates/wow-world/src/session/mod.rs
+++ b/crates/wow-world/src/session/mod.rs
@@ -210,6 +210,7 @@ use wow_data::{
 };
 #[cfg(test)]
 use wow_entities::TitanGripPenaltyAction;
+use wow_entities::player_rules::is_using_two_handed_weapon_in_one_hand_template as two_handed_in_one_hand_like_cpp;
 use wow_entities::{
     AccessorObjectKind, ActiveState, ApplyEnchantmentArgs, ApplyEnchantmentDurationAction,
     ApplyEnchantmentEffectAction, ApplyEnchantmentEffectRef, ApplyEnchantmentGemRequirementRef,
@@ -13356,10 +13357,7 @@ impl WorldSession {
                 .resolved_inventory_item_like_cpp(EQUIPMENT_SLOT_OFFHAND)
                 .and_then(|item| self.item_storage_template(item.entry_id));
             let using_two_handed_weapon_in_one_hand =
-                Player::is_using_two_handed_weapon_in_one_hand_template(
-                    main_template.as_ref(),
-                    off_template.as_ref(),
-                );
+                two_handed_in_one_hand_like_cpp(main_template.as_ref(), off_template.as_ref());
 
             let Some(action) = self.canonical_player_snapshot_like_cpp(|player| {
                 let penalty_spell_id = player.titan_grip_penalty_spell_id();

--- a/tools/architecture/runtime-ownership-ledger.json
+++ b/tools/architecture/runtime-ownership-ledger.json
@@ -1393,9 +1393,9 @@
         },
         {
           "path": "crates/wow-map/src/map/mod.rs",
-          "production_lines": 16168,
-          "test_lines": 18728,
-          "total_lines": 34896,
+          "production_lines": 16055,
+          "test_lines": 18505,
+          "total_lines": 34560,
           "owner": "wow-map canonical MapManager/runtime.",
           "open_retirement_issues": [
             584
@@ -1454,9 +1454,9 @@
         },
         {
           "path": "crates/wow-entities/src/player/mod.rs",
-          "production_lines": 11374,
+          "production_lines": 11339,
           "test_lines": 10190,
-          "total_lines": 21564,
+          "total_lines": 21529,
           "owner": "wow-entities partial canonical Player model.",
           "latest_growth_review": "2026-09-09 #628: +6 test lines. player_tests.rs splits into 20 bounded scenario modules beside it, and each new file carries a module header and a use super::* line; the 176 test functions and their assertions are unchanged, the file drops from 9,497 to 501 lines and its ceiling is tightened to that figure. Production ownership is untouched. | 2026-09-06 deferred-save intent above bc3bdd2f: +46 production/+45 tests. Private deferred_save.rs owns a checked revision and pending bit on the same Player. The existing full-save receipt captures that revision and clears only matching confirmed intent; overflow is rejected. Three root lines declare/initialize the private owner. No timer, DB, packet or Session mirror is added; whole-lifetime and C4 remain open; session-578-checkpoint.md.",
           "open_retirement_issues": [


### PR DESCRIPTION
Fifth semantic vertical, applying #676's pattern to the other curated owners. Twelve receiver-free functions left two owners:

| owner | functions | production lines | total lines |
| --- | --- | --- | --- |
| `wow-entities/src/player` | 3 | 11,374 → 11,339 | 21,564 → 21,529 |
| `wow-map/src/map` | 9 | 16,168 → 16,055 | 34,896 → 34,560 |

Both ledger baselines are tightened to the validated figures. 725 `wow-entities` tests and 727 `wow-map` tests pass unchanged, as do `wow-world`'s 3,822.

## What the survey found, and what it cost

The first pass counted 111 candidates across six owners. Most were constructors: a receiver-free `fn new() -> Self` or `default()` is not a rule, it is the type's own vocabulary, and moving one produced 480 errors from names colliding across types. The detector now excludes anything whose signature mentions `Self` and any name defined on more than one type, which leaves 31 - and of those, only these twelve could move.

The rest did not, for reasons worth recording:

- The one `wow-social/src/group` candidate reads `PendingInvites`' private field. It is group-internal behaviour that happens to take no receiver, so moving it would have meant widening that field. Reverted.
- The 18 candidates in `handlers/{quest,character,loot}` read the quest owner's private vocabulary - 17 module-level `*_LIKE_CPP_LOCAL` constants and `super::`-relative paths. Moving the functions without that vocabulary turned constant match arms into *binding patterns*, which the compiler caught as E0408 rather than silently accepting. They need a delivery scoped to that owner, which can move the constants with them.

One rule crossed a crate boundary: `wow-world` calls `Player::is_using_two_handed_weapon_in_one_hand_template`, so that function is `pub` in a `pub mod player_rules` and the call site imports it under an alias, keeping the consumer's path length unchanged.

## Evidence

- Workspace build clean; architecture check, self-test, physical ratchet, hotspot ratchet and `session-ownership-check check --syntax-only` pass.
- `./tools/validation-v2 final --base origin/3.4.3` passed at 2ca4f7a7 (clean tree, aarch64 host).

No rule body, signature or call order changes; no state moves; no new crate edge. Three of the eight curated owners have now moved off their baselines. This closes neither #133 nor #584.

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)
