### PR TITLE
Restore ownership provenance and acceptance after module decomposition (#716)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,11 +133,12 @@ they are not separate frozen architecture snapshots.
   crates/wow-world/src/session/registry.rs and actual registrations for the current thunk
   signature; do not copy an outdated snippet or reintroduce a dispatcher opcode match.
   Keep exact-set metadata/registration tests for changes to that boundary.
-- #579/#586 are merged and #578/#585 closed. #588's approved deferred visibility
-  bridge is the current prerequisite for #587's remaining live acquisition acceptance.
-  Then complete required core macrodeliverables under #584, #583 and #153 before #133 closes.
+- #578/#585 and the integrated #587/#588/#589 deliveries are closed. The current
+  architecture plan and STATE.md own the selected delivery and its evidence; do not
+  infer current status from the older dated checkpoints. Complete required core
+  macrodeliverables under #584, then #583 and #153 before #133 closes.
   #133/#584 are umbrellas, not prerequisite implementations. #584 retains unfinished C0–C4;
-  closing #585 does not open #583 immediately. No family after #587 is selected.
+  closing a bounded predecessor does not open #583 immediately.
   Analyze each responsibility before defining its implementation macro,
   include cross-crate consumers and preserve scoped regression/live acceptance. These
   evidence reviews do not add routine approvals or authorize merge/runtime operations.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,8 @@ checkbox or an old percentage is not proof that the current server implements th
 | --- | --- |
 | What is implemented, integrated or still unproven? | [STATE.md](migration/STATE.md), its dated evidence boundaries and the active issue/checkpoint |
 | What do we execute next? | [PORT_PLAN.md](migration/PORT_PLAN.md) and [GitHub #49](https://github.com/alseif0x/rustycore/issues/49) |
-| What remains in the current architecture macro? | [#578 checkpoint](architecture/session-578-checkpoint.md) |
+| What remains in the current architecture delivery? | [Current core delivery](architecture/modularity-and-ecs-plan.md#current-core-delivery--2026-09-10) |
+| How should Claude continue the complete refactor? | [Refactor completion plan](architecture/refactor-completion-plan.md) |
 | What architecture and extension direction is approved? | [Modularity/ECS plan](architecture/modularity-and-ecs-plan.md) |
 | How should responsibilities and files be organized? | [Module design](architecture/module-design-guidelines.md) and [dependency/ownership boundaries](architecture/ownership-and-boundaries.md) |
 | What reported defects need current verification? | [EXISTING-CODE-DEFECTS.md](migration/EXISTING-CODE-DEFECTS.md) |

--- a/docs/architecture/modularity-and-ecs-plan.md
+++ b/docs/architecture/modularity-and-ecs-plan.md
@@ -53,8 +53,8 @@ graph proves no path to `inventory`, including renamed and target-specific depen
 Actual macro calls, exports, includes and registration aliases retain their checks;
 packages with registration capability keep the original strict namespace guard.
 Real-source bridge regressions share one complete syntax graph so missing fixture
-parents cannot masquerade as retired authority. The first run's 349 passed/4 failed
-result is diagnostic evidence only, not acceptance of the corrections that followed.
+parents cannot masquerade as retired authority. Nested cfg and block-local imports
+retain their lexical scopes, including non-authority shadows.
 
 The repaired syntax inventory preserves all 65 earlier bridge records exactly after
 the reviewed `pending_respawn` relocation and adds seven source-reviewed records,
@@ -77,10 +77,17 @@ retain `unresolved_dual_side`: syntactic dual references are not proof of two
 writers or of a particular transfer direction. No earlier obligation, fingerprint
 or evidence multiplicity was removed, and no persistence snapshot was regenerated.
 
-Acceptance after the complete implementation includes the analyzer library tests,
-syntax-only ownership, architecture check/self-test, preserved persistence-reference
-and snapshot-policy consistency, format/diff checks and affected validation-v2.
-Implementation is in progress; no new acceptance SHA is claimed here yet.
+**Local acceptance:** implementation is committed as
+`6ae62d73a9f910ebd664d82e331520b836a73c77`. The complete candidate passed 363
+analyzer library tests, syntax-only ownership, architecture check/self-test,
+preserved persistence-reference and snapshot-policy consistency, format/diff checks
+and validation-v2 quick (six commands, verified green manifest). Runs used the
+working candidate at parent `aff42a51`; the manifest truthfully records `dirty: true`.
+The tested code/policies were committed unchanged in `6ae62d73`; subsequent handoff
+edits only record documentation. Exact commands and evidence limits are in the
+[Claude handoff](refactor-completion-plan.md#9-estado-exacto-de-la-entrega-al-pasar-a-claude).
+This is local acceptance of #716, not publication, gameplay/runtime acceptance,
+terminal physical acceptance or closure of #584.
 
 The same review measures 31 files above 2,000 physical lines and 63 above 1,000.
 `physical-files --terminal` fails at this base. The completed mechanical passes are

--- a/docs/architecture/modularity-and-ecs-plan.md
+++ b/docs/architecture/modularity-and-ecs-plan.md
@@ -10,7 +10,121 @@ The finite pre-migration conformance has passed as recorded in the V2 evidence;
 production storage integration and SDK acceptance remain distinct and unfinished.
 Storage/module choices and the full #133 outcome are unchanged.
 
+## Current core delivery — 2026-09-10
+
+The user-requested [complete continuation plan for Claude](refactor-completion-plan.md)
+collects the diagnosis, target organization, P0–P6 delivery order and handoff evidence.
+This document retains the canonical semantic/SDK contracts; the continuation plan
+does not turn its pending tasks into accepted results.
+
+The user approved starting the architecture repair program reviewed on integrated
+`3.4.3` at `aff42a5166530de948cc3b1b94dc4e813c538bff`. #587/#588/#589 are integrated
+and closed. Their checkpoints retain their scoped runtime/capture evidence; they
+are not reopened by the remaining core work or by naming preferences.
+
+**#716 — restore ownership provenance and acceptance after module decomposition**
+is the first implementation delivery under #584. Its scope is the analyzer, the
+exact reviewed inventories and the current design/status guidance. No gameplay,
+SQL, packet, scheduling or runtime operation changes belong to this delivery.
+
+At the reviewed HEAD, the general architecture check and its self-tests pass, but
+the syntax-only Session ownership check fails. Two ten-argument `WorldSession::new`
+fixture sites moved to `battle_pet_purchase::executor_tests::fixtures::session` and
+`handlers::misc::tests::world` without their baseline scopes. The third failure is
+not a retired bridge: #711 moved `world_creature_from_pending_respawn_like_cpp` into
+`map_manager/pending_respawn.rs` unchanged, where `use super::*` hides the parent's
+explicit `wow_entities::Creature` import from the file-local bridge symbol resolver.
+The function still constructs canonical `Creature` and converts it to `WorldCreature`.
+
+The repair resolves supported lexical imports against the supplied logical module
+graph, preserving exact authority provenance, local shadowing, cfg and multiplicity.
+An unresolved relevant import must not silently become absence of authority. Keep
+external authority globs rejected and do not classify every identifier named
+`Creature` as canonical. Tests cover root/inline/external moves, aliases, local
+non-authority names, missing/ambiguous context and conditionally present imports.
+Review each restored/new bridge record; a smaller generated baseline is not a repair.
+
+The first library acceptance run also exposed a separate false positive from the
+physical pass: `wow-persistence/src/player/mod.rs` declares and reexports its local
+`inventory` data module. The registration guard treated that spelling as the external
+registration crate. #716 now distinguishes that narrow local declaration/glob only
+outside the handler registry closure and when Cargo's resolved normal dependency
+graph proves no path to `inventory`, including renamed and target-specific dependencies.
+Actual macro calls, exports, includes and registration aliases retain their checks;
+packages with registration capability keep the original strict namespace guard.
+Real-source bridge regressions share one complete syntax graph so missing fixture
+parents cannot masquerade as retired authority. The first run's 349 passed/4 failed
+result is diagnostic evidence only, not acceptance of the corrections that followed.
+
+The repaired syntax inventory preserves all 65 earlier bridge records exactly after
+the reviewed `pending_respawn` relocation and adds seven source-reviewed records,
+each with multiplicity one. Six production methods receive canonical `Creature`
+through parent imports while their `Self` is legacy `WorldCreature`:
+
+| Source at reviewed base | Recovered method |
+| --- | --- |
+| `map_manager/movement/motion_master.rs:9` | `new_runtime_motion_master_like_cpp` |
+| `map_manager/runtime/creature.rs:8` | `runtime_default_generator_like_cpp` |
+| `map_manager/runtime/creature.rs:47` | `new` |
+| `map_manager/runtime/creature.rs:126` | `from_canonical` |
+| `map_manager/runtime/creature.rs:180` | `create_data_from_canonical_like_cpp` |
+| `map_manager/runtime/creature.rs:274` | `from_loaded_grid_canonical_like_cpp` |
+
+The seventh is `session/deferred_visibility/tests.rs:33`, `Fixture::new`, whose
+canonical and legacy map managers are constructed at lines 51 and 53; it retains
+`cfg(test)`. Paths in this table are relative to `crates/wow-world/src`. All seven
+retain `unresolved_dual_side`: syntactic dual references are not proof of two
+writers or of a particular transfer direction. No earlier obligation, fingerprint
+or evidence multiplicity was removed, and no persistence snapshot was regenerated.
+
+Acceptance after the complete implementation includes the analyzer library tests,
+syntax-only ownership, architecture check/self-test, preserved persistence-reference
+and snapshot-policy consistency, format/diff checks and affected validation-v2.
+Implementation is in progress; no new acceptance SHA is claimed here yet.
+
+The same review measures 31 files above 2,000 physical lines and 63 above 1,000.
+`physical-files --terminal` fails at this base. The completed mechanical passes are
+useful evidence, not completion of physical navigability. Keep both logical-owner
+and physical-file measures; a reviewed wiring delta does not retire semantic debt.
+The [module-design correction](module-design-guidelines.md#what-a-physical-division-cannot-reach)
+replaces the blanket single-item/operation prohibition with responsibility-preserving
+delegation, explicit imports and scenario names at each completed family.
+
+The next represented-operation candidate is **quest reward**, because its Session
+coordinator grants/persists participants separately and discards status-save outcomes.
+Before implementation, freeze the complete operation and compare a coherent character
+transaction with durable staged recovery where participants require it. Current source
+anchors are `handlers/quest/rewards.rs::reward_represented_quest_with_generator_like_cpp`
+and `handlers/quest/persistence.rs::save_quest_to_db`; Classic reference
+`a5f8da2ebf5424bf0450ca4e08843ecbf72577bd` has `QuestHandler.cpp:398`,
+`Player.cpp::RewardQuest:14625`, its `SaveToDB(false):14867`, and the character
+transaction in `SaveToDB:19312`. Reward mail has a separate transaction at `14794`;
+do not infer one global C++ transaction or hide an intentional durability repair in a move.
+Its acceptance must cover partial grants, unknown COMMIT, cancellation, recovery,
+restart/relogin, retry and ordered publication with all affected consumers.
+
+The initial source contrast also bounds that next design:
+
+| Participant | Current represented boundary | Consequence for the complete operation |
+| --- | --- | --- |
+| Client reward and tracking-event auto reward | `handlers/quest/handlers.rs` and `handlers/quest/state.rs` reach the same reward coordinator | Both admissions, and the objective-progress drain that follows success, belong to the migration. |
+| Required items/currencies and fixed/chosen/package grants | The coordinator awaits the participants in sequence; individual item grants can already commit before a later failure | Define the whole participant set and failure/retry contract before moving orchestration; returning `false` is not rollback. |
+| Quest status and repeatable deletion | `handlers/quest/persistence.rs` logs `Failed`/`Unknown` and returns `()`; `wow-database/src/player/quest_adapter.rs` commits each request separately | Preserve this as an identified pre-existing behavior gap until an explicit repair contract replaces it. |
+| Full character save | `PlayerCharacterSaveRequestLikeCpp` in `wow-persistence/src/player/save.rs` covers character/spell/skill and other groups, but has no quest, inventory or currency group | Calling the existing full-save helper cannot by itself make quest rewards coherent; all affected persistence consumers must participate. |
+| Mail and observable publication | Rust's `record_represented_quest_reward_mail_like_cpp` only records test evidence and is a production no-op. Classic commits reward mail separately, sends the reward and executes further effects before `SaveToDB(false)` | Keep the unimplemented mail participant explicit and record separate durability boundaries and actual message/effect order; universal commit-before-publication would be an intentional behavior change. |
+
+This is source-based design preparation, not a selected transaction protocol or new
+runtime acceptance. It does not authorize a silent durability repair inside #716.
+
+Then complete the remaining analyzed #584 operation/lifetime and map-phase/storage
+deliveries. Physical organization, scoped fixture migration and dependency disposition
+accompany each responsibility; the later #583 SDK does not inherit those core debts.
+Preserve required #584 core → #583 → #153 → #133 and the post-M6.2 whole-port review.
+The approved program grants no new push, merge, deployment or live-database authority.
+
 ## Next core candidate — 2026-09-08
+
+This dated section preserves the delivered #589 design; current selection is above.
 
 The user approved **#589 — represented Player cast-request lifecycle** on
 2026-09-08 after localized source review at `cc8a8e97`. It is now **implemented
@@ -190,21 +304,23 @@ evade a ceiling.
 
 ### What relocation cannot do — three findings that bound the track
 
-**A curated hotspot cannot be reduced by relocation.** The runtime-ownership
-ratchet measures the module aggregate, and all eight owners sit at their
-baseline. Splitting a file inside one adds module headers and re-export wiring,
-so the aggregate grows and the ratchet correctly rejects the change. #636
-recorded this for `wow-entities/src/player`, #644 for `wow-map/src/map` and #654
-for `handlers/{character,loot,quest}`; each file keeps its ceiling with the
-reason in its policy row.
+These are dated observations of the mechanical pass. The #716 correction above
+and the module-design guide govern further decomposition and terminal acceptance.
 
-**Splitting a bridge function's context narrows the audit.** The bridge
-inventory pairs canonical-side and legacy-side evidence *within one enclosing
-module*. Moving `world_creature_from_pending_respawn_like_cpp` out of
+**Relocation does not retire a logical owner.** The runtime-ownership ratchet
+measures its aggregate, so a private split adds wiring while retaining that debt.
+#636 recorded this for Player, #644 for Map and #654 for character/loot/quest
+handlers. Review the wiring delta and the benefit of the proposed physical boundary;
+do not infer from the aggregate that private decomposition must stop.
+
+**A source move must preserve bridge detection.** The bridge inventory pairs
+canonical-side and legacy-side evidence within one enclosing item, using resolved
+symbols from its lexical context. Moving `world_creature_from_pending_respawn_like_cpp` out of
 `crate::map_manager` dropped it from the 65-row inventory while the build and
 all 3,822 `wow-world` tests stayed green (#662). Only the ownership baseline
-diff caught it, so the split was reverted. A green build is not evidence that a
-scanner still sees what it saw.
+diff caught it, so that split was reverted. #711 later exposed the same import
+resolution limit in the integrated tree; #716 repairs that coverage. A green build
+does not establish that a scanner still sees the same actual bridge.
 
 **Visibility must be derived from the item's original reach, not from a rule.**
 `pub(super)` denotes a different scope at each depth; a glob re-export silently
@@ -218,7 +334,8 @@ underscore-prefixed names.
 
 ### Semantic track entry conditions
 
-116,693 lines remain above 2,000 lines in 33 files, all in four categories:
+The dated first-pass inventory reported 116,693 lines above 2,000 in 33 files;
+use the current measured inventory above for present sizes and terminal status:
 
 | Owner | Lines | What it needs |
 | --- | --- | --- |
@@ -235,9 +352,11 @@ underscore-prefixed names.
 | capture fixture shell scripts | 7,992 | Runtime swap, dump provenance and recovery orchestration, with the existing capture safeguards and runtime authorization preserved |
 | vendored `DetourNavMeshQuery.cpp` | 3,663 | Out of scope: third-party C++ carried verbatim |
 
-Each of the first ten needs a responsibility to *leave* its owner, which is
-#584's C0-C4 work and requires the ownership ledger and the hotspot baseline to
-move together. The physical track deliberately did not attempt it.
+These files retain #584 C0-C4 responsibility and physical acceptance. Some need
+semantic extraction; others can improve through private delegation within the same
+legitimate owner. Decide from their contracts and consumers, and reconcile the exact
+inventory/ceilings together. Vendor code still needs its file-specific disposition
+for terminal acceptance; its presence is not permission to modify upstream blindly.
 
 ## 1. Outcome and current evidence
 

--- a/docs/architecture/module-design-guidelines.md
+++ b/docs/architecture/module-design-guidelines.md
@@ -101,36 +101,42 @@ and physical splitting alone must not remove logical ownership debt.
 
 ### What a physical division cannot reach
 
-Three limits are measured, not opinions. Reaching them means the remaining work is
-semantic, and the honest move is to record the file with its reason instead of
-inventing a split.
+**Review correction, 2026-09-10, #716:** the earlier examples describe limits of
+item relocation, not proof that useful private decomposition is impossible. Preserve
+their measurements without treating a parser item or a LOC ceiling as the design owner.
 
-**A single item is the floor.** A file whose bulk is one `enum`, one `match` or one
-trait impl cannot become modules without changing the type or the trait's shape. Rust
-allows any number of *inherent* impl blocks per type - which is how #705 and #707
-divided a 2,069-line `impl WorldCreature` and a 1,408-line `impl WorldSession` - but
-exactly one impl per (trait, type). So `statements/character/identities.rs` (1,789
-lines, one `CharStatements` enum), `statement_def.rs` (1,627, one `match` over it) and
-`player/lifecycle_adapter.rs` (1,609, one `impl PlayerLifecyclePortLikeCpp`) stay until
-their responsibility is cut semantically.
+**Keep one implementation while delegating cohesive work.** Rust's single applicable
+trait impl can contain short methods that delegate to private modules without changing
+the trait, type or state owner. `player/lifecycle_adapter.rs` already has `economy`,
+`login_reads` and `save_plan` children; its bodies can use those responsibilities.
+An exhaustive `match` can retain its dispatch and delegate branch bodies. A large
+`CharStatements` enum may instead justify a cohesive file-specific exception. Evaluate
+these cases separately; a single item does not establish a blanket exemption.
 
-**Inside a curated hotspot, relocation is measured, not free.** The hotspot ratchet
-counts the module aggregate, so moving a file into an owner - or adding the wiring a
-division needs *inside* one - grows the number being measured. #713 measured the floor:
-dividing the loot and quest fixture roots worked and still cost those aggregates +63 and
-+43 test lines at the cheapest wiring available, about seven lines per new module for a
-doc line, `use super::*;`, the `#[path]` mount pair and one glob. #697 left
-`wow-world/player_cast` flat for the same reason at a smaller scale: two characters of
-extra path made rustfmt re-wrap three call sites, +6 lines on the session aggregate.
-A delivery whose subject *is* an owner's shape can still proceed with an explicit
-reviewed delta - #699 recorded +12 production lines in `world-server` and #703 gave one
-back - but that is a decision to record, never a side effect to absorb.
+**Review wiring growth without erasing semantic debt.** The hotspot ratchet counts
+the whole owner, so private module declarations/imports and formatting can raise its
+physical line total even when operations are unchanged. #713 measured +63/+43 test
+lines for loot/quest fixture splits; #697 recorded +6 Session lines from path wrapping.
+Those are costs to review, not evidence that the new module boundary is wrong. An
+explained delta may update only the affected ceiling while preserving the logical owner,
+its complete descendants and retirement obligation, as the existing policy permits.
+Keep the before/after evidence; never reset all baselines or count relocation as retired
+gameplay ownership. Adding a helper does not require a new issue or approval round.
 
-**A single operation stays whole.** An 865-line
-`handle_void_storage_transfer_with_generators_like_cpp` (#707) or a 1,086-line
-`session/spell_effects/execution.rs` entry point (#621) is one C++-mirroring operation.
-Cutting it into pieces is a behaviour question, so it stays whole and its group stays
-within the budget instead.
+**Keep one operation coordinator and its ordering contract.** Long operations such as
+`handle_void_storage_transfer_with_generators_like_cpp` and the spell-effects executor
+can extract cohesive private phases while retaining one coordinator, authority and
+transaction/publication sequence. Review captured values, borrows, cancellation, early
+returns and failure paths before extraction. If a faithful split is unclear, retain a
+specific bounded exit; do not infer that the operation must remain one physical function.
+
+**Names and imports are part of navigability.** New private files name a rule, operation,
+adapter or scenario. `state_1`, `ops_2` or `scenarios_14` is a temporary relocation label
+unless its number has domain meaning. Reunite definitions and operations by responsibility
+when completing the family. Prefer explicit production imports and deliberate facade
+exports; `use super::*` in a small test or a transitional `#[path]` mount can remain when
+its real dependencies, visibility and analyzer coverage are preserved. Do not widen state
+visibility merely to make a split compile or replace these criteria with a zero-glob quota.
 
 ## 4. Tests and a complete operation
 
@@ -303,7 +309,7 @@ changes; workspace Rust additionally retains its independent logical ratchet. Ch
 the physical module/policy run its adversarial unit suite during `quick`; changes to the
 shared checker/scanner run the existing architecture self-test. Macro closeout must also
 run `physical-files --terminal`; it is deliberately not the daily migration gate. All
-remaining physical splits still belong to #578, not #583/#153.
+remaining core physical splits belong to #584, not #583/#153.
 
 ## 7. Evidence and design references
 

--- a/docs/architecture/ownership-and-boundaries.md
+++ b/docs/architecture/ownership-and-boundaries.md
@@ -1,10 +1,12 @@
 # RustyCore ownership and dependency boundaries
 
-**Current selection, 2026-09-08:** #585 closed through #586 at `8c47af95`.
-#587's acquisition boundary is implemented locally; approved #588 completes its
-deferred visibility runtime prerequisite before acquisition live acceptance resumes.
-The #588 checkpoint owns that finite contract. Required #584 core still precedes
-#583, then #153 and #133 closure; no later implementation family is selected.
+**Current selection, 2026-09-10:** #587/#588/#589 are integrated and closed. The
+user approved the architecture repair program reviewed at `aff42a51`; #716 first
+restores ownership-provenance detection and exact acceptance after physical moves.
+The [current plan](modularity-and-ecs-plan.md#current-core-delivery--2026-09-10)
+owns its contract and remaining work. Required #584 core still precedes #583,
+then #153 and #133 closure. A completed mechanical pass is not terminal ownership
+or physical acceptance.
 
 **Delivery revision, user-approved 2026-09-06:** #578/#579 is the bounded delivered
 canonical-owner foundation/hardening closeout. All unfinished C0–C4 ownership,
@@ -1012,10 +1014,12 @@ display is checked against the JSON ledger:
 122. #378 — classify the remaining Session application modules; inherited implementation stays in the following ownership macro;
 123. #578 — closed canonical Player/Map foundation, merged through PR 579.
 124. #585 — closed represented session finalization outcomes and retirement supervision, merged through PR 586.
-125. #588 — approved deferred player visibility publication, a runtime prerequisite exposed by acquisition QA.
-126. #587 — represented spell-acquisition application boundary; resume live acceptance after deferred visibility.
-127. #583 — native/Wasm gameplay modules after all required core children of the coordination epic, not immediately after finalization.
-128. #153 — terminal architecture audit.
+125. #588 — closed deferred player visibility publication with scoped runtime acceptance.
+126. #587 — closed represented spell-acquisition application boundary.
+127. #589 — closed represented Player cast-request lifecycle, integrated with its predecessors.
+128. #716 — restore ownership provenance and exact acceptance after module decomposition.
+129. #583 — native/Wasm gameplay modules after all required core children of the coordination epic, not immediately after finalization.
+130. #153 — terminal architecture audit.
 
 A slice may start once its declared prerequisites are merged and its branch is current. Independent
 physical work remains parallel to semantic authority cuts. Mechanical moves use focused compile and

--- a/docs/architecture/refactor-completion-plan.md
+++ b/docs/architecture/refactor-completion-plan.md
@@ -1,0 +1,456 @@
+# Plan completo para terminar el refactor de RustyCore
+
+Fecha: 2026-09-10. Destinatario: Claude o el siguiente agente que continúe el trabajo.
+
+## 1. Objetivo y alcance
+
+Terminar una arquitectura en la que cada operación tenga un propietario claro,
+dependencias explícitas y archivos comprensibles. Revisar organización, nombres,
+módulos, submódulos, crates, pruebas, persistencia, composición, runtime y extensión.
+El objetivo no es conservar la forma actual ni producir más archivos pequeños.
+
+Se mantiene la paridad funcional completa con el servidor TrinityCore derivado de
+WoW 3.4.3. Separar archivos, tener tests o guardar el estado dentro de Player no
+demuestra por sí solo que una responsabilidad esté correctamente implementada.
+No reducir silenciosamente el port a las operaciones actualmente representadas.
+
+El usuario pidió una revisión independiente, aprobó empezar a corregirla y pidió
+este plan completo para poder continuar con Claude. La entrega activa es #716,
+la reparación de las herramientas de aceptación y de las reglas de diseño. La
+implementación de gameplay posterior requiere primero el contrato de su operación;
+una reparación intencional de comportamiento no se disfraza de refactor mecánico.
+
+Este documento es el plan de continuación solicitado. La política semántica y los
+contratos del SDK siguen en [modularity-and-ecs-plan.md](modularity-and-ecs-plan.md);
+las mediciones actuales y sus límites siguen en [STATE.md](../migration/STATE.md).
+Actualizar esos documentos cuando cambie su materia, sin mantener estados rivales.
+
+## 2. Punto de partida y entorno que se debe conservar
+
+- Repositorio: `/home/server/rustycore`; integración: `3.4.3`.
+- Revisión inicial realizada sobre `aff42a5166530de948cc3b1b94dc4e813c538bff`,
+  actualizado desde `origin/3.4.3`, no sobre la antigua rama local de #587.
+- Worktree de implementación: `/tmp/rustycore-architecture-716`.
+- Rama: `716-archcore-restore-ownership-provenance-and-acceptance-after-module-decomposition`.
+- Issue activo: [#716](https://github.com/alseif0x/rustycore/issues/716), dentro de #584.
+- El checkout original conserva cambios ajenos en
+  `docs/architecture/modularity-and-ecs-plan.md`, `docs/migration/STATE.md` y
+  `docs/architecture/lfg-343-audit.md`. No copiarlos, descartarlos ni incorporarlos
+  automáticamente a esta entrega.
+- Referencia Classic: `/home/server/woltk-trinity-legacy`, revisión contrastada
+  `a5f8da2ebf5424bf0450ca4e08843ecbf72577bd`.
+- Referencia complementaria autorizada: `/home/server/azerothcore-wotlk-reference`.
+  Consultar su pin/cobertura en `docs/README.md`; 3.3.5a no sustituye wire/SQL 3.4.3.
+- Toolchain: el declarado en `rust-toolchain.toml` y `Cargo.toml`.
+  Host aarch64; `PROTOC=/home/ubuntu/.local/protoc/bin/protoc`.
+
+Antes de continuar, verificar el estado real del worktree, sus procesos y el SHA:
+
+```bash
+cd /tmp/rustycore-architecture-716
+git status --short --branch
+git log --oneline --decorate -8
+sed -n '1,80p' docs/migration/STATE.md
+```
+
+Leer `AGENTS.md`, la skill de arquitectura y la de refactor seguro cuando corresponda.
+No hacer `reset`, sobrescribir archivos ni cambiar de rama en el checkout sucio para
+obtener una apariencia limpia. Este plan no concede permiso de push, merge, despliegue,
+reinicio ni escritura en bases de datos reales. Preparar el resultado local revisable
+antes de solicitar la autorización externa que todavía haga falta.
+
+## 3. Diagnóstico que justifica el plan
+
+Mediciones del SHA de revisión; volver a medir cuando cambie el código relevante:
+
+| Área | Evidencia | Implicación |
+| --- | --- | --- |
+| Dependencias | 38 paquetes, 101 aristas internas, 57 dependencias externas vigiladas; 15 excepciones internas y 2 externas | Hay separación física, pero cada excepción necesita una disposición semántica. |
+| Session | 221 campos de producción y 427 de fixtures; agregado lógico de 191.799 líneas, 83.158 de producción y 108.641 de pruebas | No confundir los 648 campos totales con 648 campos de producción. Mover impls no retira ownership. |
+| Tamaño físico | 63 archivos por encima de 1.000 líneas; 31 por encima de 2.000 | El modo migración pasa, pero el modo físico terminal falla. |
+| Nombres e imports | 465 nombres de fuentes numerados; abundancia de `use super::*`, reexports generales y montajes `#[path]` | La fragmentación ha conservado agrupaciones arbitrarias y dependencias poco visibles. |
+| Bridge perdido por el analizador | `world_creature_from_pending_respawn_like_cpp` pasó a `map_manager/pending_respawn.rs`, conservando el cuerpo y `use super::*` | El analizador anterior perdía el import canónico del padre. Una baseline menor habría ocultado deuda viva. |
+| Estado canónico | Player almacena estado, pero `player/vitals.rs::gameplay_state_mut` permite reglas y mutaciones externas desde Session | La ubicación del dato no basta: trasladar también invariantes y transiciones. |
+| Recompensa de misión | Concesiones persistidas por separado; el guardado de estado de misión descarta `Failed`/`Unknown` | Hay riesgo de operaciones parciales y reintentos; necesita un contrato completo. |
+| Runtime | Seis relojes trazados; fases repartidas entre Session, runtime canónico y legacy | No se ha probado doble ejecución. Hay que contrastar llamadas y orden real antes de consolidar. |
+| Extensión | Existe integración nativa acotada de login; no cierra el contrato estatal nativo/Wasm de #583 | La presencia del SDK o un ejemplo no equivale a la aceptación completa. |
+
+Conservar los logros que sí tienen contratos útiles: residencia e incarnation canónicas,
+proyecciones y reconocimiento de guardado, cuarentena ante COMMIT desconocido del
+guardado completo, fencing de dinero, lifecycle de cast y registro único de handlers.
+Las entregas #578, #585, #587, #588 y #589 están integradas y cerradas en sus alcances.
+No reabrirlas por preferencia nominal ni declarar que cierran todo #584.
+
+## 4. Reglas de la estructura objetivo
+
+1. **Player/Map poseen estado e invariantes.** Una transición completa tiene una
+   autoridad mutable; eliminar lectores/escritores antiguos al migrarla. No crear un
+   segundo espejo de Player, locks adicionales o campos públicos para facilitar el movimiento.
+2. **La aplicación coordina la operación.** Recibe capacidades concretas; no una
+   Session completa ni un contexto universal. Coordina admisión, planificación,
+   persistencia y publicación según el contrato real de esa operación.
+3. **El handler adapta el protocolo.** Decodifica, aplica la admisión de sesión y
+   llama al caso de uso. Conservar opcode, conexión, metadatos, bytes y orden observables.
+4. **Persistencia expresa datos y resultados.** `wow-persistence` conserva contratos
+   sin SQLx; `wow-database` implementa SQL/transacciones. Las reglas de gameplay no
+   deben requerir transporte, SQL o un writer para evaluarse.
+5. **Composición construye y supervisa.** `world-server` conecta recursos y tareas;
+   mantiene una secuencia visible de arranque, cierre y tratamiento de errores.
+6. **Submódulos privados antes que crates.** Crear un crate solo cuando una dependencia,
+   superficie pública o consumidor real justifique la frontera. No un crate/trait por helper.
+7. **El propietario lógico y el archivo físico se evalúan por separado.** Un agregado
+   válido puede tener varios archivos privados. Una raíz pequeña con cientos de impls
+   de Session repartidos continúa siendo una responsabilidad distribuida de Session.
+8. **Conservar un coordinador no exige una función gigante.** Un único trait impl o
+   match puede delegar fases cohesivas. Un incremento explicado de imports/montajes
+   puede aceptarse con una modificación puntual de su techo, conservando toda la deuda.
+
+Los límites numéricos y excepciones vinculantes están en
+[module-design-guidelines.md](module-design-guidelines.md). Los 1.000/2.000 de esta
+revisión son indicadores de revisión y cierre, no permiso automático para nuevos
+archivos de ese tamaño. Aplicar también los presupuestos de archivos nuevos, tests y fixtures.
+
+### Árbol orientativo, no orden de traslado masivo
+
+```text
+wow-world/src/
+  session/                 conexión, admisión, dispatch, adaptación y lifecycle
+  handlers/quest/          accept, reward, abandon, share: adaptación de paquetes
+  quest/
+    application/           operaciones completas y sus resultados
+    presentation/          intención de publicación -> protocolo/destinatarios
+    tests/                 escenarios de operación y recuperación
+  spell/                   cast y acquisition: reunir cuando se migren sus consumidores
+  player/                  partes del Player canónico que hoy residen en wow-world
+  legacy_runtime/          nombre explícito mientras queden obligaciones legacy
+wow-entities/src/
+  player/                  reglas/estado de subdominios que no dependan de Session o SQL
+wow-map/src/
+  manager/player_owner/
+  map/                     fases, visibilidad, respawn, almacenamiento privado
+wow-persistence/src/
+  player/                  proyecciones y contratos de carga/guardado
+  quest_reward/            solo si el contrato durable de la operación lo exige
+wow-database/src/
+  player/lifecycle_adapter/ un impl delgado, helpers por lectura/guardado/economía
+  quest_reward/            implementación SQL de ese contrato
+world-server/src/
+  app.rs                   secuencia de composición comprensible
+  bootstrap/               bases de datos, catálogos, realm
+  runtime/                 mapas, sesiones, respawn writer, cierre
+tools/wow-test-bot/src/
+  runner/
+  client/
+  scenarios/               login, quest, void_storage, spell_cast...
+```
+
+Elegir la ubicación final de cada parte de Player mediante sus dependencias y su
+autoridad actual. El árbol no autoriza copiar el Player de `wow-world` a
+`wow-entities`, duplicarlo ni trasladarlo entero sin migrar consumidores.
+Respetar las fronteras de cast/acquisition entregadas mientras se gana una agrupación mejor.
+
+## 5. Secuencia de ejecución y criterios de cierre
+
+### P0 — Recuperar confianza en las herramientas y reglas de aceptación (#716)
+
+**Trabajo de esta entrega:**
+
+- Resolver imports de módulos por grafo lógico suministrado, incluidos padres,
+  globs relativos, alias y `cfg`; mantener sombreado local y aislamiento entre paquetes.
+- Detectar contexto relativo faltante y ciclos relevantes; un cambio de nombre o
+  de fichero no puede hacer desaparecer una autoridad del inventario.
+- Mantener la prohibición de globs externos opacos capaces de ocultar autoridad.
+- Trasladar exactamente las dos ubicaciones de fixtures de `WorldSession::new`
+  y la ubicación del bridge de `pending_respawn`, conservando huella y multiplicidad.
+- Reparar la confusión entre el módulo de datos `inventory` y el crate de registro,
+  con prueba de dependencias y manteniendo la prohibición de alias de registro reales.
+- Corregir la falsa prohibición de separar un trait impl; revisar solo los incrementos
+  puntuales de montaje/fixtures y actualizar los punteros de entregas ya cerradas.
+- Compartir un grafo completo de fuentes entre las pruebas que verifican el repositorio.
+- Conservar los 65 registros anteriores tras la reubicación y añadir los siete accesos
+  existentes recuperados por el analizador: seis métodos de WorldCreature y una fixture
+  de visibilidad. Sus anclas y límites están en la entrega actual del plan semántico.
+
+**Aceptación:** pruebas de la herramienta, ownership sintáctico, checks/self-tests de
+arquitectura, referencias de persistencia preservadas, consistencia snapshot/policy,
+formato, diff y perfil local aplicable. Comparar el conjunto exacto de bridges, no su
+cantidad solamente. Revisar individualmente cualquier acceso adicional que aparezca.
+
+**Límite:** P0 no cambia el servidor, SQL, packets ni tareas runtime. No cierra la deuda
+física terminal ni las operaciones de gameplay. El estado ejecutado se registra en la
+sección 9; no asumir que una tarea de esta lista está aceptada solo por aparecer descrita.
+
+### P1 — Recompensa de misión como primera operación completa
+
+**Seleccionar primero el contrato**, sin empezar por mover `rewards.rs`:
+
+1. Trazar todos los callers: entrega de recompensa en
+   `handlers/quest/handlers.rs`, auto recompensa de tracking events en
+   `handlers/quest/state.rs`, y el drenaje posterior de progreso de objetivos.
+2. Inventariar participantes: objetivos/items a consumir, timed quest, recompensa
+   fija/elegida/paquete, monedas, oro, XP/nivel, skill, títulos/talento, reputación,
+   lockouts, estado activo/recompensado, spells, correo, game events y publicación.
+3. Contrastar Classic: `QuestHandler.cpp:398`, `Player.cpp::RewardQuest:14625`,
+   `SaveToDB(false):14867`, transacciones de `SaveToDB:19312` y sus grupos desde
+   `19632`. El correo tiene una transacción aparte en `14794`.
+4. Registrar divergencias existentes antes de cambiar comportamiento. Rust concede
+   items secuencialmente; `save_quest_to_db` devuelve `()` tras fallos/desconocidos.
+   El comentario del fallo de oro evita dejar retryable una misión tras concesiones:
+   no retirar esa protección como si fuera una simple limpieza.
+5. Comparar una transacción coherente de personaje con una operación durable por
+   etapas. Elegir según participantes, recuperación, coste y fidelidad; no inventar
+   una transacción global entre correo, cuenta y personaje.
+6. Definir una tabla de estados: admitida, preparada, escritura enviada, commit
+   conocido/rollback/desconocido, aplicación canónica, publicación y recuperación.
+   Para cada estado: dueño, cancelación, reintento, disconnect/transfer y relogin.
+7. Revisar el diseño concreto cuando haya una decisión material de comportamiento;
+   conservar las partes no conflictivas ya autorizadas y no pedir permiso por helpers.
+
+**Limitaciones que ya están contrastadas:**
+
+- `PlayerCharacterSaveRequestLikeCpp` no incluye misiones, inventario ni monedas.
+  Llamar al full save actual no crea atomicidad para la recompensa.
+- `record_represented_quest_reward_mail_like_cpp` solo registra evidencia en tests;
+  en producción es un no-op. No presentarlo como correo implementado tras moverlo.
+- Classic publica la recompensa y ejecuta otros efectos antes de su guardado final.
+  Imponer siempre commit antes de publicación sería un cambio intencional.
+- El port completo de lo no representado sigue abierto aunque se cierre la frontera
+  arquitectónica de las partes existentes. Identificar participantes no implementados.
+
+**Implementación:** invariantes en Player/subdominios; coordinación privada de la
+operación; puertos de persistencia concretos; adaptador SQL; handler/presentación.
+Una proyección no constituye un segundo propietario. Migrar también la entrada
+automática, los lectores/reintentos y consumidores de resultados; retirar el camino anterior.
+
+**Pruebas y cierre:** éxito normal, recompensa elegida/inválida, inventario lleno,
+repetible/no repetible, lockouts, fallo después de la primera concesión, rollback,
+COMMIT desconocido de item/estado/oro, cancelación, residencia obsoleta, restart/relogin
+y reintento sin duplicación. Conservar orden y destinatarios de publicación. Las
+afirmaciones de durabilidad exigen evidencia real DB/reinicio, con autorización runtime.
+
+### P2 — Completar las otras fronteras del núcleo por operaciones
+
+No fijar una cola por números de issue ni extraer campos sueltos. Después de P1,
+elegir la siguiente macro por sus consumidores y dependencias reales:
+
+| Familia | Trazado mínimo | Evidencia de cierre |
+| --- | --- | --- |
+| Inventario/vendor/loot | planificación, reservas, persistencia, aplicación, publicación y reintentos de la operación completa | Un propietario de items/oro; ninguna concesión perdida/duplicada por fallo parcial; retirada de mutadores generales afectados. |
+| Progresión/spells/effects | callers directos e indirectos, Player/Unit, lanzamiento/cancelación y efectos dependientes | Reutilización de acquisition/cast entregados; invariantes fuera de Session; metadata y orden preservados. |
+| Social y grupos | owner de grupo, registro, sesión, lifecycle y fanout | Sin dobles escritores ni datos derivados confundidos con autoridad; backpressure y desconexión tratados. |
+| Cuenta, carga y guardado | personaje/cuenta, ownership durante carga/transfer, fencing, acknowledge y estado desconocido | No perder revisiones nuevas ni reanudar una sesión cuyo commit siga incierto; consumidores de login/logout migrados. |
+| Otras reglas representadas | cada uso de acceso mutable amplio, setters y closures sobre gameplay state | Lista completa de lectores/escritores migrados y eliminación o excepción acotada del acceso anterior. |
+
+No dar por retirado `gameplay_state_mut` cambiándole de archivo. Reducir sus usos al
+cerrar cada familia y reemplazarlos por transiciones de dominio con inputs/resultados
+concretos. Mantener los accesos de carga/hidratación explícitos y separados de reglas activas.
+
+### P3 — Fases de ejecución, lifetime y almacenamiento real
+
+- Releer composición: `world-server/src/app.rs`, `runtime/*`, fábrica de sesiones y
+  `wow-world/src/session/driver`. Contrastar `wow-map` y runtime legacy con `Map.cpp`.
+- Dibujar quién ejecuta cada fase, dónde se admite al actor, qué reloj usa, dónde se
+  obtiene/consume el estado y cuándo se entregan mensajes. Contar tareas reales, no enums.
+- Resolver cada fase partida entre Session, mapa canónico y legacy. No declarar un
+  doble tick sin reproducción; existe protección `GlobalLegacy` en parte del melee.
+- Conservar una residencia/incarnation válida durante entrada, salida, transfer,
+  detach, unload y shutdown. Un Player detached puede seguir teniendo dueño válido.
+- Integrar hecs selectivo solo en almacenamiento privado con propietario real y las
+  pruebas de conformidad exigidas. La dependencia ECS o el laboratorio no prueban su
+  integración en producción. Mantener las garantías aprobadas antes de migrar storage.
+- Retirar cada bridge legacy solo cuando hayan migrado sus lectores, escritores,
+  persistencia y publicación. Suprimir entonces el registro exacto de la baseline.
+
+**Cierre:** traza de fases sobre la composición ejecutada, una ejecución por transición,
+pruebas de demora de I/O, backpressure, varias sesiones, reentrada, cancelación,
+transfer/unload/cierre. Ningún guard síncrono de entidad/mapa cruza `await`, I/O o
+entrega de paquetes. Los gates async existentes conservan su contrato de orden y recovery.
+
+P2/P3 pueden intercambiar una entrega cuando una operación necesita antes una fase
+de mapa o un lifetime. Esa dependencia debe quedar escrita; no habilitar producción
+antes del requisito ni paralelizar campañas pesadas en distintos worktrees.
+
+### P4 — Organización física, nombres y excepciones
+
+Esta tarea acompaña a P1–P3 desde el comienzo. Completar además los propietarios de
+datos, protocolo, composición y tooling que no entren en esas operaciones.
+
+| Superficie | Tratamiento esperado |
+| --- | --- |
+| `session/mod.rs`, `map/mod.rs`, `player/mod.rs`, `world-server/app.rs` | Raíces que expliquen composición y API; reglas, fases y adaptadores en submódulos cohesivos. No nuevos contextos universales. |
+| `session_tests.rs` y fixtures de quest/loot | Fixtures por familia y escenarios nombrados; conservar alcance cfg, montaje y conjunto de pruebas. Evitar otro test_support gigante. |
+| `spell/stores/state_1..3.rs` | Reunir tipos y operaciones de ranks, area rules, pet auras, prerequisites, groups, procs, target positions, etc. Un mero cambio de nombre conserva la mezcla. |
+| `state_4_ops_1/2.rs` y similares | Separar hidratación, dificultad, consultas del catálogo y reglas según su propietario; migrar consumidores y APIs. |
+| `main_tests/scenarios_1..14.rs` | Escenarios de GUID, realm, cierre, respawn y runtime cerca de sus responsabilidades; mantener pruebas de composición real. |
+| `misc_generated.rs` y datos DB2 | Dividir lectores por dominio y declarar procedencia/generador reproducible cuando exista. El nombre generated no concede excepción. |
+| `player/lifecycle_adapter.rs`, `statement_def.rs` | Un trait impl/match puede delegar en módulos privados por operación. Mantener un coordinador y orden de transacción. |
+| `statements/character/identities.rs` | Revisar cohesión del enum y alternativa de generación; una excepción individual puede ser correcta con procedencia y condición de salida. |
+| `wow-world/map_manager` | Hacer explícito que es legacy cuando se migren consumidores e inventario; alias de transición solo con obligación de retirada. |
+| `wow-script` / `wow-scripts` | Diferenciar dispatcher/runtime y contenido; evaluar nombres descriptivos al cerrar la responsabilidad, sin fusionarlos por parecido. |
+| QA bot y herramientas de arquitectura | Entrypoint único y pequeño; runner, cliente, escenarios y propietarios de política separados; imports explícitos entre responsabilidades. |
+| Fuentes externas/vendor | Excepción por fichero con procedencia, versión y motivo, o división mantenible; no una exención general por directorio o extensión. |
+
+Conservar `snake_case`, `mod.rs` y nombres de crates con guiones: son convenciones
+válidas. No hacer una campaña global de borrar `LikeCpp`/`_like_cpp`; no demuestra
+paridad, pero comunica procedencia y tiene muchos consumidores. En APIs nuevas usar
+nombres semánticos; revisar el ruido al migrar una responsabilidad completa.
+
+Preferir imports explícitos y fachadas deliberadas en producción. Los globs de una
+fixture pequeña pueden ser razonables. No imponer una cuota cero ni ampliar la
+visibilidad de estado para que compile una separación. Los nombres numéricos solo
+son finales cuando el número expresa dominio, versión o protocolo.
+
+**Cierre:** cada archivo grande tiene una partición coherente o una excepción
+individual conforme a la política. `physical-files --terminal` pasa; revisar también
+cohesión por encima del umbral de revisión. Actualizar solo los techos afectados con
+medición y explicación; mantener la deuda lógica hasta retirar realmente la responsabilidad.
+
+### P5 — Extensión nativa/Wasm pendiente (#583)
+
+Comienza después de los requisitos de núcleo #584, no al cerrar #716 ni por estar
+#578 cerrado. Usar el contrato vigente de `modularity-and-ecs-plan.md` y #583; no
+reinventar otro framework a partir de un ejemplo de login.
+
+- Hooks y resultados compartidos por ejecución nativa y Wasm, antes/después donde
+  corresponda al contrato y al orden de gameplay.
+- Estado independiente de módulo, lifetime, persistencia/progreso/recompensa y
+  operación de instalar, actualizar, desactivar y recuperar.
+- Capacidades acotadas: sin SQL, Player mutable, guards o writers expuestos al módulo.
+- Módulo útil independiente que pueda actuar sin parchear el núcleo; comportamiento
+  base correcto con cero módulos; pruebas nativo-only y Wasm-enabled.
+- Aceptación del segundo lenguaje/contrato acordado, límites del executor y errores.
+  No prometer ABI nativa estable, hot reload o todos los lenguajes sin contrato aprobado.
+
+### P6 — Aceptación terminal (#153 y cierre #133)
+
+Orden global: **núcleo requerido #584 → #583 → #153 → cierre #133**.
+#133/#584 son umbrellas, no implementaciones previas que bloqueen por sí mismas.
+
+Auditar el código final y la evidencia aplicable: propietarios, dependencias, acceso
+mutable, clocks/fases, guards, persistencia, bridges, registros/opcodes, organización
+física, SDK y operación real. #153 verifica; no absorbe implementación conocida que
+se haya dejado pendiente. Distinguir implementado, integrado y probado frente a C++.
+
+Después de M6.2/#47 se mantiene el nuevo análisis de todo el port antes de descomponer
+Part 2/#48. Este plan no crea anticipadamente ese árbol de issues.
+
+## 6. Cómo ejecutar cada macro sin volver a fragmentar el problema
+
+1. Reproducir/contrastar el problema y enumerar todos los consumidores.
+2. Fijar operación, propietario, dependencias, fases, persistencia y publicación;
+   separar movimientos, cambios de frontera y reparaciones de comportamiento.
+3. Reutilizar la macro/branch activa; abrir la siguiente macro coherente cuando el
+   contrato y las dependencias estén definidos, no una issue por fichero o helper.
+4. Implementar la entrega completa con tests y consumidores. Delegar una tarea
+   independiente con archivos propios cuando aporte valor; el padre integra y
+   programa la validación. No ejecutar CI por cada cambio interno.
+5. Validar el resultado completo, corregir fallos y volver a ejecutar lo afectado.
+6. Registrar SHA/comandos/resultados/límites en el documento propietario y hacer
+   commits locales coherentes. Publicación y runtime conservan sus autorizaciones.
+
+## 7. Validación concreta
+
+Elegir los targets reales según el cambio. Un cambio exclusivo en herramientas no
+requiere atribuirse pruebas de gameplay. Un refactor de runtime no se acepta solo
+con mocks ni con una suite de librería que no compruebe la composición en producción.
+
+```bash
+# Herramientas/ownership; secuencial, una vez completa la entrega.
+CARGO_BUILD_JOBS=1 cargo test --release --locked \
+  --manifest-path tools/architecture/handler-contract-check/Cargo.toml --lib
+CARGO_BUILD_JOBS=1 cargo run --release --locked \
+  --manifest-path tools/architecture/handler-contract-check/Cargo.toml \
+  --bin session-ownership-check -- check --syntax-only
+python3 tools/architecture/check_architecture.py check
+python3 tools/architecture/check_architecture.py self-test
+python3 tools/architecture/check_architecture.py physical-files --terminal
+
+# Para cambios de servidor, elegir las pruebas de la operación y sus integraciones.
+CARGO_BUILD_JOBS=1 PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo check -p world-server
+CARGO_BUILD_JOBS=1 PROTOC=/home/ubuntu/.local/protoc/bin/protoc \
+  cargo test -p wow-world <prueba-de-la-operacion> --lib
+cargo fmt --all -- --check
+git diff --check
+VALIDATION_V2_CARGO_JOBS=1 ./tools/validation-v2 quick --base origin/3.4.3
+
+# Antes de un push autorizado, sobre el candidato comprometido.
+VALIDATION_V2_CARGO_JOBS=1 ./tools/validation-v2 final --base origin/3.4.3
+```
+
+No ejecutar todo este bloque a ciegas por cada helper. El modo físico terminal
+seguirá fallando hasta cerrar P4; conservar ese resultado como deuda, no ocultarlo
+subiendo techos. El ownership sin `--syntax-only` recompone el inventario exhaustivo
+de persistencia: usarlo en los cambios/aceptaciones que lo requieran. No regenerar
+baselines para tapar drift. Preservar las nueve columnas del ledger R8 si se modifica.
+
+Para operaciones con bytes/metadata/conexión/orden nuevos, ejecutar capture-diff y
+la captura específica pertinente. Para durabilidad o lifecycle, leer las guías del
+QA bot y obtener la autorización runtime necesaria antes de DB/reinicio/relogin.
+Registrar host, SHA y límite real de cada evidencia. No relabelar un test de un SHA
+como si hubiese probado uno posterior; los deltas documentales pueden reutilizar
+evidencia verde con su consistencia comprobada según validation-v2.
+
+## 8. Decisiones que siguen abiertas
+
+- Protocolo durable exacto de recompensa: transacción de personaje coherente frente
+  a etapas con recovery, y tratamiento explícito de participantes no implementados.
+- Siguiente familia P2 y sus requisitos de fases P3, después de contrastar consumidores.
+- Ubicación final de reglas hoy repartidas entre los dos componentes de Player.
+- Excepciones físicas individuales, especialmente enums/tablas cohesivas y vendor.
+- Renombrado público de crates de scripting y garantías de compatibilidad necesarias.
+
+Resolver con evidencia y alternativas concretas. No elegir por inercia de la
+estructura actual ni crear aprobaciones rutinarias para imports, helpers o tests.
+
+## 9. Estado exacto de la entrega al pasar a Claude
+
+La revisión y el plan están escritos; #716 está implementándose y validándose en el
+worktree indicado. Primera ejecución de librería: 349 passed, 4 failed. Esos fallos
+motivaron correcciones adicionales y no constituyen aceptación de la versión actual.
+La evidencia final y el commit local se añadirán aquí al terminar la ejecución en curso.
+
+Hasta entonces no afirmar P0 terminado, no cerrar #716 y no iniciar una implementación
+de recompensa de misión sobre un analizador que todavía esté sin aceptar. P1–P6
+siguen pendientes; las tablas anteriores son tareas y criterios, no resultados ejecutados.
+
+## 10. Inventario físico pendiente para P4
+
+Estos 31 archivos siguen rechazados por el control físico terminal en la entrega
+P0, igual que en la base revisada. Conteo bruto de líneas físicas; no confundirlo
+con las métricas lógicas de producción/tests. No convertir esta tabla en 31 issues:
+agrupar por la responsabilidad y los consumidores de cada entrega. Para vendor o
+fixtures con runtime, evaluar la excepción o evidencia específica descrita en P4.
+
+| Archivo | Líneas físicas |
+| --- | ---: |
+| `crates/capture-diff/scripts/capture-rust.sh` | 2,243 |
+| `crates/capture-diff/scripts/creature-spell-casting-fixture-common.sh` | 2,144 |
+| `crates/capture-diff/scripts/detour-chase-fixture-common.sh` | 3,605 |
+| `crates/world-server/src/app.rs` | 5,645 |
+| `crates/world-server/src/creature_loaded_grid.rs` | 2,944 |
+| `crates/world-server/src/lib.rs` | 2,078 |
+| `crates/world-server/src/runtime/game_events.rs` | 2,643 |
+| `crates/world-server/src/runtime/map.rs` | 2,063 |
+| `crates/world-server/src/spawn_store_loader.rs` | 5,125 |
+| `crates/world-server/src/spell/acquisition_loader.rs` | 2,267 |
+| `crates/wow-entities/src/player/items/storage.rs` | 3,298 |
+| `crates/wow-entities/src/player/mod.rs` | 4,881 |
+| `crates/wow-map/src/map/game_object.rs` | 2,299 |
+| `crates/wow-map/src/map/mod.rs` | 5,269 |
+| `crates/wow-map/src/map/relocation.rs` | 2,169 |
+| `crates/wow-map/src/map/spawn_groups.rs` | 2,384 |
+| `crates/wow-recastdetour/vendor/Detour/Source/DetourNavMeshQuery.cpp` | 3,663 |
+| `crates/wow-social/src/group/tests.rs` | 2,508 |
+| `crates/wow-world/src/handlers/character/items.rs` | 3,874 |
+| `crates/wow-world/src/handlers/character/mod.rs` | 2,728 |
+| `crates/wow-world/src/handlers/character/session_state.rs` | 2,809 |
+| `crates/wow-world/src/handlers/character/vendor.rs` | 2,513 |
+| `crates/wow-world/src/handlers/character/world_entry.rs` | 2,771 |
+| `crates/wow-world/src/handlers/loot/handlers.rs` | 2,463 |
+| `crates/wow-world/src/handlers/loot/requests.rs` | 2,524 |
+| `crates/wow-world/src/handlers/loot/sources.rs` | 3,109 |
+| `crates/wow-world/src/handlers/quest/handlers.rs` | 2,716 |
+| `crates/wow-world/src/handlers/quest/rewards.rs` | 2,159 |
+| `crates/wow-world/src/session/directory.rs` | 2,351 |
+| `crates/wow-world/src/session/mod.rs` | 18,571 |
+| `crates/wow-world/src/session_tests.rs` | 5,755 |

--- a/docs/architecture/refactor-completion-plan.md
+++ b/docs/architecture/refactor-completion-plan.md
@@ -404,14 +404,47 @@ estructura actual ni crear aprobaciones rutinarias para imports, helpers o tests
 
 ## 9. Estado exacto de la entrega al pasar a Claude
 
-La revisión y el plan están escritos; #716 está implementándose y validándose en el
-worktree indicado. Primera ejecución de librería: 349 passed, 4 failed. Esos fallos
-motivaron correcciones adicionales y no constituyen aceptación de la versión actual.
-La evidencia final y el commit local se añadirán aquí al terminar la ejecución en curso.
+**P0 tiene aceptación local.** La implementación está en
+`6ae62d73a9f910ebd664d82e331520b836a73c77`, en la rama y worktree de la sección 2.
+El commit posterior de documentación completa este relevo. Los cambios de código
+afectan exclusivamente al tooling de arquitectura; no se modificó gameplay, SQL,
+protocolo, scheduling ni procesos del servidor.
 
-Hasta entonces no afirmar P0 terminado, no cerrar #716 y no iniciar una implementación
-de recompensa de misión sobre un analizador que todavía esté sin aceptar. P1–P6
-siguen pendientes; las tablas anteriores son tareas y criterios, no resultados ejecutados.
+Evidencia ejecutada en aarch64, Rust 1.98.0 y un job de Cargo:
+
+| Comprobación | Resultado |
+| --- | --- |
+| `cargo test --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml --lib -- --quiet` | 363 passed, 0 failed; incluye contrato real de handlers, grafo completo, referencias preservadas y consistencia snapshot/policy. |
+| `cargo run --release --locked --manifest-path tools/architecture/handler-contract-check/Cargo.toml --bin session-ownership-check -- check --syntax-only` | PASS; 221 campos de producción, 427 de fixtures, 594 accesos directos de registro y baseline exacta de 72 bridges. |
+| `python3 tools/architecture/check_architecture.py check` | PASS; 38 paquetes, 101 aristas internas; migración física y ocho propietarios lógicos dentro de sus techos. |
+| `python3 tools/architecture/check_architecture.py self-test` | PASS; fixtures adversariales de política y 20 tests de archivos físicos. |
+| `./tools/validation-v2 quick --base origin/3.4.3` | PASS; seis comandos, incluidos formato de la herramienta, cargo check, JSON, higiene y tests físicos; manifiesto verificado con `validation-v2 verify`. |
+| `git diff --check` | PASS. |
+| `python3 tools/architecture/check_architecture.py physical-files --terminal` | FAIL esperado y pendiente: los mismos 31 archivos de la sección 10. No es aceptación terminal del refactor. |
+
+Las ejecuciones usaron `CARGO_BUILD_JOBS=1 CARGO_NET_OFFLINE=true` cuando
+correspondía; V2 usó `VALIDATION_V2_CARGO_JOBS=1` y el PROTOC de la sección 2.
+Se ejecutaron sobre la versión de trabajo cuyo padre era `aff42a51`, antes del
+commit. El manifiesto `/tmp/rustycore-716-quick-manifest.json` registra ese SHA y
+`dirty: true`; no se presenta como una ejecución posterior sobre `6ae62d73`.
+El código y las políticas probadas se incorporaron sin cambios a ese commit.
+Los ajustes posteriores de entrega son documentales.
+
+El inventario conserva exactamente los 65 bridges anteriores tras el cambio de
+ubicación revisado y añade siete accesos existentes contrastados en código; no
+elimina ninguna obligación. Las dos ubicaciones de fixtures también se reconciliaron.
+No se regeneró el inventario exhaustivo de persistencia. No se ejecutaron build del
+servidor, capturas, QA live, reinicio, escrituras de DB, push, merge ni despliegue.
+El perfil de publicación `final` sigue siendo obligatorio antes de un push autorizado.
+
+**Siguiente acción para Claude:** leer P1 y contrastar el contrato completo de
+recompensa de misión antes de elegir su implementación. No repetir P0 salvo que
+cambie su código o aparezca una regresión. P1–P6 siguen pendientes; #716 aún requiere
+su publicación/integración para cerrar la issue, y #584 continúa abierto.
+
+Si el worktree temporal ya no existe, localizar la rama local anterior con
+`git worktree list` y `git branch --list '*716*'`; el commit conserva el plan y la
+implementación. Recuperar un worktree desde esa rama sin alterar el checkout sucio.
 
 ## 10. Inventario físico pendiente para P4
 

--- a/docs/migration/PORT_PLAN.md
+++ b/docs/migration/PORT_PLAN.md
@@ -15,16 +15,14 @@ before implementation. Architecture/tooling work uses its explicit, proportional
 
 ## Current execution agreement — #133 / #578
 
-**Active delivery, 2026-09-08:** #586 merged as `8c47af95`; #585 and #578 are closed.
-#587's acquisition boundary is implemented locally. Its live trainer acceptance
-exposed the missing deferred player visibility bridge; the user approved #588 as
-the concrete prerequisite, followed by resumption of #587. The
-[visibility checkpoint](../architecture/deferred-visibility-588-checkpoint.md)
-owns that finite contract and evidence. #133/#584 remain umbrellas. Complete the
-required core deliveries before #583, then #153 and #133 closure. No later family
-or fixed crate sequence is selected. Complete each implementation and its consumers
-before tests/QA; do not run CI for internal microchanges. This allocation supersedes
-older open-#578/#585 and iteration-cadence text below.
+**Active delivery, 2026-09-10:** #578/#585/#587/#588/#589 are integrated and closed
+within their named scopes. The user approved the architecture repair program at
+`aff42a51`; #716 first restores the ownership analyzer and exact acceptance after
+physical module moves. The [current architecture plan](../architecture/modularity-and-ecs-plan.md#current-core-delivery--2026-09-10)
+owns that contract and the next quest-reward candidate. #133/#584 remain umbrellas.
+Complete required #584 core before #583, then #153 and #133 closure. No fixed crate
+sequence or helper-issue tree is selected. Complete each implementation and its
+consumers before tests/QA; do not run CI for internal microchanges.
 
 **Superseding delivery agreement, 2026-09-06:** the user replaced the single
 all-core implementation PR with crate-focused macrodeliverables, each preceded by
@@ -40,32 +38,32 @@ completion means its agreed architecture outcome, not every future port feature.
 `session-578-checkpoint.md` owns the exact #578 remaining gates. Older one-PR/C0–C4
 allocation paragraphs in this section are the superseded plan, not active scope.
 
-The current ownership delivery remains one **macro-issue #578 / draft PR #579**. The subsequent
-functional modularity proof is **#583 under #99**, then #153 independently audits both before
-#133 closes. Keep coherent internal commits and checkpoints; do not turn
-field families into micro-issues/PRs or require permission to continue between routine steps.
-The contract-led plan and exact remaining boundaries are maintained in
-[`session-578-checkpoint.md`](../architecture/session-578-checkpoint.md), not inferred from the
-number of closed historical children, fields moved, or passing tests.
+The closed **#578 / PR #579** delivered the canonical-owner foundation. The remaining
+program is **#584**, followed by **#583 under #99**, then #153's independent audit.
+Keep coherent internal commits and checkpoints; do not turn field families into
+micro-issues/PRs or require permission to continue between routine steps. The
+[architecture plan](../architecture/modularity-and-ecs-plan.md) owns current delivery;
+[`session-578-checkpoint.md`](../architecture/session-578-checkpoint.md) retains the
+predecessor's exact evidence, not the current selection or an undated completion claim.
 
 Each internal block must name its complete operation, input/admission contract, canonical owner,
 mutation/commit/publication order, narrow dependencies, retired access/bridge and acceptance
 evidence. Move every related reader/writer before claiming that boundary complete. A shared
 resource bag with fewer outer fields, or gameplay spread over more Session impls, does not meet
-the terminal contract. Already-known cuts stay in #578; #153 verifies them rather than absorbing
+the terminal contract. Already-known core cuts stay in #584; #153 verifies them rather than absorbing
 their implementation. Preserve the full #133 outcome.
 
 The [module design guidelines](../architecture/module-design-guidelines.md) add independent
 physical source/test acceptance to each semantic family: manageable files, bounded file-specific
-exceptions and legacy retirement inside #578 C2/C4. They include a Rust submodule skeleton and
+exceptions and legacy retirement inside #584 C2/C4. They include a Rust submodule skeleton and
 cover SDK/modules in #583. Safe mechanical splits need not wait for the hecs conformance gate,
 which remains mandatory before production storage migration. The existing checker now enforces
 physical migration ceilings and a separate terminal mode. Remaining legacy-file retirement and
-semantic acceptance belong to #578 C2/C4, not #153 or a new micro-issue; a migration PASS is not
+semantic acceptance belong to #584 C2/C4, not #153 or a new micro-issue; a migration PASS is not
 terminal acceptance. The owning checkpoint records the exact remaining ceilings and evidence.
 
-During development, run affected-crate checks, focused positive/negative tests, formatting and
-the inexpensive ownership/architecture checks. At an affected owner boundary, exercise bounded
+At completed-delivery acceptance, run affected-crate checks, focused positive/negative tests,
+formatting and the applicable ownership/architecture checks. At an affected owner boundary, exercise bounded
 production-path integration and failure cases, including stale generation, detached transfer,
 save/logout and publication/backpressure as applicable. The complete exhaustive/final stack
 belongs at macro acceptance, not every internal commit. Required capture/runtime evidence remains
@@ -73,8 +71,8 @@ an explicit gate, and this cadence grants no new deployment, push or merge autho
 
 The [reanalysis checkpoints](../architecture/modularity-and-ecs-plan.md#reanalysis-checkpoints--evidence-before-replication)
 make the order explicit: conformance before production storage migration; review the first real
-C1/C2 vertical with C0 admission/phase evidence before replicating it; reconcile all C0–C4 at #578
-closeout before #583 production integration; audit both merged macros in #153. Review the next
+C1/C2 vertical with C0 admission/phase evidence before replicating it; reconcile required C0–C4
+core under #584 before #583 production integration; audit accepted deliveries in #153. Review the next
 gameplay macro just in time, then the entire port at #47/M6.2 before Part 2 planning. These are
 evidence reviews inside the approved macros, not new issues or routine confirmation gates.
 
@@ -100,15 +98,16 @@ and a bounded Wasm executor with Rust/C bindings, alongside policies, scoped/ree
 behavior, independent state composition, durable progress/reward and install/update/disable/recovery.
 **This explicitly expands #133's closure:** Wasm is optional for the operator to enable, not
 optional for #583/#153 acceptance. The bounded delivery no longer waits for M6; broader language
-ecosystem expansion retains the fresh #99 planning gate. #583 depends on #231/#578; #578 does not
-depend on #583 or a production SDK/Wasm executor. #153 audits both completed macros, not the entire
+ecosystem expansion retains the fresh #99 planning gate. #583 depends on #231/#578 and required
+#584 core; core work does not depend on #583 or a production SDK/Wasm executor. #153 audits the completed program, not the entire
 #99 epic. Native-only and Wasm-enabled builds must preserve the same supported hook contracts;
 the plan does not promise every language, a stable native ABI or hot reload.
 
 The [V1 laboratory is complete](../architecture/modularity-lab-results.md) at `ee9a0128`: its
 corrected campaign passes the recorded functional/resource gates, but does not prove the new
 independent-module/multilanguage gate or production integration. Native remains the default;
-the next checkpoint is the specified conformance proof, not repeated V1 timings. This is one
+the finite V2 conformance proof has also passed with its recorded limits. Real-owner production
+integration remains required. This is one
 expanded complete capability, not a PR per hook. Part 1, Part 2 and the D-track retain their goals
 and hard dependencies; the architecture update is not a fresh audit of every historical gameplay
 issue and does not change their completion states or publication/deployment approvals.

--- a/docs/migration/STATE.md
+++ b/docs/migration/STATE.md
@@ -1,5 +1,19 @@
 # RustyCore — Honest Current State (single source of truth)
 
+**Current architecture delivery — 2026-09-10, reviewed integration `aff42a51`:**
+the user approved starting the architecture repair program. #716 restores exact
+ownership-provenance acceptance after the mechanical module passes. At that base,
+the general architecture check and self-tests pass; the syntax-only Session check
+fails on two relocated fixture scopes and one still-live canonical/legacy bridge
+whose parent import is lost by the analyzer. Physical terminal acceptance also fails:
+31 files exceed 2,000 lines, while migration ceilings still pass. These results do not
+reopen the integrated, closed #587/#588/#589 scoped gameplay deliveries.
+Implementation and acceptance of #716 are tracked in the
+[current architecture plan](../architecture/modularity-and-ecs-plan.md#current-core-delivery--2026-09-10).
+No new acceptance, publication or runtime result is claimed yet. Required #584 core
+still precedes #583, #153 and #133 closure; quest reward is the next operation candidate
+whose complete durability/consumer contract is being investigated.
+
 **Second physical pass closed — 2026-09-10, integration `a4a9073e`:** fourteen
 deliveries between #685 and #711 finished the physical track outside the curated
 hotspots. #685 and #687 moved the last inline `mod tests` blocks out of oversized
@@ -12,12 +26,13 @@ taking the `wow-persistence` root from 53 entries to 26, `wow-database` from 64 
 each crate's test count unchanged, and passed
 `./tools/validation-v2 final --base origin/3.4.3` at the committed SHA.
 
-Four files outside the hotspots remain above the 1,000-line review budget, and none is a
-relocation problem: `session_tests.rs` (5,756) keeps its 197 shared helpers in the root
-deliberately by #626, while `statements/character/identities.rs` (1,789),
-`statement_def.rs` (1,627) and `player/lifecycle_adapter.rs` (1,609) are one `enum`, one
-`match` and one trait impl - a single item, which cannot become modules without changing
-the type. Forty-four more sit inside the eight curated hotspot aggregates. This corrects
+That pass retained four files outside the hotspots above the 1,000-line review
+budget: `session_tests.rs` (5,756) and its 197 shared helpers, plus
+`statements/character/identities.rs` (1,789), `statement_def.rs` (1,627) and
+`player/lifecycle_adapter.rs` (1,609). Forty-four more sat inside the eight curated
+hotspot aggregates. #716 corrects the earlier claim that a trait impl or match must
+change its type to delegate to private modules; those shapes and fixture sharing do
+not establish terminal exceptions. This corrects
 the earlier claim that relocation was exhausted for "the `map_manager` pair": #705 divided
 its 2,069-line `impl WorldCreature` into seven submodules and #711 divided the 2,191-line
 root into five, so both now sit at 130 and 255 lines. The measured limits behind the rest
@@ -25,7 +40,8 @@ are recorded in
 [the module-design guide](../architecture/module-design-guidelines.md#what-a-physical-division-cannot-reach),
 including #713's measurement that dividing the loot and quest fixture roots costs their
 hotspot aggregates +63 and +43 test lines at the cheapest wiring available. What remains
-is the semantic extraction owned by #584 C0-C4. This closes neither #133 nor #584.
+includes both semantic extraction and justified private decomposition under #584
+C0-C4. This closes neither #133 nor #584.
 
 **Physical decomposition track closed — 2026-09-09, integration `df94f231`:**
 #589 and its sub-issues #590-#595 are merged. Sixteen deliveries between #634 and
@@ -38,15 +54,18 @@ surface identical before and after, kept its crate's test count unchanged, and
 passed `./tools/validation-v2 final --base origin/3.4.3` at the committed SHA;
 sixty-seven of the hundred reviewed ceilings are now at or below 2,000 lines.
 
-116,693 lines remain above 2,000 lines in 33 files, and relocation is exhausted
-for all of them: 29 sit inside the eight curated runtime-ownership hotspots or
-the `map_manager` pair, one is a vendored C++ translation unit and three are
-capture fixture shell scripts with their own runtime-authorization gates. The
+At that revision, 116,693 lines remained above 2,000 lines in 33 files: 29 sat
+inside the eight curated runtime-ownership hotspots or the `map_manager` pair,
+one was a vendored C++ translation unit and three were capture fixture shell
+scripts with their own runtime-authorization gates. The earlier conclusion that
+all relocation was exhausted is superseded by the 2026-09-10 review above. The
 hotspot ratchet measures the module aggregate, so splitting a file inside an
 owner at its baseline makes the aggregate grow; and splitting a bridge
 function's context removed a row from the 65-row bridge inventory while the
-build and all 3,822 `wow-world` tests stayed green (#662, reverted). What
-remains is the semantic extraction owned by #584 C0-C4, with the per-owner entry
+build and all 3,822 `wow-world` tests stayed green (#662, reverted). That count
+loss did not prove retirement or make file separation invalid; #716 repairs the
+parent-import provenance gap. What remains includes semantic extraction and
+justified physical decomposition under #584 C0-C4, with the per-owner entry
 conditions recorded in
 [the modularity plan](../architecture/modularity-and-ecs-plan.md#physical-decomposition-track-closed--2026-09-09).
 This closes neither #133 nor #584.

--- a/docs/migration/STATE.md
+++ b/docs/migration/STATE.md
@@ -10,9 +10,19 @@ whose parent import is lost by the analyzer. Physical terminal acceptance also f
 reopen the integrated, closed #587/#588/#589 scoped gameplay deliveries.
 Implementation and acceptance of #716 are tracked in the
 [current architecture plan](../architecture/modularity-and-ecs-plan.md#current-core-delivery--2026-09-10).
-No new acceptance, publication or runtime result is claimed yet. Required #584 core
-still precedes #583, #153 and #133 closure; quest reward is the next operation candidate
-whose complete durability/consumer contract is being investigated.
+**#716 is locally accepted**, with implementation commit
+`6ae62d73a9f910ebd664d82e331520b836a73c77`: 363 analyzer library tests, syntax-only
+ownership, architecture check/self-test and validation-v2 quick pass. The 65 earlier
+bridge records are preserved after the reviewed relocation; seven existing dual
+references are now inventoried, giving 72 exact records. Test commands ran on the
+working candidate at `aff42a51` and its verified V2 manifest records `dirty: true`;
+the tested code/policies were committed unchanged. The
+[complete plan for Claude](../architecture/refactor-completion-plan.md#9-estado-exacto-de-la-entrega-al-pasar-a-claude)
+records commands, source identity and the remaining boundaries. No push, merge,
+server build, deployment, live QA or exhaustive persistence rescan was performed
+for this tooling delivery. Physical terminal acceptance still fails at the same
+31 files. Required #584 core still precedes #583, #153 and #133 closure; quest reward
+is the next operation candidate requiring its complete durability/consumer contract.
 
 **Second physical pass closed — 2026-09-10, integration `a4a9073e`:** fourteen
 deliveries between #685 and #711 finished the physical track outside the curated

--- a/tools/architecture/architecture-issue-ledger.json
+++ b/tools/architecture/architecture-issue-ledger.json
@@ -178,6 +178,8 @@
     585,
     588,
     587,
+    589,
+    716,
     583,
     153
   ],
@@ -2309,7 +2311,7 @@
     },
     {
       "number": 588,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.CORE] Complete deferred player visibility publication",
       "kind": "slice",
       "parents": [133, 584],
@@ -2317,11 +2319,27 @@
     },
     {
       "number": 587,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.CORE] Complete represented spell-acquisition application boundary",
       "kind": "slice",
       "parents": [133, 584],
       "depends_on": [585, 588]
+    },
+    {
+      "number": 589,
+      "state": "closed",
+      "title": "[ARCH.CORE] Complete represented Player cast-request lifecycle",
+      "kind": "slice",
+      "parents": [133, 584],
+      "depends_on": [587, 588]
+    },
+    {
+      "number": 716,
+      "state": "open",
+      "title": "[ARCH.CORE] Restore ownership provenance and acceptance after module decomposition",
+      "kind": "slice",
+      "parents": [133, 584],
+      "depends_on": [589]
     }
   ]
 }

--- a/tools/architecture/handler-contract-check/src/bridge_access.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access.rs
@@ -29,17 +29,19 @@ use quote::ToTokens;
 use serde::{Deserialize, Serialize};
 use syn::visit::{self, Visit};
 use syn::{
-    Attribute, Expr, ExprCall, ExprField, ExprMacro, ExprMethodCall, FnArg, ImplItem, Item, ItemFn,
-    ItemImpl, ItemMacro, ItemMod, Local, Member, Pat, Path, Signature, Type, UseTree,
+    Attribute, Expr, FnArg, ImplItem, Item, ItemFn, ItemImpl, ItemMacro, ItemMod, Member, Pat,
+    Path, Signature, Type, UseTree,
 };
 
 use crate::ownership::{
     cfg_context_allows_production, cfg_context_allows_test, extend_cfg_context,
 };
 
+mod provenance;
 mod state_1;
 mod state_2;
 mod state_3;
+use provenance::{build_module_index, resolve_module_symbols};
 #[allow(unused_imports)]
 pub use state_1::*;
 #[allow(unused_imports)]

--- a/tools/architecture/handler-contract-check/src/bridge_access/provenance.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access/provenance.rs
@@ -1,0 +1,852 @@
+//! Resolve authority provenance from the supplied lexical module graph.
+//!
+//! Resolution is keyed by the enclosing item's cfg, including negative guards
+//! for shadowed globs. Unknown relative provenance survives aliases and is only
+//! reported when a candidate actually uses it. This is not a Rust type checker.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use quote::ToTokens;
+use syn::visit::{self, Visit};
+use syn::{Item, ItemMod, Path, Type};
+
+use super::{BridgeSide, BridgeSource, Symbols};
+use crate::ownership::{cfg_context_allows_production, cfg_context_allows_test};
+
+mod candidate_visitor;
+mod cfg_context;
+mod glob_context;
+mod scope;
+mod source_graph;
+use scope::{LocalBinding, ModuleScope, collect_scope, collect_use_specs};
+pub(super) use source_graph::ModuleIndex;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum Provenance {
+    Authority(BTreeSet<BridgeSide>),
+    Module(String),
+    NonAuthority,
+    Unknown,
+}
+
+#[derive(Clone, Debug)]
+struct Candidate {
+    provenance: Provenance,
+    cfg: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct Resolution {
+    candidates: Vec<Candidate>,
+    issues: BTreeSet<String>,
+    // A glob search may revisit a root before reaching the defining child.
+    // Keep that back-edge pending until the complete search has a source.
+    cycles: BTreeSet<String>,
+}
+
+impl Resolution {
+    fn one(provenance: Provenance, cfg: &[String]) -> Self {
+        Self {
+            candidates: vec![Candidate {
+                provenance,
+                cfg: cfg.to_vec(),
+            }],
+            issues: BTreeSet::new(),
+            cycles: BTreeSet::new(),
+        }
+    }
+
+    fn append(&mut self, other: Self) {
+        self.candidates.extend(other.candidates);
+        self.issues.extend(other.issues);
+        self.cycles.extend(other.cycles);
+    }
+}
+
+type ResolutionKey = (usize, String, Vec<String>);
+
+struct Resolver<'a> {
+    index: &'a ModuleIndex,
+    scopes: Vec<ModuleScope>,
+    memo: BTreeMap<ResolutionKey, Resolution>,
+    active: BTreeSet<ResolutionKey>,
+}
+
+fn canonical_cfg(cfg: &[String]) -> Vec<String> {
+    let mut cfg = cfg.to_vec();
+    cfg.sort();
+    cfg.dedup();
+    cfg
+}
+
+fn possible(cfg: &[String]) -> bool {
+    cfg_context_allows_production(cfg, &[]).unwrap_or(true)
+        || cfg_context_allows_test(cfg, &[]).unwrap_or(true)
+}
+
+fn combine_cfg(left: &[String], right: &[String]) -> Option<Vec<String>> {
+    let mut cfg = left.to_vec();
+    cfg.extend_from_slice(right);
+    let cfg = canonical_cfg(&cfg);
+    possible(&cfg).then_some(cfg)
+}
+
+// Convert a cfg/cfg_attr presence condition to a predicate that can be negated.
+// The shared ownership solver still decides satisfiability; this only expresses
+// "none of these stronger lexical bindings exists" for fallback to a glob.
+fn presence_predicate(meta: &syn::Meta) -> Option<String> {
+    use syn::parse::Parser;
+    let syn::Meta::List(list) = meta else {
+        return Some("all()".to_owned());
+    };
+    if list.path.is_ident("cfg") {
+        return Some(list.tokens.to_string());
+    }
+    if !list.path.is_ident("cfg_attr") {
+        return Some("all()".to_owned());
+    }
+    let metas = syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated
+        .parse2(list.tokens.clone())
+        .ok()?;
+    let mut metas = metas.iter();
+    let condition = metas.next()?.to_token_stream().to_string();
+    let effects = metas.map(presence_predicate).collect::<Option<Vec<_>>>()?;
+    Some(format!(
+        "any(not({condition}), all({}))",
+        effects.join(", ")
+    ))
+}
+
+fn uncovered_cfg(context: &[String], guards: &[Vec<String>]) -> Option<Vec<String>> {
+    if guards.is_empty() {
+        return Some(context.to_vec());
+    }
+    let alternatives = guards
+        .iter()
+        .map(|guard| {
+            let predicates = guard
+                .iter()
+                .map(|text| {
+                    syn::parse_str::<syn::Meta>(text)
+                        .ok()
+                        .and_then(|meta| presence_predicate(&meta))
+                })
+                .collect::<Option<Vec<_>>>()?;
+            Some(format!("all({})", predicates.join(", ")))
+        })
+        .collect::<Option<Vec<_>>>();
+    // Invalid cfg is independently rejected by the inventory's validation.
+    let alternatives = alternatives?;
+    combine_cfg(
+        context,
+        &[format!("cfg(not(any({})))", alternatives.join(", "))],
+    )
+}
+
+impl<'a> Resolver<'a> {
+    fn new(index: &'a ModuleIndex, errors: &mut Vec<String>) -> Self {
+        Self {
+            index,
+            scopes: index
+                .modules
+                .iter()
+                .map(|module| collect_scope(module, errors))
+                .collect(),
+            memo: BTreeMap::new(),
+            active: BTreeSet::new(),
+        }
+    }
+
+    fn diagnostic(&self, node: usize, name: &str, reason: &str) -> String {
+        let module = &self.index.modules[node];
+        format!(
+            "cannot resolve bridge provenance for {} {} {} name `{name}`: {reason}",
+            module.package, module.module, module.source_path
+        )
+    }
+
+    fn unresolved(&self, node: usize, name: &str, cfg: &[String], reason: &str) -> Resolution {
+        let mut result = Resolution::one(Provenance::Unknown, cfg);
+        result.issues.insert(self.diagnostic(node, name, reason));
+        result
+    }
+
+    fn resolve_name(&mut self, node: usize, name: &str, cfg: &[String]) -> Resolution {
+        let Some(cfg) = combine_cfg(cfg, &self.index.modules[node].cfg) else {
+            return Resolution::default();
+        };
+        // A parent may re-export a child that imports super::*. That ordinary
+        // glob graph is cyclic, but it is not an alias cycle for every
+        // unrelated identifier in the program.
+        if !known_authority_name(name)
+            && !self.has_visible_binding(node, name, &mut BTreeSet::new())
+        {
+            return Resolution::default();
+        }
+        let key = (node, name.to_owned(), cfg.clone());
+        if let Some(result) = self.memo.get(&key) {
+            return result.clone();
+        }
+        if !self.active.insert(key.clone()) {
+            return Resolution {
+                cycles: BTreeSet::from([self.diagnostic(
+                    node,
+                    name,
+                    "relative import or type alias resolution cycle",
+                )]),
+                ..Resolution::default()
+            };
+        }
+
+        let scope = self.scopes[node].clone();
+        let mut result = Resolution::default();
+        let mut guards = Vec::new();
+        for declaration in scope.declarations.get(name).into_iter().flatten() {
+            let Some(branch_cfg) = combine_cfg(&cfg, &declaration.cfg) else {
+                continue;
+            };
+            guards.push(declaration.cfg.clone());
+            let resolved = match &declaration.binding {
+                LocalBinding::NonAuthority => {
+                    Resolution::one(Provenance::NonAuthority, &branch_cfg)
+                }
+                LocalBinding::Authority(side) => {
+                    Resolution::one(Provenance::Authority(BTreeSet::from([*side])), &branch_cfg)
+                }
+                LocalBinding::Module(module) => {
+                    Resolution::one(Provenance::Module(module.clone()), &branch_cfg)
+                }
+                LocalBinding::Alias(ty) => self.resolve_type(node, ty, &branch_cfg),
+            };
+            result.append(resolved);
+        }
+        if let Some(import_cfg) = uncovered_cfg(&cfg, &guards) {
+            let mut import_guards = Vec::new();
+            for import in scope.explicit.get(name).into_iter().flatten() {
+                let Some(branch_cfg) = combine_cfg(&import_cfg, &import.cfg) else {
+                    continue;
+                };
+                import_guards.push(import.cfg.clone());
+                let resolved = if import.path.len() > 1
+                    && import.path.first().is_some_and(|first| first == name)
+                    && !matches!(name, "crate" | "self" | "super")
+                {
+                    // In use anyhow::{Result, anyhow}, the imported terminal
+                    // name does not replace its own external namespace root.
+                    Resolution::one(
+                        recognized_absolute_provenance(&import.path)
+                            .unwrap_or(Provenance::NonAuthority),
+                        &branch_cfg,
+                    )
+                } else {
+                    self.resolve_path(node, &import.path, &branch_cfg)
+                };
+                result.append(resolved);
+            }
+            if let Some(glob_cfg) = uncovered_cfg(&import_cfg, &import_guards) {
+                let mut glob_result = Resolution::default();
+                for glob in &scope.globs {
+                    let Some(branch_cfg) = combine_cfg(&glob_cfg, &glob.cfg) else {
+                        continue;
+                    };
+                    let targets = self.module_targets(node, &glob.path);
+                    if targets.is_empty() {
+                        if known_authority_name(name)
+                            && glob
+                                .path
+                                .first()
+                                .is_some_and(|s| matches!(s.as_str(), "super" | "self"))
+                        {
+                            glob_result.append(self.unresolved(
+                                node,
+                                name,
+                                &branch_cfg,
+                                "a relative glob module is missing or unavailable",
+                            ));
+                        }
+                    } else {
+                        for target in targets {
+                            if self.active.iter().any(|(active_node, active_name, _)| {
+                                *active_node == target && active_name == name
+                            }) {
+                                // Glob re-export loops are ordinary Rust module
+                                // wiring. An explicit import/alias edge still
+                                // enters resolve_name and diagnoses its cycle.
+                                glob_result.cycles.insert(self.diagnostic(
+                                    target,
+                                    name,
+                                    "relative glob resolution cycle has no defining source yet",
+                                ));
+                                continue;
+                            }
+                            glob_result.append(self.resolve_name(target, name, &branch_cfg));
+                        }
+                    }
+                }
+                if glob_result.candidates.is_empty() {
+                    if let Some(side) = scope.builtins.get(name) {
+                        glob_result = Resolution::one(
+                            Provenance::Authority(BTreeSet::from([*side])),
+                            &glob_cfg,
+                        );
+                    }
+                }
+                if !glob_result.candidates.is_empty() {
+                    let guards = glob_result
+                        .candidates
+                        .iter()
+                        .map(|candidate| candidate.cfg.clone())
+                        .collect::<Vec<_>>();
+                    if uncovered_cfg(&glob_cfg, &guards).is_none() {
+                        glob_result.cycles.clear();
+                    }
+                }
+                result.append(glob_result);
+            }
+        }
+        self.active.remove(&key);
+        // An intermediate re-export can be unresolved only because its root
+        // is still being searched. Caching it would make source order matter.
+        if result.cycles.is_empty() {
+            self.memo.insert(key, result.clone());
+        }
+        result
+    }
+
+    fn has_visible_binding(&self, node: usize, name: &str, active: &mut BTreeSet<usize>) -> bool {
+        if !active.insert(node) {
+            return false;
+        }
+        let scope = &self.scopes[node];
+        let found = scope.declarations.contains_key(name)
+            || scope.explicit.contains_key(name)
+            || scope.builtins.contains_key(name)
+            || scope.globs.iter().any(|glob| {
+                self.module_targets(node, &glob.path)
+                    .into_iter()
+                    .any(|target| self.has_visible_binding(target, name, active))
+            });
+        active.remove(&node);
+        found
+    }
+
+    fn resolve_type(&mut self, node: usize, ty: &Type, cfg: &[String]) -> Resolution {
+        let mut collector = PathCollector::default();
+        collector.visit_type(ty);
+        // Type components coexist, whereas import candidates are alternatives.
+        // Arc<Creature> aggregates Creature's side; Arc is not a conflicting
+        // unknown alternative. A diagnostic from any component is preserved.
+        let mut aggregate = Resolution::one(Provenance::NonAuthority, cfg);
+        for path in collector.paths {
+            let resolved = self.resolve_path(node, &path, cfg);
+            aggregate.issues.extend(resolved.issues);
+            // A cycle within a type expression is a real alias cycle, not a
+            // glob forwarding edge that another defining child can discharge.
+            aggregate.issues.extend(resolved.cycles);
+            if resolved.candidates.is_empty() {
+                continue;
+            }
+            let mut next = Vec::new();
+            for left in &aggregate.candidates {
+                for right in &resolved.candidates {
+                    let Some(cfg) = combine_cfg(&left.cfg, &right.cfg) else {
+                        continue;
+                    };
+                    let mut sides = BTreeSet::new();
+                    for provenance in [&left.provenance, &right.provenance] {
+                        if let Provenance::Authority(found) = provenance {
+                            sides.extend(found);
+                        }
+                    }
+                    next.push(Candidate {
+                        provenance: if sides.is_empty() {
+                            if matches!(left.provenance, Provenance::Unknown)
+                                || matches!(right.provenance, Provenance::Unknown)
+                            {
+                                Provenance::Unknown
+                            } else {
+                                Provenance::NonAuthority
+                            }
+                        } else {
+                            Provenance::Authority(sides)
+                        },
+                        cfg,
+                    });
+                }
+            }
+            aggregate.candidates = next;
+        }
+        aggregate
+    }
+
+    fn resolve_path(&mut self, node: usize, segments: &[String], cfg: &[String]) -> Resolution {
+        let Some(first) = segments.first().map(String::as_str) else {
+            return Resolution::default();
+        };
+        if matches!(first, "crate" | "self" | "super") {
+            let Some((base, rest)) = self.relative_base(node, segments) else {
+                return self.unresolved(
+                    node,
+                    &segments.join("::"),
+                    cfg,
+                    "relative path escapes crate root",
+                );
+            };
+            return self.resolve_from_module(node, &base, rest, cfg);
+        }
+        // A local module/import named like an external crate takes lexical
+        // precedence. Only unbound crate roots use exact external identities.
+        let local = self.resolve_name(node, first, cfg);
+        if !local.candidates.is_empty() || !local.issues.is_empty() || !local.cycles.is_empty() {
+            return self.follow_resolution(node, local, &segments[1..], cfg);
+        }
+        let module = format!("{}::{first}", self.index.modules[node].module);
+        if !self.module_ids(node, &module).is_empty() {
+            return self.resolve_from_module(node, &module, &segments[1..], cfg);
+        }
+        if let Some(provenance) = recognized_absolute_provenance(segments) {
+            return Resolution::one(provenance, cfg);
+        }
+        if segments.len() > 1 {
+            // An explicit ordinary external import or enum/DTO path is known
+            // not to be one of the exact authority surfaces.
+            return Resolution::one(Provenance::NonAuthority, cfg);
+        }
+        Resolution::default()
+    }
+
+    fn follow_resolution(
+        &mut self,
+        node: usize,
+        resolution: Resolution,
+        rest: &[String],
+        cfg: &[String],
+    ) -> Resolution {
+        let mut result = Resolution {
+            candidates: Vec::new(),
+            issues: resolution.issues,
+            cycles: resolution.cycles,
+        };
+        for candidate in resolution.candidates {
+            if let Provenance::Module(module) = &candidate.provenance {
+                if !rest.is_empty() {
+                    result.append(self.resolve_from_module(node, module, rest, &candidate.cfg));
+                    continue;
+                }
+            }
+            result.candidates.push(candidate);
+        }
+        let _ = cfg;
+        result
+    }
+
+    fn resolve_from_module(
+        &mut self,
+        node: usize,
+        module: &str,
+        rest: &[String],
+        cfg: &[String],
+    ) -> Resolution {
+        let targets = self.module_ids(node, module);
+        if targets.is_empty() {
+            return self.unresolved(
+                node,
+                &format!("{module}::{}", rest.join("::")),
+                cfg,
+                "relative module or authority declaration is unavailable",
+            );
+        }
+        let mut result = Resolution::default();
+        for target in targets {
+            let Some(branch_cfg) = combine_cfg(cfg, &self.index.modules[target].cfg) else {
+                continue;
+            };
+            if rest.is_empty() {
+                result.append(Resolution::one(
+                    Provenance::Module(module.to_owned()),
+                    &branch_cfg,
+                ));
+            } else {
+                let name = &rest[0];
+                let resolved = self.resolve_name(target, name, &branch_cfg);
+                if resolved.candidates.is_empty()
+                    && resolved.issues.is_empty()
+                    && resolved.cycles.is_empty()
+                {
+                    let child = format!("{module}::{name}");
+                    if !self.module_ids(node, &child).is_empty() {
+                        result.append(self.resolve_from_module(
+                            node,
+                            &child,
+                            &rest[1..],
+                            &branch_cfg,
+                        ));
+                    } else {
+                        result.append(self.unresolved(
+                            node,
+                            name,
+                            &branch_cfg,
+                            "relative authority declaration is unavailable",
+                        ));
+                    }
+                } else {
+                    result.append(self.follow_resolution(node, resolved, &rest[1..], &branch_cfg));
+                }
+            }
+        }
+        if result.candidates.is_empty()
+            && result.issues.is_empty()
+            && result.cycles.is_empty()
+            && possible(cfg)
+        {
+            return self.unresolved(
+                node,
+                &format!("{module}::{}", rest.join("::")),
+                cfg,
+                "relative declaration is unavailable under the enclosing cfg context",
+            );
+        }
+        result
+    }
+
+    fn relative_base<'s>(&self, node: usize, path: &'s [String]) -> Option<(String, &'s [String])> {
+        let mut base = self.index.modules[node].module.clone();
+        let mut cursor = 1;
+        match path.first()?.as_str() {
+            "crate" => base = "crate".to_owned(),
+            "self" => {}
+            "super" => {
+                base = base.rsplit_once("::")?.0.to_owned();
+                while path.get(cursor).is_some_and(|segment| segment == "super") {
+                    base = base.rsplit_once("::")?.0.to_owned();
+                    cursor += 1;
+                }
+            }
+            _ => return None,
+        }
+        Some((base, &path[cursor..]))
+    }
+
+    fn module_targets(&self, node: usize, path: &[String]) -> Vec<usize> {
+        self.module_targets_inner(node, path, &mut BTreeSet::new())
+    }
+
+    fn module_targets_inner(
+        &self,
+        node: usize,
+        path: &[String],
+        active: &mut BTreeSet<(usize, Vec<String>)>,
+    ) -> Vec<usize> {
+        let key = (node, path.to_vec());
+        if !active.insert(key.clone()) {
+            return Vec::new();
+        }
+        let module = if path
+            .first()
+            .is_some_and(|s| matches!(s.as_str(), "crate" | "self" | "super"))
+        {
+            let Some((base, rest)) = self.relative_base(node, path) else {
+                return Vec::new();
+            };
+            if rest.is_empty() {
+                base
+            } else {
+                format!("{base}::{}", rest.join("::"))
+            }
+        } else {
+            format!("{}::{}", self.index.modules[node].module, path.join("::"))
+        };
+        let mut targets = self.module_ids(node, &module);
+        if targets.is_empty()
+            && let Some(first) = path.first()
+            && let Some(imports) = self.scopes[node].explicit.get(first)
+        {
+            for import in imports {
+                let mut expanded = import.path.clone();
+                expanded.extend_from_slice(&path[1..]);
+                targets.extend(self.module_targets_inner(node, &expanded, active));
+            }
+        }
+        active.remove(&key);
+        targets.sort();
+        targets.dedup();
+        targets
+    }
+
+    fn module_ids(&self, node: usize, module: &str) -> Vec<usize> {
+        self.index
+            .by_module
+            .get(&(self.index.modules[node].package.clone(), module.to_owned()))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn add_resolution(
+        &self,
+        symbols: &mut Symbols,
+        node: usize,
+        path: &[String],
+        cfg: &[String],
+        mut resolution: Resolution,
+    ) {
+        let key = path.join("::");
+        resolution.issues.append(&mut resolution.cycles);
+        let guards = resolution
+            .candidates
+            .iter()
+            .map(|c| c.cfg.clone())
+            .collect::<Vec<_>>();
+        // A conditional binding with no fallback leaves the name unresolved in
+        // part of the candidate's context. Keep that alternative, too.
+        if !resolution.candidates.is_empty()
+            && let Some(uncovered) = uncovered_cfg(cfg, &guards)
+        {
+            resolution.candidates.push(Candidate {
+                provenance: Provenance::Unknown,
+                cfg: uncovered,
+            });
+        }
+        let alternatives = resolution
+            .candidates
+            .iter()
+            .map(|candidate| candidate.provenance.clone())
+            .collect::<BTreeSet<_>>();
+        let authority = alternatives
+            .iter()
+            .filter_map(|provenance| {
+                if let Provenance::Authority(sides) = provenance {
+                    Some(sides)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        if !authority.is_empty() && alternatives.len() > 1 {
+            resolution.issues.insert(self.diagnostic(
+                node,
+                &key,
+                "ambiguous authority candidates under the enclosing cfg context",
+            ));
+        }
+        if alternatives.len() == 1 && resolution.issues.is_empty() {
+            if let Some(sides) = authority.first() {
+                symbols.qualified.insert(key.clone(), (**sides).clone());
+                if path.len() == 1 {
+                    symbols.named.insert(key.clone(), (**sides).clone());
+                }
+            } else {
+                symbols.qualified.insert(key.clone(), BTreeSet::new());
+                if path.len() == 1 {
+                    symbols.non_authority.insert(key.clone());
+                }
+            }
+        } else {
+            // Resolved unknowns must not fall back to curated spelling rules.
+            symbols.qualified.insert(key.clone(), BTreeSet::new());
+        }
+        if !resolution.issues.is_empty() {
+            symbols.path_issues.insert(
+                key,
+                resolution.issues.into_iter().collect::<Vec<_>>().join("; "),
+            );
+        }
+    }
+
+    fn symbols_for(&mut self, node: usize, cfg: &[String], paths: &[Vec<String>]) -> Symbols {
+        let mut symbols = Symbols::default();
+        let missing_globs = self.missing_relative_globs(node, cfg, &mut BTreeSet::new());
+        for path in paths {
+            let result = self.resolve_path(node, path, cfg);
+            if !missing_globs.is_empty()
+                && let Some(first) = path.first()
+                && !self.has_visible_binding(node, first, &mut BTreeSet::new())
+                && recognized_absolute_provenance(path).is_none()
+                && !matches!(first.as_str(), "crate" | "self" | "super" | "Self")
+            {
+                symbols.unresolved_glob_paths.insert(
+                    path.join("::"),
+                    self.diagnostic(
+                        node,
+                        &path.join("::"),
+                        &format!(
+                            "relative glob context is unavailable: {}",
+                            missing_globs.iter().cloned().collect::<Vec<_>>().join(", "),
+                        ),
+                    ),
+                );
+            }
+            self.add_resolution(&mut symbols, node, path, cfg, result);
+        }
+        symbols
+    }
+
+    fn all_symbols(&mut self) -> Vec<Symbols> {
+        let mut all = Vec::new();
+        for node in 0..self.index.modules.len() {
+            let module = &self.index.modules[node];
+            let cfg = module.cfg.clone();
+            let contexts = cfg_context::item_cfg_contexts(&module.items, &cfg);
+            let mut collector = PathCollector::default();
+            for item in &module.items {
+                if matches!(item, Item::Use(_)) {
+                    continue;
+                }
+                collector.visit_item(item);
+            }
+            let paths = collector.paths.into_iter().collect::<Vec<_>>();
+            let mut symbols = self.symbols_for(node, &cfg, &paths);
+            for context in contexts {
+                let table = self.symbols_for(node, &context, &paths);
+                symbols.contexts.insert(context, table);
+            }
+            all.push(symbols);
+        }
+        all
+    }
+}
+
+#[derive(Default)]
+struct PathCollector {
+    paths: BTreeSet<Vec<String>>,
+}
+
+impl<'ast> Visit<'ast> for PathCollector {
+    fn visit_path(&mut self, path: &'ast Path) {
+        self.paths
+            .insert(path.segments.iter().map(|s| s.ident.to_string()).collect());
+        visit::visit_path(self, path);
+    }
+
+    fn visit_item_mod(&mut self, _item: &'ast ItemMod) {}
+
+    fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+        let mut explicit = Vec::new();
+        let mut globs = Vec::new();
+        collect_use_specs(&item.tree, &mut Vec::new(), &mut explicit, &mut globs);
+        self.paths
+            .extend(explicit.into_iter().map(|(_, path)| path));
+    }
+
+    fn visit_macro(&mut self, mac: &'ast syn::Macro) {
+        self.paths.extend(token_paths(&mac.tokens));
+    }
+}
+
+pub(super) fn token_paths(tokens: &proc_macro2::TokenStream) -> BTreeSet<Vec<String>> {
+    use proc_macro2::TokenTree;
+    let trees = tokens.clone().into_iter().collect::<Vec<_>>();
+    let mut paths = BTreeSet::new();
+    for tree in &trees {
+        if let TokenTree::Group(group) = tree {
+            paths.extend(token_paths(&group.stream()));
+        }
+    }
+    for start in 0..trees.len() {
+        if start >= 2
+            && matches!(&trees[start - 2], TokenTree::Punct(p) if p.as_char() == ':')
+            && matches!(&trees[start - 1], TokenTree::Punct(p) if p.as_char() == ':')
+        {
+            continue;
+        }
+        let TokenTree::Ident(first) = &trees[start] else {
+            continue;
+        };
+        let mut path = vec![first.to_string()];
+        let mut cursor = start + 1;
+        while cursor + 2 < trees.len()
+            && matches!(&trees[cursor], TokenTree::Punct(p) if p.as_char() == ':')
+            && matches!(&trees[cursor + 1], TokenTree::Punct(p) if p.as_char() == ':')
+        {
+            let TokenTree::Ident(next) = &trees[cursor + 2] else {
+                break;
+            };
+            path.push(next.to_string());
+            cursor += 3;
+        }
+        paths.insert(path);
+    }
+    paths
+}
+
+fn known_authority_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Creature"
+            | "WorldCreature"
+            | "MapManager"
+            | "SharedMapManager"
+            | "LegacyMapManager"
+            | "SharedCanonicalMapManager"
+    )
+}
+
+fn recognized_absolute_provenance(segments: &[String]) -> Option<Provenance> {
+    let first = segments.first()?.as_str();
+    let canonical_map = segments
+        .get(1)
+        .is_some_and(|s| matches!(s.as_str(), "MapManager" | "ManagedMap" | "Map"))
+        || (segments
+            .get(1)
+            .is_some_and(|s| matches!(s.as_str(), "manager" | "map"))
+            && segments
+                .get(2)
+                .is_some_and(|s| matches!(s.as_str(), "MapManager" | "ManagedMap" | "Map")));
+    if (first == "wow_map" && canonical_map)
+        || (first == "wow_entities" && segments.get(1).is_some_and(|s| s == "Creature"))
+        || (first == "wow_world"
+            && (segments
+                .get(1)
+                .is_some_and(|s| s == "SharedCanonicalMapManager")
+                || (segments.get(1).is_some_and(|s| s == "session")
+                    && segments
+                        .get(2)
+                        .is_some_and(|s| s == "SharedCanonicalMapManager"))))
+    {
+        return Some(Provenance::Authority(BTreeSet::from([
+            BridgeSide::Canonical,
+        ])));
+    }
+    let legacy = |name: &str| {
+        matches!(
+            name,
+            "MapManager" | "SharedMapManager" | "LegacyMapManager" | "WorldCreature"
+        )
+    };
+    if first == "wow_world"
+        && (segments.get(1).is_some_and(|s| legacy(s))
+            || (segments.get(1).is_some_and(|s| s == "map_manager")
+                && segments.get(2).is_some_and(|s| legacy(s))))
+    {
+        return Some(Provenance::Authority(BTreeSet::from([BridgeSide::Legacy])));
+    }
+    None
+}
+
+pub(super) fn resolve_module_symbols(
+    index: &ModuleIndex,
+    errors: &mut Vec<String>,
+) -> Vec<Symbols> {
+    let mut mounts = BTreeSet::new();
+    for module in &index.modules {
+        if !mounts.insert((
+            &module.package,
+            &module.module,
+            &module.source_path,
+            &module.cfg,
+        )) {
+            errors.push(format!(
+                "duplicate bridge source mount {} {} {}",
+                module.package, module.module, module.source_path,
+            ));
+        }
+    }
+    Resolver::new(index, errors).all_symbols()
+}
+
+pub(super) fn build_module_index(sources: &[(BridgeSource<'_>, syn::File)]) -> ModuleIndex {
+    let mut index = ModuleIndex::default();
+    for (source, syntax) in sources {
+        index.add_source(*source, syntax.clone());
+    }
+    index
+}

--- a/tools/architecture/handler-contract-check/src/bridge_access/provenance/candidate_visitor.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access/provenance/candidate_visitor.rs
@@ -1,0 +1,320 @@
+//! Candidate AST traversal, including lexical cfg transitions.
+
+use std::collections::BTreeSet;
+
+use syn::visit::{self, Visit};
+use syn::{
+    Attribute, Expr, ExprCall, ExprField, ExprMacro, ExprMethodCall, FnArg, Item, Local, Member,
+    Pat, Path,
+};
+
+use super::super::{
+    BridgeEvidenceKind, CandidateAnalyzer, add_use_to_symbols, collect_use_bindings,
+    last_path_ident, normalized_tokens, sides_in_type_with_cfg, validate_cfg,
+};
+use crate::ownership::extend_cfg_context;
+
+impl CandidateAnalyzer<'_> {
+    pub(in crate::bridge_access) fn apply_local_imports(&mut self) {
+        for (guard, import) in self.local_imports.clone() {
+            if super::combine_cfg(&self.active_cfg, &guard).is_none() {
+                continue;
+            }
+            add_use_to_symbols(&import, &mut self.symbols, self.errors);
+            if super::uncovered_cfg(&self.active_cfg, &[guard]).is_some() {
+                let mut bindings = Vec::new();
+                let mut globs = Vec::new();
+                collect_use_bindings(&import.tree, &mut Vec::new(), &mut bindings, &mut globs);
+                for (name, _) in bindings {
+                    self.symbols.bind_local_import(
+                        &name, BTreeSet::new(), Some(format!(
+                            "cannot resolve bridge provenance for {} local import {name}: conditional binding under enclosing cfg",
+                            self.enclosing,
+                        )),
+                    );
+                }
+            }
+        }
+    }
+
+    pub(in crate::bridge_access) fn within_cfg(
+        &mut self,
+        attrs: &[Attribute],
+        visit: impl FnOnce(&mut Self),
+    ) {
+        if !attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("cfg") || attr.path().is_ident("cfg_attr"))
+        {
+            visit(self);
+            return;
+        }
+        let next = extend_cfg_context(&self.active_cfg, attrs);
+        if next == self.active_cfg {
+            visit(self);
+            return;
+        }
+        validate_cfg(&self.active_cfg, attrs, &self.enclosing, self.errors);
+        let previous_cfg = self.active_cfg.clone();
+        let previous_symbols = std::mem::take(&mut self.symbols);
+        self.set_active_cfg(next);
+        visit(self);
+        self.active_cfg = previous_cfg;
+        self.symbols = previous_symbols;
+    }
+
+    pub(in crate::bridge_access) fn report_missing_glob_path(
+        &mut self,
+        path: &Path,
+        value_position: bool,
+    ) {
+        let Some(first) = path
+            .segments
+            .first()
+            .map(|segment| segment.ident.to_string())
+        else {
+            return;
+        };
+        if self.generic_parameters.contains(&first)
+            || (value_position && self.variables.contains_key(&first))
+            || first == "Self"
+        {
+            return;
+        }
+        let key = path
+            .segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::");
+        if let Some(issue) = self.symbols.unresolved_glob_paths.get(&key)
+            && self.reported_resolution_issues.insert(key)
+        {
+            self.errors.push(issue.clone());
+        }
+    }
+
+    pub(in crate::bridge_access) fn report_path_issue(&mut self, path: &Path) {
+        let key = path
+            .segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::");
+        if let Some(issue) = self.symbols.path_issue_with_cfg(path, &self.active_cfg)
+            && self.reported_resolution_issues.insert(key)
+        {
+            self.errors.push(issue.to_owned());
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for CandidateAnalyzer<'_> {
+    fn visit_block(&mut self, block: &'ast syn::Block) {
+        let previous_symbols = self.symbols.clone();
+        let inherited_imports = self.local_imports.len();
+        for statement in &block.stmts {
+            if let syn::Stmt::Item(Item::Use(import)) = statement {
+                self.local_imports.push((
+                    extend_cfg_context(&self.active_cfg, &import.attrs),
+                    import.clone(),
+                ));
+            }
+        }
+        self.apply_local_imports();
+        visit::visit_block(self, block);
+        self.local_imports.truncate(inherited_imports);
+        self.symbols = previous_symbols;
+    }
+
+    fn visit_expr(&mut self, expression: &'ast Expr) {
+        self.within_cfg(
+            super::cfg_context::expression_attributes(expression),
+            |analyzer| {
+                visit::visit_expr(analyzer, expression);
+            },
+        );
+    }
+
+    fn visit_stmt(&mut self, statement: &'ast syn::Stmt) {
+        self.within_cfg(
+            super::cfg_context::statement_attributes(statement),
+            |analyzer| {
+                visit::visit_stmt(analyzer, statement);
+            },
+        );
+    }
+
+    fn visit_field(&mut self, field: &'ast syn::Field) {
+        self.within_cfg(&field.attrs, |analyzer| visit::visit_field(analyzer, field));
+    }
+
+    fn visit_variant(&mut self, variant: &'ast syn::Variant) {
+        self.within_cfg(&variant.attrs, |analyzer| {
+            visit::visit_variant(analyzer, variant)
+        });
+    }
+
+    fn visit_field_value(&mut self, field: &'ast syn::FieldValue) {
+        self.within_cfg(&field.attrs, |analyzer| {
+            visit::visit_field_value(analyzer, field)
+        });
+    }
+
+    fn visit_arm(&mut self, arm: &'ast syn::Arm) {
+        self.within_cfg(&arm.attrs, |analyzer| visit::visit_arm(analyzer, arm));
+    }
+
+    fn visit_fn_arg(&mut self, argument: &'ast FnArg) {
+        self.within_cfg(
+            super::cfg_context::argument_attributes(argument),
+            |analyzer| {
+                visit::visit_fn_arg(analyzer, argument);
+            },
+        );
+    }
+
+    fn visit_type_path(&mut self, path: &'ast syn::TypePath) {
+        self.report_path_issue(&path.path);
+        self.report_missing_glob_path(&path.path, false);
+        let sides = self
+            .symbols
+            .sides_for_path_with_cfg(&path.path, &self.active_cfg);
+        if !sides.is_empty() {
+            self.add_sides(
+                &sides,
+                BridgeEvidenceKind::TypeReference,
+                last_path_ident(&path.path).unwrap_or_else(|| "<type>".to_owned()),
+                normalized_tokens(path),
+            );
+        }
+        visit::visit_type_path(self, path);
+    }
+
+    fn visit_expr_path(&mut self, path: &'ast syn::ExprPath) {
+        let local_value = path.path.segments.len() == 1
+            && path
+                .path
+                .segments
+                .first()
+                .is_some_and(|segment| self.variables.contains_key(&segment.ident.to_string()));
+        if !local_value {
+            self.report_path_issue(&path.path);
+        }
+        self.report_missing_glob_path(&path.path, true);
+        let mut sides = self
+            .symbols
+            .sides_for_path_with_cfg(&path.path, &self.active_cfg);
+        if let Some(name) = last_path_ident(&path.path) {
+            if let Some(variable_sides) = self.variables.get(&name) {
+                sides.extend(variable_sides);
+            }
+        }
+        if !sides.is_empty() {
+            self.add_sides(
+                &sides,
+                BridgeEvidenceKind::ValueReference,
+                last_path_ident(&path.path).unwrap_or_else(|| "<value>".to_owned()),
+                normalized_tokens(path),
+            );
+        }
+        visit::visit_expr_path(self, path);
+    }
+
+    fn visit_expr_field(&mut self, field: &'ast ExprField) {
+        let sides = self.sides_of_expr(&Expr::Field(field.clone()));
+        if !sides.is_empty() {
+            let symbol = match &field.member {
+                Member::Named(member) => member.to_string(),
+                Member::Unnamed(index) => index.index.to_string(),
+            };
+            self.add_sides(
+                &sides,
+                BridgeEvidenceKind::FieldAccess,
+                symbol,
+                normalized_tokens(field),
+            );
+        }
+        visit::visit_expr_field(self, field);
+    }
+
+    fn visit_expr_call(&mut self, call: &'ast ExprCall) {
+        if let Expr::Path(path) = call.func.as_ref() {
+            let name = last_path_ident(&path.path).unwrap_or_else(|| "<call>".to_owned());
+            let sides = self
+                .symbols
+                .sides_for_path_with_cfg(&path.path, &self.active_cfg);
+            if !sides.is_empty() {
+                self.add_sides(
+                    &sides,
+                    BridgeEvidenceKind::FunctionCall,
+                    name.clone(),
+                    normalized_tokens(call),
+                );
+            }
+        }
+        visit::visit_expr_call(self, call);
+    }
+
+    fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
+        let name = call.method.to_string();
+        let sides = self.sides_of_expr(&call.receiver);
+        if !sides.is_empty() {
+            self.add_sides(
+                &sides,
+                BridgeEvidenceKind::MethodCall,
+                name.clone(),
+                normalized_tokens(call),
+            );
+        }
+        visit::visit_expr_method_call(self, call);
+    }
+
+    fn visit_local(&mut self, local: &'ast Local) {
+        if let Pat::Type(typed) = &local.pat {
+            self.visit_type(&typed.ty);
+        }
+        let mut sides = BTreeSet::new();
+        if let Some(init) = &local.init {
+            self.visit_expr(&init.expr);
+            sides.extend(self.sides_of_expr(&init.expr));
+            if let Some((_, diverge)) = &init.diverge {
+                self.visit_expr(diverge);
+            }
+        }
+        if let Pat::Type(typed) = &local.pat {
+            sides.extend(sides_in_type_with_cfg(
+                &self.symbols,
+                &typed.ty,
+                &self.active_cfg,
+            ));
+        }
+        self.bind_pattern(&local.pat, &sides);
+    }
+
+    fn visit_expr_macro(&mut self, expression: &'ast ExprMacro) {
+        self.audit_macro(&expression.mac, "expression macro");
+    }
+
+    fn visit_stmt_macro(&mut self, statement: &'ast syn::StmtMacro) {
+        self.audit_macro(&statement.mac, "statement macro");
+    }
+
+    fn visit_type_macro(&mut self, type_macro: &'ast syn::TypeMacro) {
+        self.audit_macro(&type_macro.mac, "type macro");
+    }
+
+    fn visit_item(&mut self, item: &'ast Item) {
+        match item {
+            // Rust block imports are in scope throughout the block. They
+            // were bound on block entry, including their cfg guard.
+            Item::Use(_) => {}
+            Item::Macro(item_macro) => {
+                self.audit_macro(&item_macro.mac, "nested item macro");
+            }
+            // Nested items have their own enclosing identity and must be passed
+            // as source/module items rather than folded into this function.
+            _ => {}
+        }
+    }
+}

--- a/tools/architecture/handler-contract-check/src/bridge_access/provenance/cfg_context.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access/provenance/cfg_context.rs
@@ -1,0 +1,174 @@
+//! Collect the same nested cfg contexts that candidate traversal enters.
+
+use std::collections::BTreeSet;
+
+use syn::visit::{self, Visit};
+use syn::{Attribute, Expr, FnArg, ImplItem, Item};
+
+use super::scope::item_attributes;
+use crate::ownership::extend_cfg_context;
+
+pub(super) fn expression_attributes(expression: &Expr) -> &[Attribute] {
+    match expression {
+        Expr::Array(value) => &value.attrs,
+        Expr::Assign(value) => &value.attrs,
+        Expr::Async(value) => &value.attrs,
+        Expr::Await(value) => &value.attrs,
+        Expr::Binary(value) => &value.attrs,
+        Expr::Block(value) => &value.attrs,
+        Expr::Break(value) => &value.attrs,
+        Expr::Call(value) => &value.attrs,
+        Expr::Cast(value) => &value.attrs,
+        Expr::Closure(value) => &value.attrs,
+        Expr::Const(value) => &value.attrs,
+        Expr::Continue(value) => &value.attrs,
+        Expr::Field(value) => &value.attrs,
+        Expr::ForLoop(value) => &value.attrs,
+        Expr::Group(value) => &value.attrs,
+        Expr::If(value) => &value.attrs,
+        Expr::Index(value) => &value.attrs,
+        Expr::Infer(value) => &value.attrs,
+        Expr::Let(value) => &value.attrs,
+        Expr::Lit(value) => &value.attrs,
+        Expr::Loop(value) => &value.attrs,
+        Expr::Macro(value) => &value.attrs,
+        Expr::Match(value) => &value.attrs,
+        Expr::MethodCall(value) => &value.attrs,
+        Expr::Paren(value) => &value.attrs,
+        Expr::Path(value) => &value.attrs,
+        Expr::Range(value) => &value.attrs,
+        Expr::RawAddr(value) => &value.attrs,
+        Expr::Reference(value) => &value.attrs,
+        Expr::Repeat(value) => &value.attrs,
+        Expr::Return(value) => &value.attrs,
+        Expr::Struct(value) => &value.attrs,
+        Expr::Try(value) => &value.attrs,
+        Expr::TryBlock(value) => &value.attrs,
+        Expr::Tuple(value) => &value.attrs,
+        Expr::Unary(value) => &value.attrs,
+        Expr::Unsafe(value) => &value.attrs,
+        Expr::While(value) => &value.attrs,
+        Expr::Yield(value) => &value.attrs,
+        _ => &[],
+    }
+}
+
+pub(super) fn statement_attributes(statement: &syn::Stmt) -> &[Attribute] {
+    match statement {
+        syn::Stmt::Local(local) => &local.attrs,
+        syn::Stmt::Macro(mac) => &mac.attrs,
+        syn::Stmt::Item(item) => item_attributes(item),
+        syn::Stmt::Expr(_, _) => &[],
+    }
+}
+
+pub(super) fn argument_attributes(argument: &FnArg) -> &[Attribute] {
+    match argument {
+        FnArg::Receiver(receiver) => &receiver.attrs,
+        FnArg::Typed(typed) => &typed.attrs,
+    }
+}
+
+fn impl_item_attributes(item: &ImplItem) -> &[Attribute] {
+    match item {
+        ImplItem::Fn(item) => &item.attrs,
+        ImplItem::Const(item) => &item.attrs,
+        ImplItem::Type(item) => &item.attrs,
+        ImplItem::Macro(item) => &item.attrs,
+        _ => &[],
+    }
+}
+
+struct ContextCollector {
+    current: Vec<String>,
+    contexts: BTreeSet<Vec<String>>,
+}
+
+impl ContextCollector {
+    fn within(&mut self, attrs: &[Attribute], visit: impl FnOnce(&mut Self)) {
+        if !attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("cfg") || attr.path().is_ident("cfg_attr"))
+        {
+            visit(self);
+            return;
+        }
+        let next = extend_cfg_context(&self.current, attrs);
+        if next == self.current {
+            visit(self);
+            return;
+        }
+        self.contexts.insert(next.clone());
+        let previous = std::mem::replace(&mut self.current, next);
+        visit(self);
+        self.current = previous;
+    }
+}
+
+impl<'ast> Visit<'ast> for ContextCollector {
+    fn visit_item(&mut self, item: &'ast Item) {
+        if matches!(item, Item::Mod(_)) {
+            return;
+        }
+        self.within(item_attributes(item), |collector| {
+            visit::visit_item(collector, item)
+        });
+    }
+
+    fn visit_impl_item(&mut self, item: &'ast ImplItem) {
+        self.within(impl_item_attributes(item), |collector| {
+            visit::visit_impl_item(collector, item)
+        });
+    }
+
+    fn visit_expr(&mut self, expression: &'ast Expr) {
+        self.within(expression_attributes(expression), |collector| {
+            visit::visit_expr(collector, expression);
+        });
+    }
+
+    fn visit_stmt(&mut self, statement: &'ast syn::Stmt) {
+        self.within(statement_attributes(statement), |collector| {
+            visit::visit_stmt(collector, statement);
+        });
+    }
+
+    fn visit_field(&mut self, field: &'ast syn::Field) {
+        self.within(&field.attrs, |collector| {
+            visit::visit_field(collector, field)
+        });
+    }
+
+    fn visit_variant(&mut self, variant: &'ast syn::Variant) {
+        self.within(&variant.attrs, |collector| {
+            visit::visit_variant(collector, variant)
+        });
+    }
+
+    fn visit_field_value(&mut self, field: &'ast syn::FieldValue) {
+        self.within(&field.attrs, |collector| {
+            visit::visit_field_value(collector, field)
+        });
+    }
+
+    fn visit_arm(&mut self, arm: &'ast syn::Arm) {
+        self.within(&arm.attrs, |collector| visit::visit_arm(collector, arm));
+    }
+
+    fn visit_fn_arg(&mut self, argument: &'ast FnArg) {
+        self.within(argument_attributes(argument), |collector| {
+            visit::visit_fn_arg(collector, argument)
+        });
+    }
+}
+
+pub(super) fn item_cfg_contexts(items: &[Item], cfg: &[String]) -> BTreeSet<Vec<String>> {
+    let mut collector = ContextCollector {
+        current: cfg.to_vec(),
+        contexts: BTreeSet::from([cfg.to_vec()]),
+    };
+    for item in items {
+        collector.visit_item(item);
+    }
+    collector.contexts
+}

--- a/tools/architecture/handler-contract-check/src/bridge_access/provenance/glob_context.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access/provenance/glob_context.rs
@@ -1,0 +1,57 @@
+//! Identify unavailable relative glob context without guessing imported names.
+
+use std::collections::BTreeSet;
+
+use super::{Resolver, combine_cfg, uncovered_cfg};
+
+impl Resolver<'_> {
+    pub(super) fn missing_relative_globs(
+        &self,
+        node: usize,
+        cfg: &[String],
+        active: &mut BTreeSet<usize>,
+    ) -> BTreeSet<String> {
+        if !active.insert(node) {
+            return BTreeSet::new();
+        }
+        let mut missing = BTreeSet::new();
+        for glob in &self.scopes[node].globs {
+            let Some(branch_cfg) = combine_cfg(cfg, &glob.cfg) else {
+                continue;
+            };
+            let targets = self.module_targets(node, &glob.path);
+            if targets.is_empty() {
+                if glob.path.first().is_some_and(|first| {
+                    matches!(first.as_str(), "crate" | "self" | "super")
+                        || self.scopes[node].declarations.contains_key(first)
+                        || self.scopes[node].explicit.contains_key(first)
+                }) {
+                    missing.insert(format!(
+                        "{}::use {}::*",
+                        self.index.modules[node].module,
+                        glob.path.join("::"),
+                    ));
+                }
+            } else {
+                let mut available_cfg = Vec::new();
+                for target in targets {
+                    if let Some(target_cfg) =
+                        combine_cfg(&branch_cfg, &self.index.modules[target].cfg)
+                    {
+                        available_cfg.push(target_cfg.clone());
+                        missing.extend(self.missing_relative_globs(target, &target_cfg, active));
+                    }
+                }
+                if uncovered_cfg(&branch_cfg, &available_cfg).is_some() {
+                    missing.insert(format!(
+                        "{}::use {}::* (unavailable under enclosing cfg)",
+                        self.index.modules[node].module,
+                        glob.path.join("::"),
+                    ));
+                }
+            }
+        }
+        active.remove(&node);
+        missing
+    }
+}

--- a/tools/architecture/handler-contract-check/src/bridge_access/provenance/scope.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access/provenance/scope.rs
@@ -1,0 +1,235 @@
+//! Declarations, imports and cfg guards used by bridge provenance resolution.
+
+use std::collections::BTreeMap;
+
+use syn::{Attribute, Item, Type, UseTree};
+
+use super::super::{
+    BridgeSide, Symbols, bridge_capable_namespace_import, sides_for_segments, validate_cfg,
+};
+use super::source_graph::IndexedModule;
+use crate::ownership::{
+    cfg_context_allows_production, cfg_context_allows_test, extend_cfg_context,
+};
+
+#[derive(Clone)]
+pub(super) enum LocalBinding {
+    NonAuthority,
+    Authority(BridgeSide),
+    Module(String),
+    Alias(Type),
+}
+
+#[derive(Clone)]
+pub(super) struct DeclaredBinding {
+    pub(super) binding: LocalBinding,
+    pub(super) cfg: Vec<String>,
+}
+
+#[derive(Clone)]
+pub(super) struct ImportBinding {
+    pub(super) path: Vec<String>,
+    pub(super) cfg: Vec<String>,
+}
+
+#[derive(Clone)]
+pub(super) struct GlobBinding {
+    pub(super) path: Vec<String>,
+    pub(super) cfg: Vec<String>,
+}
+
+#[derive(Clone, Default)]
+pub(super) struct ModuleScope {
+    pub(super) declarations: BTreeMap<String, Vec<DeclaredBinding>>,
+    pub(super) explicit: BTreeMap<String, Vec<ImportBinding>>,
+    pub(super) globs: Vec<GlobBinding>,
+    pub(super) builtins: BTreeMap<String, BridgeSide>,
+}
+
+pub(super) fn collect_use_specs(
+    tree: &UseTree,
+    prefix: &mut Vec<String>,
+    explicit: &mut Vec<(String, Vec<String>)>,
+    globs: &mut Vec<Vec<String>>,
+) {
+    match tree {
+        UseTree::Path(path) => {
+            prefix.push(path.ident.to_string());
+            collect_use_specs(&path.tree, prefix, explicit, globs);
+            prefix.pop();
+        }
+        UseTree::Name(name) => {
+            if name.ident == "self" {
+                if let Some(local) = prefix.last() {
+                    explicit.push((local.to_string(), prefix.clone()));
+                }
+            } else {
+                let mut path = prefix.clone();
+                path.push(name.ident.to_string());
+                explicit.push((name.ident.to_string(), path));
+            }
+        }
+        UseTree::Rename(rename) => {
+            let mut path = prefix.clone();
+            if rename.ident != "self" {
+                path.push(rename.ident.to_string());
+            }
+            explicit.push((rename.rename.to_string(), path));
+        }
+        UseTree::Group(group) => {
+            for item in &group.items {
+                collect_use_specs(item, prefix, explicit, globs);
+            }
+        }
+        UseTree::Glob(_) => globs.push(prefix.clone()),
+    }
+}
+
+fn cfg_for_binding(parent: &[String], attrs: &[Attribute]) -> Option<Vec<String>> {
+    let cfg = extend_cfg_context(parent, attrs);
+    let production = cfg_context_allows_production(&cfg, &[]).ok()?;
+    let test = cfg_context_allows_test(&cfg, &[]).ok()?;
+    (production || test).then_some(cfg)
+}
+
+pub(super) fn collect_scope(module: &IndexedModule, errors: &mut Vec<String>) -> ModuleScope {
+    let mut scope = ModuleScope::default();
+    for (name, sides) in Symbols::for_module(&module.package, &module.module).named {
+        if let Some(side) = sides.iter().next().copied() {
+            scope.builtins.insert(name, side);
+        }
+    }
+    for item in &module.items {
+        let attrs = item_attributes(item);
+        validate_cfg(&module.cfg, attrs, &module.module, errors);
+        let Some(cfg) = cfg_for_binding(&module.cfg, attrs) else {
+            continue;
+        };
+        match item {
+            Item::Use(item_use) => {
+                let mut explicit = Vec::new();
+                let mut globs = Vec::new();
+                collect_use_specs(&item_use.tree, &mut Vec::new(), &mut explicit, &mut globs);
+                for (local, path) in explicit {
+                    if sides_for_segments(
+                        &Symbols::for_module(&module.package, &module.module),
+                        &path,
+                    )
+                    .is_empty()
+                        && bridge_capable_namespace_import(&path)
+                        && path.first().is_some_and(|root| {
+                            !matches!(root.as_str(), "crate" | "self" | "super")
+                        })
+                        && !(path.len() == 1 && local == path[0])
+                    {
+                        errors.push(format!(
+                            "bridge-capable namespace import `{}` as `{local}` hides exact legacy/canonical symbols",
+                            path.join("::")
+                        ));
+                    }
+                    scope
+                        .explicit
+                        .entry(local.clone())
+                        .or_default()
+                        .push(ImportBinding {
+                            path,
+                            cfg: cfg.clone(),
+                        });
+                }
+                for path in globs {
+                    if path.first().is_some_and(|root| {
+                        matches!(root.as_str(), "wow_map" | "wow_entities" | "wow_world")
+                    }) {
+                        errors.push(format!(
+                            "bridge-capable glob import `{}` hides exact legacy/canonical symbols",
+                            path.join("::")
+                        ));
+                    }
+                    scope.globs.push(GlobBinding {
+                        path,
+                        cfg: cfg.clone(),
+                    });
+                }
+            }
+            Item::Type(item_type) => {
+                let binding = if module.package == "wow-world"
+                    && module.module == "crate::map_manager"
+                    && matches!(
+                        item_type.ident.to_string().as_str(),
+                        "MapManager" | "WorldCreature" | "SharedMapManager"
+                    ) {
+                    LocalBinding::Authority(BridgeSide::Legacy)
+                } else {
+                    LocalBinding::Alias((*item_type.ty).clone())
+                };
+                scope
+                    .declarations
+                    .entry(item_type.ident.to_string())
+                    .or_default()
+                    .push(DeclaredBinding { binding, cfg });
+            }
+            _ => {
+                if let Some(name) = item_declared_name(item) {
+                    let binding = if module.package == "wow-world"
+                        && module.module == "crate::map_manager"
+                        && matches!(
+                            name.as_str(),
+                            "MapManager" | "WorldCreature" | "SharedMapManager"
+                        ) {
+                        LocalBinding::Authority(BridgeSide::Legacy)
+                    } else if matches!(item, Item::Mod(_)) {
+                        LocalBinding::Module(format!("{}::{name}", module.module))
+                    } else {
+                        LocalBinding::NonAuthority
+                    };
+                    scope
+                        .declarations
+                        .entry(name)
+                        .or_default()
+                        .push(DeclaredBinding { binding, cfg });
+                }
+            }
+        }
+    }
+    scope
+}
+
+pub(super) fn item_attributes(item: &Item) -> &[Attribute] {
+    match item {
+        Item::Const(item) => &item.attrs,
+        Item::Enum(item) => &item.attrs,
+        Item::ExternCrate(item) => &item.attrs,
+        Item::Fn(item) => &item.attrs,
+        Item::ForeignMod(item) => &item.attrs,
+        Item::Impl(item) => &item.attrs,
+        Item::Macro(item) => &item.attrs,
+        Item::Mod(item) => &item.attrs,
+        Item::Static(item) => &item.attrs,
+        Item::Struct(item) => &item.attrs,
+        Item::Trait(item) => &item.attrs,
+        Item::TraitAlias(item) => &item.attrs,
+        Item::Type(item) => &item.attrs,
+        Item::Union(item) => &item.attrs,
+        Item::Use(item) => &item.attrs,
+        Item::Verbatim(_) => &[],
+        _ => &[],
+    }
+}
+
+fn item_declared_name(item: &Item) -> Option<String> {
+    match item {
+        Item::Const(item) => Some(item.ident.to_string()),
+        Item::Enum(item) => Some(item.ident.to_string()),
+        Item::ExternCrate(item) => Some(item.ident.to_string()),
+        Item::Fn(item) => Some(item.sig.ident.to_string()),
+        Item::Macro(item) => item.ident.as_ref().map(ToString::to_string),
+        Item::Mod(item) => Some(item.ident.to_string()),
+        Item::Static(item) => Some(item.ident.to_string()),
+        Item::Struct(item) => Some(item.ident.to_string()),
+        Item::Trait(item) => Some(item.ident.to_string()),
+        Item::TraitAlias(item) => Some(item.ident.to_string()),
+        Item::Type(item) => Some(item.ident.to_string()),
+        Item::Union(item) => Some(item.ident.to_string()),
+        _ => None,
+    }
+}

--- a/tools/architecture/handler-contract-check/src/bridge_access/provenance/source_graph.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access/provenance/source_graph.rs
@@ -1,0 +1,81 @@
+//! Supplied source mounts and their lexical inline module relationships.
+
+use std::collections::BTreeMap;
+
+use syn::{Item, ItemMod};
+
+use super::super::BridgeSource;
+use crate::ownership::extend_cfg_context;
+
+#[derive(Clone)]
+pub(in crate::bridge_access) struct IndexedModule {
+    pub(in crate::bridge_access) package: String,
+    pub(in crate::bridge_access) module: String,
+    pub(in crate::bridge_access) source_path: String,
+    pub(in crate::bridge_access) cfg: Vec<String>,
+    pub(in crate::bridge_access) items: Vec<Item>,
+}
+
+#[derive(Default)]
+pub(in crate::bridge_access) struct ModuleIndex {
+    pub(in crate::bridge_access) modules: Vec<IndexedModule>,
+    pub(super) by_module: BTreeMap<(String, String), Vec<usize>>,
+}
+
+impl ModuleIndex {
+    pub(super) fn add_source(&mut self, source: BridgeSource<'_>, syntax: syn::File) {
+        let cfg = extend_cfg_context(source.inherited_cfg, &syntax.attrs);
+        self.add_module(
+            source.package.to_owned(),
+            source.module.to_owned(),
+            source.source_path.to_owned(),
+            cfg,
+            syntax.items,
+        );
+    }
+
+    fn add_module(
+        &mut self,
+        package: String,
+        module: String,
+        source_path: String,
+        cfg: Vec<String>,
+        items: Vec<Item>,
+    ) {
+        let id = self.modules.len();
+        self.by_module
+            .entry((package.clone(), module.clone()))
+            .or_default()
+            .push(id);
+        self.modules.push(IndexedModule {
+            package: package.clone(),
+            module: module.clone(),
+            source_path: source_path.clone(),
+            cfg: cfg.clone(),
+            items: items.clone(),
+        });
+
+        // Inline and external modules are intentionally entered through the
+        // same graph.  External children arrive as their own BridgeSource;
+        // inline children use this source mount and inherit its cfg.
+        for item in items {
+            let Item::Mod(ItemMod {
+                attrs,
+                ident,
+                content: Some((_, child_items)),
+                ..
+            }) = item
+            else {
+                continue;
+            };
+            let child_cfg = extend_cfg_context(&cfg, &attrs);
+            self.add_module(
+                package.clone(),
+                format!("{module}::{ident}"),
+                source_path.clone(),
+                child_cfg,
+                child_items,
+            );
+        }
+    }
+}

--- a/tools/architecture/handler-contract-check/src/bridge_access/state_1.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access/state_1.rs
@@ -242,6 +242,23 @@ impl BridgeAccumulator {
 #[derive(Clone, Default)]
 pub(super) struct Symbols {
     pub(super) named: BTreeMap<String, BTreeSet<BridgeSide>>,
+    /// Names that are known to bind locally, but whose provenance is not one
+    /// of the authority surfaces.  Keeping this separate from `named` is
+    /// important: an ordinary local `Creature` must shadow a parent glob
+    /// without turning unknown external data into a known non-authority.
+    pub(super) non_authority: BTreeSet<String>,
+    /// Resolution failures are retained beside the final table and reported
+    /// only when a candidate path actually uses the affected name.
+    pub(super) path_issues: BTreeMap<String, String>,
+    /// A missing relative glob can supply an arbitrarily renamed type.
+    /// These diagnostics need lexical use context before they can be emitted.
+    pub(super) unresolved_glob_paths: BTreeMap<String, String>,
+    /// Qualified paths are resolved from the supplied module graph.  The
+    /// legacy `named` table remains the compact fast path for bare names and
+    /// transparent macro tokens.
+    pub(super) qualified: BTreeMap<String, BTreeSet<BridgeSide>>,
+    /// Private symbol tables for each enclosing item's exact cfg context.
+    pub(super) contexts: BTreeMap<Vec<String>, Symbols>,
 }
 
 impl Symbols {
@@ -261,7 +278,9 @@ impl Symbols {
     where
         I: IntoIterator<Item = BridgeSide>,
     {
-        self.named.entry(name.into()).or_default().extend(sides);
+        let name = name.into();
+        self.non_authority.remove(&name);
+        self.named.entry(name).or_default().extend(sides);
     }
 
     pub(super) fn sides_for_ident(&self, name: &str) -> BTreeSet<BridgeSide> {
@@ -275,6 +294,84 @@ impl Symbols {
             .map(|segment| segment.ident.to_string())
             .collect();
         sides_for_segments(self, &segments)
+    }
+
+    pub(super) fn path_issue(&self, path: &Path) -> Option<&str> {
+        let segments: Vec<_> = path
+            .segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect();
+        self.path_issue_for_segments(&segments)
+    }
+
+    pub(super) fn sides_for_path_with_cfg(
+        &self,
+        path: &Path,
+        cfg: &[String],
+    ) -> BTreeSet<BridgeSide> {
+        let segments: Vec<_> = path
+            .segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect();
+        self.sides_for_segments_with_cfg(&segments, cfg)
+    }
+
+    pub(super) fn for_cfg(&self, cfg: &[String]) -> &Self {
+        self.contexts.get(cfg).unwrap_or(self)
+    }
+
+    pub(super) fn shadow_generic(&mut self, name: &str) {
+        self.named.remove(name);
+        self.non_authority.insert(name.to_owned());
+        let prefix = format!("{name}::");
+        self.qualified
+            .retain(|path, _| path != name && !path.starts_with(&prefix));
+        self.path_issues
+            .retain(|path, _| path != name && !path.starts_with(&prefix));
+    }
+
+    pub(super) fn bind_local_import(
+        &mut self,
+        name: &str,
+        sides: BTreeSet<BridgeSide>,
+        issue: Option<String>,
+    ) {
+        self.shadow_generic(name);
+        let prefix = format!("{name}::");
+        self.unresolved_glob_paths
+            .retain(|path, _| path != name && !path.starts_with(&prefix));
+        if !sides.is_empty() {
+            self.non_authority.remove(name);
+            self.named.insert(name.to_owned(), sides);
+        }
+        if let Some(issue) = issue {
+            self.path_issues.insert(name.to_owned(), issue);
+        }
+    }
+
+    pub(super) fn sides_for_segments_with_cfg(
+        &self,
+        segments: &[String],
+        cfg: &[String],
+    ) -> BTreeSet<BridgeSide> {
+        sides_for_segments(self.for_cfg(cfg), segments)
+    }
+
+    pub(super) fn path_issue_with_cfg(&self, path: &Path, cfg: &[String]) -> Option<&str> {
+        self.for_cfg(cfg).path_issue(path)
+    }
+
+    pub(super) fn path_issue_for_segments(&self, segments: &[String]) -> Option<&str> {
+        self.path_issues
+            .get(&segments.join("::"))
+            .or_else(|| {
+                segments
+                    .first()
+                    .and_then(|first| self.path_issues.get(first))
+            })
+            .map(String::as_str)
     }
 }
 
@@ -360,10 +457,23 @@ pub(super) fn direction_sides(direction: BridgeDirection) -> &'static [BridgeSid
 }
 
 pub(super) fn sides_for_segments(symbols: &Symbols, segments: &[String]) -> BTreeSet<BridgeSide> {
+    let qualified = segments.join("::");
+    if let Some(sides) = symbols.qualified.get(&qualified) {
+        return sides.clone();
+    }
     let mut sides = BTreeSet::new();
     let Some(first) = segments.first().map(String::as_str) else {
         return sides;
     };
+
+    // A local declaration or an explicit unknown import has lexical
+    // precedence over inherited/glob provenance.  Do this before the
+    // hard-coded crate roots below so a fixture-local `Creature` cannot be
+    // mistaken for `wow_entities::Creature` merely because a parent imports
+    // it.
+    if symbols.non_authority.contains(first) {
+        return sides;
+    }
 
     // Authority provenance is deliberately narrower than crate provenance:
     // using a coordinate, key, entity, or DTO from an authority-owned crate
@@ -621,6 +731,7 @@ pub(super) fn add_use_to_symbols(
     collect_use_bindings(&item_use.tree, &mut Vec::new(), &mut bindings, &mut globs);
     for (local, full) in bindings {
         let sides = sides_for_segments(symbols, &full);
+        let issue = symbols.path_issue_for_segments(&full).map(str::to_owned);
         if sides.is_empty()
             && bridge_capable_namespace_import(&full)
             && !(full.len() == 1 && local == full[0])
@@ -630,7 +741,7 @@ pub(super) fn add_use_to_symbols(
                 full.join("::")
             ));
         }
-        symbols.add(local, sides);
+        symbols.bind_local_import(&local, sides, issue);
     }
     for glob in globs {
         let sides = sides_for_segments(symbols, &glob);
@@ -645,63 +756,47 @@ pub(super) fn add_use_to_symbols(
 
 pub(super) struct TypeSideCollector<'a> {
     pub(super) symbols: &'a Symbols,
+    pub(super) cfg: Option<&'a [String]>,
     pub(super) sides: BTreeSet<BridgeSide>,
 }
 
 impl<'ast> Visit<'ast> for TypeSideCollector<'_> {
     fn visit_type_path(&mut self, path: &'ast syn::TypePath) {
-        self.sides.extend(self.symbols.sides_for_path(&path.path));
+        let sides = self.cfg.map_or_else(
+            || self.symbols.sides_for_path(&path.path),
+            |cfg| self.symbols.sides_for_path_with_cfg(&path.path, cfg),
+        );
+        self.sides.extend(sides);
         visit::visit_type_path(self, path);
     }
 }
 
-pub(super) fn sides_in_type(symbols: &Symbols, type_expression: &Type) -> BTreeSet<BridgeSide> {
+pub(super) fn sides_in_type_with_cfg(
+    symbols: &Symbols,
+    type_expression: &Type,
+    cfg: &[String],
+) -> BTreeSet<BridgeSide> {
     let mut collector = TypeSideCollector {
         symbols,
+        cfg: Some(cfg),
         sides: BTreeSet::new(),
     };
     collector.visit_type(type_expression);
     collector.sides
 }
 
-pub(super) fn register_module_symbols(
-    items: &[Item],
-    context: &ModuleContext<'_>,
-    inherited: &Symbols,
-    errors: &mut Vec<String>,
-) -> Symbols {
-    let mut symbols = inherited.clone();
-    let builtins = Symbols::for_module(context.package, &context.module);
-    for (name, sides) in builtins.named {
-        symbols.add(name, sides);
-    }
-    for item in items {
-        if let Item::Use(item_use) = item {
-            add_use_to_symbols(item_use, &mut symbols, errors);
-        }
-    }
-
-    // A few passes resolve explicit type-alias chains without pretending that
-    // every struct/function touching an authority type inherits that
-    // authority. The latter poisoned generic symbols such as WorldSession and
-    // then propagated false provenance through `Self` and ordinary calls.
-    for _ in 0..3 {
-        for item in items {
-            if let Item::Type(alias) = item {
-                symbols.add(alias.ident.to_string(), sides_in_type(&symbols, &alias.ty));
-            }
-        }
-    }
-    symbols
-}
-
 pub(super) struct CandidateAnalyzer<'a> {
     pub(super) context: &'a ModuleContext<'a>,
     pub(super) enclosing: String,
     pub(super) symbols: Symbols,
+    pub(super) module_symbols: &'a Symbols,
+    pub(super) local_imports: Vec<(Vec<String>, syn::ItemUse)>,
+    pub(super) active_cfg: Vec<String>,
     pub(super) variables: BTreeMap<String, BTreeSet<BridgeSide>>,
     pub(super) evidence: Vec<RawEvidence>,
     pub(super) directions: BTreeSet<BridgeDirection>,
     pub(super) opaque_authority_macros: Vec<String>,
+    pub(super) reported_resolution_issues: BTreeSet<String>,
+    pub(super) generic_parameters: BTreeSet<String>,
     pub(super) errors: &'a mut Vec<String>,
 }

--- a/tools/architecture/handler-contract-check/src/bridge_access/state_2.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access/state_2.rs
@@ -8,19 +8,33 @@ impl<'a> CandidateAnalyzer<'a> {
     pub(super) fn new(
         context: &'a ModuleContext<'a>,
         enclosing: String,
-        symbols: &Symbols,
+        symbols: &'a Symbols,
         errors: &'a mut Vec<String>,
     ) -> Self {
         Self {
             context,
             enclosing,
-            symbols: symbols.clone(),
+            symbols: symbols.for_cfg(&context.cfg).clone(),
+            module_symbols: symbols,
+            local_imports: Vec::new(),
+            active_cfg: context.cfg.clone(),
             variables: BTreeMap::new(),
             evidence: Vec::new(),
             directions: BTreeSet::new(),
             opaque_authority_macros: Vec::new(),
+            reported_resolution_issues: BTreeSet::new(),
+            generic_parameters: BTreeSet::new(),
             errors,
         }
+    }
+
+    pub(super) fn set_active_cfg(&mut self, cfg: Vec<String>) {
+        self.symbols = self.module_symbols.for_cfg(&cfg).clone();
+        for name in &self.generic_parameters {
+            self.symbols.shadow_generic(name);
+        }
+        self.active_cfg = cfg;
+        self.apply_local_imports();
     }
 
     pub(super) fn add(
@@ -85,7 +99,8 @@ impl<'a> CandidateAnalyzer<'a> {
                 }
             }
             Pat::Type(typed) => {
-                let typed_sides = sides_in_type(&self.symbols, &typed.ty);
+                let typed_sides =
+                    sides_in_type_with_cfg(&self.symbols, &typed.ty, &self.active_cfg);
                 let bound = if typed_sides.is_empty() {
                     sides.clone()
                 } else {
@@ -125,21 +140,40 @@ impl<'a> CandidateAnalyzer<'a> {
     }
 
     pub(super) fn bind_signature(&mut self, signature: &Signature) {
+        self.bind_generics(&signature.generics);
         for input in &signature.inputs {
-            match input {
-                FnArg::Receiver(_) => {}
-                FnArg::Typed(typed) => {
-                    let sides = sides_in_type(&self.symbols, &typed.ty);
-                    self.bind_pattern(&typed.pat, &sides);
+            let attrs = match input {
+                FnArg::Receiver(receiver) => &receiver.attrs,
+                FnArg::Typed(typed) => &typed.attrs,
+            };
+            self.within_cfg(attrs, |analyzer| {
+                if let FnArg::Typed(typed) = input {
+                    let sides =
+                        sides_in_type_with_cfg(&analyzer.symbols, &typed.ty, &analyzer.active_cfg);
+                    analyzer.bind_pattern(&typed.pat, &sides);
                 }
-            }
+            });
+        }
+    }
+
+    fn bind_generics(&mut self, generics: &syn::Generics) {
+        for parameter in &generics.params {
+            let name = match parameter {
+                syn::GenericParam::Type(parameter) => parameter.ident.to_string(),
+                syn::GenericParam::Const(parameter) => parameter.ident.to_string(),
+                syn::GenericParam::Lifetime(_) => continue,
+            };
+            self.generic_parameters.insert(name.clone());
+            self.symbols.shadow_generic(&name);
         }
     }
 
     pub(super) fn sides_of_expr(&self, expression: &Expr) -> BTreeSet<BridgeSide> {
         match expression {
             Expr::Path(path) => {
-                let mut sides = self.symbols.sides_for_path(&path.path);
+                let mut sides = self
+                    .symbols
+                    .sides_for_path_with_cfg(&path.path, &self.active_cfg);
                 if let Some(name) = last_path_ident(&path.path) {
                     if let Some(variable_sides) = self.variables.get(&name) {
                         sides.extend(variable_sides);
@@ -172,7 +206,10 @@ impl<'a> CandidateAnalyzer<'a> {
             Expr::Call(call) => {
                 let mut sides = BTreeSet::new();
                 if let Expr::Path(path) = call.func.as_ref() {
-                    sides.extend(self.symbols.sides_for_path(&path.path));
+                    sides.extend(
+                        self.symbols
+                            .sides_for_path_with_cfg(&path.path, &self.active_cfg),
+                    );
                     let passthrough = last_path_ident(&path.path)
                         .is_some_and(|name| matches!(name.as_str(), "clone" | "from"));
                     if passthrough {
@@ -189,6 +226,18 @@ impl<'a> CandidateAnalyzer<'a> {
 
     pub(super) fn audit_macro(&mut self, mac: &syn::Macro, label: &str) {
         let name = last_path_ident(&mac.path).unwrap_or_else(|| "<macro>".to_owned());
+        for path in provenance::token_paths(&mac.tokens) {
+            if let Some(issue) = self.symbols.path_issue_for_segments(&path)
+                && self.reported_resolution_issues.insert(path.join("::"))
+            {
+                self.errors.push(issue.to_owned());
+            }
+            if path.len() > 1
+                && let Ok(path) = syn::parse_str::<Path>(&path.join("::"))
+            {
+                self.report_missing_glob_path(&path, true);
+            }
+        }
         let sides = token_sides(&mac.tokens, &self.symbols, &self.variables);
         let has_both =
             sides.contains(&BridgeSide::Canonical) && sides.contains(&BridgeSide::Legacy);
@@ -301,128 +350,6 @@ impl<'a> CandidateAnalyzer<'a> {
     }
 }
 
-impl<'ast> Visit<'ast> for CandidateAnalyzer<'_> {
-    fn visit_type_path(&mut self, path: &'ast syn::TypePath) {
-        let sides = self.symbols.sides_for_path(&path.path);
-        if !sides.is_empty() {
-            self.add_sides(
-                &sides,
-                BridgeEvidenceKind::TypeReference,
-                last_path_ident(&path.path).unwrap_or_else(|| "<type>".to_owned()),
-                normalized_tokens(path),
-            );
-        }
-        visit::visit_type_path(self, path);
-    }
-
-    fn visit_expr_path(&mut self, path: &'ast syn::ExprPath) {
-        let mut sides = self.symbols.sides_for_path(&path.path);
-        if let Some(name) = last_path_ident(&path.path) {
-            if let Some(variable_sides) = self.variables.get(&name) {
-                sides.extend(variable_sides);
-            }
-        }
-        if !sides.is_empty() {
-            self.add_sides(
-                &sides,
-                BridgeEvidenceKind::ValueReference,
-                last_path_ident(&path.path).unwrap_or_else(|| "<value>".to_owned()),
-                normalized_tokens(path),
-            );
-        }
-        visit::visit_expr_path(self, path);
-    }
-
-    fn visit_expr_field(&mut self, field: &'ast ExprField) {
-        let sides = self.sides_of_expr(&Expr::Field(field.clone()));
-        if !sides.is_empty() {
-            let symbol = match &field.member {
-                Member::Named(member) => member.to_string(),
-                Member::Unnamed(index) => index.index.to_string(),
-            };
-            self.add_sides(
-                &sides,
-                BridgeEvidenceKind::FieldAccess,
-                symbol,
-                normalized_tokens(field),
-            );
-        }
-        visit::visit_expr_field(self, field);
-    }
-
-    fn visit_expr_call(&mut self, call: &'ast ExprCall) {
-        if let Expr::Path(path) = call.func.as_ref() {
-            let name = last_path_ident(&path.path).unwrap_or_else(|| "<call>".to_owned());
-            let sides = self.symbols.sides_for_path(&path.path);
-            if !sides.is_empty() {
-                self.add_sides(
-                    &sides,
-                    BridgeEvidenceKind::FunctionCall,
-                    name.clone(),
-                    normalized_tokens(call),
-                );
-            }
-        }
-        visit::visit_expr_call(self, call);
-    }
-
-    fn visit_expr_method_call(&mut self, call: &'ast ExprMethodCall) {
-        let name = call.method.to_string();
-        let sides = self.sides_of_expr(&call.receiver);
-        if !sides.is_empty() {
-            self.add_sides(
-                &sides,
-                BridgeEvidenceKind::MethodCall,
-                name.clone(),
-                normalized_tokens(call),
-            );
-        }
-        visit::visit_expr_method_call(self, call);
-    }
-
-    fn visit_local(&mut self, local: &'ast Local) {
-        if let Pat::Type(typed) = &local.pat {
-            self.visit_type(&typed.ty);
-        }
-        let mut sides = BTreeSet::new();
-        if let Some(init) = &local.init {
-            self.visit_expr(&init.expr);
-            sides.extend(self.sides_of_expr(&init.expr));
-            if let Some((_, diverge)) = &init.diverge {
-                self.visit_expr(diverge);
-            }
-        }
-        if let Pat::Type(typed) = &local.pat {
-            sides.extend(sides_in_type(&self.symbols, &typed.ty));
-        }
-        self.bind_pattern(&local.pat, &sides);
-    }
-
-    fn visit_expr_macro(&mut self, expression: &'ast ExprMacro) {
-        self.audit_macro(&expression.mac, "expression macro");
-    }
-
-    fn visit_stmt_macro(&mut self, statement: &'ast syn::StmtMacro) {
-        self.audit_macro(&statement.mac, "statement macro");
-    }
-
-    fn visit_type_macro(&mut self, type_macro: &'ast syn::TypeMacro) {
-        self.audit_macro(&type_macro.mac, "type macro");
-    }
-
-    fn visit_item(&mut self, item: &'ast Item) {
-        match item {
-            Item::Use(item_use) => add_use_to_symbols(item_use, &mut self.symbols, self.errors),
-            Item::Macro(item_macro) => {
-                self.audit_macro(&item_macro.mac, "nested item macro");
-            }
-            // Nested items have their own enclosing identity and must be passed
-            // as source/module items rather than folded into this function.
-            _ => {}
-        }
-    }
-}
-
 pub(super) fn method_enclosing(item_impl: &ItemImpl, signature: &Signature) -> String {
     let self_type = normalized_tokens(&item_impl.self_ty);
     match &item_impl.trait_ {
@@ -452,6 +379,7 @@ pub(super) fn analyze_function(
     let cfg = extend_cfg_context(&context.cfg, &function.attrs);
     let enclosing = format!("fn::{}", function.sig.ident);
     let mut analyzer = CandidateAnalyzer::new(context, enclosing, symbols, errors);
+    analyzer.set_active_cfg(cfg.clone());
     analyzer.seed_definition_anchor(&function.sig.ident.to_string());
     analyzer.bind_signature(&function.sig);
     analyzer.visit_signature(&function.sig);
@@ -475,12 +403,6 @@ pub(super) fn analyze_impl(
 ) {
     validate_cfg(&context.cfg, &item_impl.attrs, "impl", errors);
     let impl_cfg = extend_cfg_context(&context.cfg, &item_impl.attrs);
-    let self_sides = sides_in_type(symbols, &item_impl.self_ty);
-    let trait_sides = item_impl
-        .trait_
-        .as_ref()
-        .map(|(_, path, _)| symbols.sides_for_path(path))
-        .unwrap_or_default();
     for item in &item_impl.items {
         match item {
             ImplItem::Fn(method) => {
@@ -491,8 +413,22 @@ pub(super) fn analyze_impl(
                     errors,
                 );
                 let cfg = extend_cfg_context(&impl_cfg, &method.attrs);
+                let self_sides = sides_in_type_with_cfg(symbols, &item_impl.self_ty, &cfg);
+                let trait_sides = item_impl
+                    .trait_
+                    .as_ref()
+                    .map(|(_, path, _)| symbols.sides_for_path_with_cfg(path, &cfg))
+                    .unwrap_or_default();
                 let enclosing = method_enclosing(item_impl, &method.sig);
                 let mut analyzer = CandidateAnalyzer::new(context, enclosing, symbols, errors);
+                analyzer.set_active_cfg(cfg.clone());
+                analyzer.bind_generics(&item_impl.generics);
+                if let Type::Path(path) = item_impl.self_ty.as_ref() {
+                    analyzer.report_path_issue(&path.path);
+                }
+                if let Some((_, path, _)) = &item_impl.trait_ {
+                    analyzer.report_path_issue(path);
+                }
                 analyzer.seed_definition_anchor(&method.sig.ident.to_string());
                 analyzer.bind_signature(&method.sig);
                 if !self_sides.is_empty() {
@@ -543,6 +479,7 @@ pub(super) fn analyze_impl(
                     constant.ident
                 );
                 let mut analyzer = CandidateAnalyzer::new(context, enclosing, symbols, errors);
+                analyzer.set_active_cfg(cfg.clone());
                 analyzer.visit_type(&constant.ty);
                 analyzer.visit_expr(&constant.expr);
                 let header = format!(
@@ -563,6 +500,7 @@ pub(super) fn analyze_impl(
                     item_type.ident
                 );
                 let mut analyzer = CandidateAnalyzer::new(context, enclosing, symbols, errors);
+                analyzer.set_active_cfg(cfg.clone());
                 analyzer.visit_type(&item_type.ty);
                 let header = format!(
                     "type {}={}",
@@ -611,20 +549,22 @@ pub(super) fn analyze_data_item(
     let cfg = extend_cfg_context(&context.cfg, attrs);
     let header = format!("{name}|surface={}", compact_token_fingerprint(item));
     let mut analyzer = CandidateAnalyzer::new(context, name, symbols, errors);
+    analyzer.set_active_cfg(cfg.clone());
+    match item {
+        Item::Struct(item) => analyzer.bind_generics(&item.generics),
+        Item::Enum(item) => analyzer.bind_generics(&item.generics),
+        Item::Type(item) => analyzer.bind_generics(&item.generics),
+        _ => {}
+    }
     match item {
         Item::Struct(value) => {
             for field in &value.fields {
-                analyzer.visit_type(&field.ty);
+                analyzer.visit_field(field);
             }
         }
         Item::Enum(value) => {
             for variant in &value.variants {
-                for field in &variant.fields {
-                    analyzer.visit_type(&field.ty);
-                }
-                if let Some((_, discriminant)) = &variant.discriminant {
-                    analyzer.visit_expr(discriminant);
-                }
+                analyzer.visit_variant(variant);
             }
         }
         Item::Type(value) => analyzer.visit_type(&value.ty),
@@ -650,6 +590,8 @@ pub(super) fn audit_item_macro(
     errors: &mut Vec<String>,
     label: &str,
 ) {
+    let cfg = extend_cfg_context(&context.cfg, &item_macro.attrs);
+    let symbols = symbols.for_cfg(&cfg);
     let name = item_macro
         .ident
         .as_ref()
@@ -672,11 +614,10 @@ pub(super) fn audit_item_macro(
 pub(super) fn analyze_module_items(
     items: &[Item],
     context: &ModuleContext<'_>,
-    inherited_symbols: &Symbols,
+    symbols: &Symbols,
     accumulator: &mut BridgeAccumulator,
     errors: &mut Vec<String>,
 ) {
-    let symbols = register_module_symbols(items, context, inherited_symbols, errors);
     for item in items {
         match item {
             Item::Fn(function) => {
@@ -698,13 +639,11 @@ pub(super) fn analyze_module_items(
                 ..
             }) => {
                 validate_cfg(&context.cfg, attrs, &format!("module {ident}"), errors);
-                let child = ModuleContext {
-                    package: context.package,
-                    module: format!("{}::{ident}", context.module),
-                    path: context.path,
-                    cfg: extend_cfg_context(&context.cfg, attrs),
-                };
-                analyze_module_items(child_items, &child, &symbols, accumulator, errors);
+                // Inline children are indexed and analyzed as independent
+                // lexical modules by `provenance.rs`.  Re-entering them here
+                // would use the parent's symbol table and double-count the
+                // same source mount.
+                let _ = child_items;
             }
             _ => {}
         }
@@ -736,6 +675,7 @@ pub(crate) fn inventory_bridge_accesses(
     let mut seen = BTreeSet::new();
     let mut accumulator = BridgeAccumulator::default();
     let mut errors = Vec::new();
+    let mut parsed_sources = Vec::new();
     for source in ordered {
         if source.package.is_empty() || source.module.is_empty() || source.source_path.is_empty() {
             errors.push("bridge source package/module/path must be non-empty".to_owned());
@@ -769,16 +709,25 @@ pub(crate) fn inventory_bridge_accesses(
             source.source_path,
             &mut errors,
         );
+        parsed_sources.push((source, syntax));
+    }
+
+    // The repository caller has already resolved source mounts and logical
+    // module paths.  Build the lexical graph from exactly those inputs so
+    // external and inline children receive identical `super`/glob handling.
+    let index = build_module_index(&parsed_sources);
+    let symbols = resolve_module_symbols(&index, &mut errors);
+    for (node, module_symbols) in index.modules.iter().zip(symbols.iter()) {
         let context = ModuleContext {
-            package: source.package,
-            module: source.module.to_owned(),
-            path: source.source_path,
-            cfg: extend_cfg_context(source.inherited_cfg, &syntax.attrs),
+            package: &node.package,
+            module: node.module.clone(),
+            path: &node.source_path,
+            cfg: node.cfg.clone(),
         };
         analyze_module_items(
-            &syntax.items,
+            &node.items,
             &context,
-            &Symbols::for_module(source.package, source.module),
+            module_symbols,
             &mut accumulator,
             &mut errors,
         );

--- a/tools/architecture/handler-contract-check/src/bridge_access/tests/import_provenance.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access/tests/import_provenance.rs
@@ -1,0 +1,395 @@
+//! Lexical import regressions for physical module moves (#716).
+
+use super::*;
+
+const TRANSLATE: &str = r#"
+    fn translate(old: &wow_world::SharedMapManager) {
+        let _ = old;
+        let _ = Creature::new(false);
+    }
+"#;
+
+fn mounted<'a>(module: &'a str, path: &'a str, text: &'a str) -> BridgeSource<'a> {
+    BridgeSource {
+        package: "fixture",
+        module,
+        source_path: path,
+        inherited_cfg: &[],
+        source: text,
+    }
+}
+
+fn pair(parent: &str, child: &str) -> Result<BridgeAccessBaseline, String> {
+    inventory_bridge_accesses(&[
+        mounted("crate", "src/lib.rs", parent),
+        mounted("crate::child", "src/child.rs", child),
+    ])
+}
+
+#[test]
+fn root_inline_and_external_moves_preserve_exact_bridge_evidence() {
+    let root = format!("use wow_entities::Creature; {TRANSLATE}");
+    let inline = format!("use wow_entities::Creature; mod child {{ use super::*; {TRANSLATE} }}");
+    let external = format!("use super::*; {TRANSLATE}");
+    let expected = inventory_bridge_accesses(&[mounted("crate", "src/lib.rs", &root)])
+        .expect("root provenance");
+    let inline = inventory_bridge_accesses(&[mounted("crate", "src/lib.rs", &inline)])
+        .expect("inline provenance");
+    let external =
+        pair("use wow_entities::Creature; mod child;", &external).expect("external provenance");
+    assert_eq!(expected.bridges.len(), 1);
+    for mut moved in [inline, external] {
+        assert_eq!(moved.bridges.len(), 1);
+        moved.bridges[0].module = expected.bridges[0].module.clone();
+        moved.bridges[0].path = expected.bridges[0].path.clone();
+        compare_bridge_access_baseline(&expected, &moved)
+            .expect("only the physical/logical location may change");
+    }
+}
+
+#[test]
+fn explicit_grouped_renamed_and_generic_alias_imports_keep_provenance() {
+    let parent = "use wow_entities::Creature; type ParentCreature = Creature; mod child;";
+    for imports in [
+        "use super::Creature;",
+        "use super::{Creature, ParentCreature as Unused};",
+        "use super::ParentCreature as Creature;",
+        "use super::Creature as Parent; type Creature = Parent;",
+        "use super::Creature as Parent; type Creature = std::sync::Arc<Parent>;",
+    ] {
+        let child = format!("{imports} {TRANSLATE}");
+        let baseline = pair(parent, &child).expect(imports);
+        assert_eq!(baseline.bridges.len(), 1, "{imports}");
+    }
+}
+
+#[test]
+fn exact_public_canonical_manager_alias_survives_parent_imports() {
+    for path in [
+        "wow_world::SharedCanonicalMapManager",
+        "wow_world::session::SharedCanonicalMapManager",
+    ] {
+        let parent = format!("use {path}; mod child;");
+        let child = r#"
+            use super::*;
+            fn synchronize(old: &wow_world::SharedMapManager, new: &SharedCanonicalMapManager) {}
+        "#;
+        assert_eq!(pair(&parent, child).expect(path).bridges.len(), 1);
+    }
+    let text = r#"
+        use unrelated_data::SharedCanonicalMapManager;
+        fn inspect(old: &wow_world::SharedMapManager, dto: &SharedCanonicalMapManager) {}
+    "#;
+    assert!(inventory(text).unwrap().bridges.is_empty());
+}
+
+#[test]
+fn qualified_and_two_level_parent_paths_resolve_without_bare_imports() {
+    let leaf = r#"
+        fn translate(old: &wow_world::SharedMapManager) {
+            let _ = old;
+            let _ = super::super::Creature::new(false);
+        }
+    "#;
+    let sources = [
+        mounted(
+            "crate",
+            "src/lib.rs",
+            "use wow_entities::Creature; mod child;",
+        ),
+        mounted("crate::child", "src/child.rs", "mod leaf;"),
+        mounted("crate::child::leaf", "src/child/leaf.rs", leaf),
+    ];
+    let expected = inventory_bridge_accesses(&sources).expect("two-level qualified path");
+    assert_eq!(expected.bridges.len(), 1);
+    let reversed = sources.into_iter().rev().collect::<Vec<_>>();
+    let actual = inventory_bridge_accesses(&reversed).expect("source-order independence");
+    compare_bridge_access_baseline(&expected, &actual).unwrap();
+}
+
+#[test]
+fn two_level_glob_chain_preserves_parent_type_aliases() {
+    let leaf = format!("use super::*; {TRANSLATE}");
+    let sources = [
+        mounted(
+            "crate",
+            "src/lib.rs",
+            "type Creature = wow_entities::Creature; mod child;",
+        ),
+        mounted("crate::child", "src/child.rs", "use super::*; mod leaf;"),
+        mounted("crate::child::leaf", "src/child/leaf.rs", &leaf),
+    ];
+    assert_eq!(
+        inventory_bridge_accesses(&sources).unwrap().bridges.len(),
+        1
+    );
+}
+
+#[test]
+fn parent_reexport_cycle_does_not_hide_an_explicit_authority_binding() {
+    let result = pair(
+        "use wow_entities::Creature; mod child; pub use child::*;",
+        &format!("use super::*; {TRANSLATE}"),
+    )
+    .expect("ordinary parent reexports and child imports have an explicit type source");
+    assert_eq!(result.bridges.len(), 1);
+}
+
+#[test]
+fn conflicting_glob_authorities_fail_closed_at_the_used_name() {
+    let text = format!(
+        "mod canonical {{ pub use wow_entities::Creature; }} \
+         mod legacy {{ pub use wow_world::WorldCreature as Creature; }} \
+         mod child {{ use crate::canonical::*; use crate::legacy::*; {TRANSLATE} }}"
+    );
+    inventory_bridge_accesses(&[mounted("crate", "src/lib.rs", &text)])
+        .expect_err("a used ambiguous name cannot silently select one glob");
+}
+
+#[test]
+fn local_and_explicit_foreign_names_shadow_parent_globs() {
+    for declaration in [
+        "struct Creature;",
+        "use unrelated_data::Creature;",
+        "enum Creature { Idle }",
+    ] {
+        let child = format!("use super::*; {declaration} {TRANSLATE}");
+        let result = pair("use wow_entities::Creature; mod child;", &child)
+            .expect("a local or explicit imported name shadows the glob");
+        assert!(result.bridges.is_empty(), "{declaration}");
+    }
+}
+
+#[test]
+fn inline_children_do_not_implicitly_inherit_unimported_parent_types() {
+    let text = format!("use wow_entities::Creature; mod child {{ {TRANSLATE} }}");
+    let result = inventory_bridge_accesses(&[mounted("crate", "src/lib.rs", &text)])
+        .expect("no Rust import connects the child name to the parent type");
+    assert!(result.bridges.is_empty());
+}
+
+#[test]
+fn parent_enum_variants_are_not_canonical_creature_authority() {
+    let child = r#"
+        use super::*;
+        fn inspect(old: &wow_world::SharedMapManager) {
+            let _ = SpawnObjectType::Creature;
+            assert!(matches!(SpawnObjectType::Creature, SpawnObjectType::Creature));
+        }
+    "#;
+    let result = pair(
+        "use wow_entities::Creature; use wow_map::SpawnObjectType; mod child;",
+        child,
+    )
+    .expect("variant and imported type have distinct provenance");
+    assert!(result.bridges.is_empty());
+}
+
+#[test]
+fn matching_import_and_function_cfg_retains_test_and_feature_bridges() {
+    for cfg in ["test", "feature = \"bridge\""] {
+        let text = format!("#[cfg({cfg})] use wow_entities::Creature; #[cfg({cfg})] {TRANSLATE}");
+        let baseline = inventory_bridge_accesses(&[mounted("crate", "src/lib.rs", &text)])
+            .expect("the import and candidate share the same presence condition");
+        assert_eq!(baseline.bridges.len(), 1, "{cfg}");
+        assert!(!baseline.bridges[0].cfg.is_empty());
+    }
+}
+
+#[test]
+fn nested_test_cfg_uses_the_matching_import_scope() {
+    for body in [
+        "#[cfg(test)] { let _ = Creature::new(false); }",
+        "#[cfg(test)] let _ = Creature::new(false);",
+        "#[cfg(test)] consume(Creature::new(false));",
+        "let _ = Holder { old, #[cfg(test)] new: Creature::new(false) };",
+    ] {
+        let text = format!(
+            "#[cfg(test)] use wow_entities::Creature; \
+             mod child {{ use super::*; \
+               struct Holder<'a> {{ old: &'a wow_world::SharedMapManager, #[cfg(test)] new: Creature }} \
+               fn translate(old: &wow_world::SharedMapManager) {{ {body} }} \
+             }}"
+        );
+        let baseline = inventory_bridge_accesses(&[mounted("crate", "src/lib.rs", &text)]).expect(
+            "nested cfg must constrain the provenance use, not just the enclosing function",
+        );
+        assert_eq!(
+            baseline
+                .bridges
+                .iter()
+                .filter(|record| record.enclosing == "fn::translate")
+                .count(),
+            1,
+            "{body}",
+        );
+    }
+}
+
+#[test]
+fn block_local_import_replaces_unresolved_parent_glob_context() {
+    let child = r#"
+        use super::*;
+        fn bridge(new: &wow_entities::Creature) {
+            use wow_world::WorldCreature;
+            let _ = WorldCreature::from_canonical(new);
+        }
+    "#;
+    let baseline = pair("pub use child::*; mod child;", child)
+        .expect("a block-local import overrides the unresolved parent glob binding");
+    assert_eq!(baseline.bridges.len(), 1);
+}
+
+#[test]
+fn nested_cfg_retains_enclosing_block_imports_and_shadows() {
+    for (parent, import, expected) in [
+        ("", "use wow_entities::Creature as Entity;", 1),
+        (
+            "use wow_entities::Creature as Entity;",
+            "use other_data::Entity;",
+            0,
+        ),
+    ] {
+        let source = format!(
+            "{parent} fn bridge(old: &wow_world::SharedMapManager) {{ \
+               {import} #[cfg(test)] {{ let _ = Entity::new(false); }} \
+             }}"
+        );
+        let baseline =
+            inventory(&source).expect("entering nested cfg preserves the enclosing lexical import");
+        assert_eq!(baseline.bridges.len(), expected, "{source}");
+    }
+}
+
+#[test]
+fn cfg_test_local_shadow_does_not_hide_production_parent_authority() {
+    let child = r#"
+        use super::*;
+        #[cfg(test)] struct Creature;
+        #[cfg(not(test))]
+        fn production(old: &wow_world::SharedMapManager) { let _ = Creature::new(false); }
+        #[cfg(test)]
+        fn test_fixture(old: &wow_world::SharedMapManager) { let _ = Creature; }
+    "#;
+    let result = pair("use wow_entities::Creature; mod child;", child)
+        .expect("the local test shadow and production import never overlap");
+    assert_eq!(result.bridges.len(), 1);
+    assert_eq!(result.bridges[0].enclosing, "fn::production");
+}
+
+#[test]
+fn impossible_import_does_not_supply_authority() {
+    let text = format!("#[cfg(any())] use wow_entities::Creature; {TRANSLATE}");
+    let result = inventory_bridge_accesses(&[mounted("crate", "src/lib.rs", &text)])
+        .expect("an impossible declaration is absent");
+    assert!(result.bridges.is_empty());
+}
+
+#[test]
+fn relevant_conditional_authority_ambiguity_fails_closed() {
+    let text = format!(
+        "#[cfg(test)] use wow_entities::Creature; \
+         #[cfg(not(test))] use other_data::Creature; {TRANSLATE}"
+    );
+    inventory_bridge_accesses(&[mounted("crate", "src/lib.rs", &text)])
+        .expect_err("one unconditional candidate cannot silently select an authority branch");
+}
+
+#[test]
+fn missing_relative_context_is_reported_only_when_provenance_is_used() {
+    let used = format!("use super::Creature; {TRANSLATE}");
+    inventory_bridge_accesses(&[mounted("crate::child", "src/child.rs", &used)])
+        .expect_err("a used relative authority import needs its parent context");
+    let unused = "use super::Creature; fn innocent(value: u32) -> u32 { value }";
+    let result = inventory_bridge_accesses(&[mounted("crate::child", "src/child.rs", unused)])
+        .expect("an unrelated function does not need missing authority context");
+    assert!(result.bridges.is_empty());
+}
+
+#[test]
+fn renamed_missing_relative_authority_cannot_hide_behind_an_arbitrary_alias() {
+    for import in [
+        "use super::Entity;",
+        "type Entity = super::Entity;",
+        "use super::*;",
+    ] {
+        let text =
+            format!("{import} fn translate(old: &wow_world::SharedMapManager, new: &Entity) {{}}");
+        inventory_bridge_accesses(&[mounted("crate::child", "src/child.rs", &text)])
+            .expect_err("missing parent provenance is independent of the alias spelling");
+    }
+    let unused = "use super::Entity; fn innocent(value: u32) -> u32 { value }";
+    assert!(
+        inventory_bridge_accesses(&[mounted("crate::child", "src/child.rs", unused)])
+            .unwrap()
+            .bridges
+            .is_empty()
+    );
+}
+
+#[test]
+fn relative_import_and_type_alias_cycles_fail_closed() {
+    let child = format!("use super::Creature; {TRANSLATE}");
+    pair("use crate::child::Creature; mod child;", &child)
+        .expect_err("a relative import cycle is not proof of absent authority");
+    let child = format!("type Creature = super::Creature; {TRANSLATE}");
+    pair("type Creature = crate::child::Creature; mod child;", &child)
+        .expect_err("aliases must retain the cycle diagnostic");
+}
+
+#[test]
+fn same_named_modules_in_other_packages_cannot_supply_provenance() {
+    let text = r#"
+        mod child;
+        fn inspect(old: &wow_world::SharedMapManager) { let _ = child::Creature; }
+    "#;
+    let foreign = BridgeSource {
+        package: "another-package",
+        module: "crate::child",
+        source_path: "other/src/child.rs",
+        inherited_cfg: &[],
+        source: "pub use wow_entities::Creature;",
+    };
+    let result = inventory_bridge_accesses(&[
+        mounted("crate", "src/lib.rs", text),
+        mounted("crate::child", "src/child.rs", "pub struct Creature;"),
+        foreign,
+    ])
+    .expect("provenance stays within the source package");
+    assert!(result.bridges.is_empty());
+}
+
+#[test]
+fn unresolved_external_authority_glob_remains_rejected_after_parent_import() {
+    pair(
+        "use wow_entities::*; mod child;",
+        &format!("use super::*; {TRANSLATE}"),
+    )
+    .expect_err("a parent glob cannot make an opaque external authority glob inspectable");
+}
+
+#[test]
+fn moved_pending_respawn_bridge_matches_its_exact_reviewed_record() {
+    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..");
+    let baseline = crate::session_ownership::repository_syntax_for_tests()
+        .expect("the moved function retains complete parent import provenance");
+    let actual = baseline
+        .bridge_accesses
+        .bridges
+        .iter()
+        .filter(|record| record.enclosing == "fn::world_creature_from_pending_respawn_like_cpp")
+        .collect::<Vec<_>>();
+    assert_eq!(actual.len(), 1);
+    let policy: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(repository.join("tools/architecture/session-ownership-policy.json"))
+            .unwrap(),
+    )
+    .unwrap();
+    let expected = policy["syntax_baseline"]["bridge_accesses"]["bridges"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|record| record["enclosing"] == "fn::world_creature_from_pending_respawn_like_cpp")
+        .expect("reviewed bridge remains in the exact inventory");
+    assert_eq!(&serde_json::to_value(actual[0]).unwrap(), expected);
+}

--- a/tools/architecture/handler-contract-check/src/bridge_access/tests/mod.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access/tests/mod.rs
@@ -20,4 +20,5 @@ fn inventory(text: &str) -> Result<BridgeAccessBaseline, String> {
     inventory_bridge_accesses(&[source(text)])
 }
 
+mod import_provenance;
 mod scenarios_1;

--- a/tools/architecture/handler-contract-check/src/bridge_access/tests/scenarios_1.rs
+++ b/tools/architecture/handler-contract-check/src/bridge_access/tests/scenarios_1.rs
@@ -21,7 +21,7 @@ fn innocent_bridge_shaped_function_name_is_not_evidence() {
 fn canonical_dto_in_transparent_macro_does_not_invent_authority() {
     let baseline = inventory(
         r#"
-            fn step(creature: &crate::map_manager::WorldCreature) {
+            fn step(creature: &wow_world::WorldCreature) {
                 let _ = matches!(
                     creature.state(),
                     wow_entities::CreatureAiState::Idle
@@ -86,7 +86,7 @@ fn bridge_capable_globs_and_namespace_aliases_fail_closed() {
     let error = inventory(
         r#"
             use wow_entities::*;
-            use crate::map_manager as old_runtime;
+            use wow_world::map_manager as old_runtime;
         "#,
     )
     .expect_err("namespace indirection can hide exact authority types");
@@ -358,38 +358,8 @@ fn comparator_rejects_multiplicity_and_noncanonical_rows() {
 
 #[test]
 fn real_runtime_ledger_anchor_definitions_are_present_once() {
-    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..");
-    let delivery_path = repository.join("crates/world-server/src/runtime/delivery.rs");
-    let game_events_path = repository.join("crates/world-server/src/runtime/game_events.rs");
-    let session_path = repository.join("crates/wow-world/src/session/mod.rs");
-    let delivery = fs::read_to_string(&delivery_path).expect("world-server delivery source");
-    let game_events =
-        fs::read_to_string(&game_events_path).expect("world-server game-events source");
-    let session = fs::read_to_string(&session_path).expect("wow-world session source");
-    let baseline = inventory_bridge_accesses(&[
-        BridgeSource {
-            package: "world-server",
-            module: "crate::runtime::delivery",
-            source_path: "crates/world-server/src/runtime/delivery.rs",
-            inherited_cfg: &[],
-            source: &delivery,
-        },
-        BridgeSource {
-            package: "world-server",
-            module: "crate::runtime::game_events",
-            source_path: "crates/world-server/src/runtime/game_events.rs",
-            inherited_cfg: &[],
-            source: &game_events,
-        },
-        BridgeSource {
-            package: "wow-world",
-            module: "crate::session",
-            source_path: "crates/wow-world/src/session/mod.rs",
-            inherited_cfg: &[],
-            source: &session,
-        },
-    ])
-    .expect("real bridge anchor sources must remain inspectable");
-    validate_curated_bridge_anchors(&baseline)
+    let baseline = crate::session_ownership::repository_syntax_for_tests()
+        .expect("real bridge anchors retain complete lexical source context");
+    validate_curated_bridge_anchors(&baseline.bridge_accesses)
         .expect("every curated runtime-ledger anchor is defined exactly once");
 }

--- a/tools/architecture/handler-contract-check/src/ownership.rs
+++ b/tools/architecture/handler-contract-check/src/ownership.rs
@@ -25,9 +25,10 @@ use syn::{Attribute, Item, ItemMod, Meta, Token};
 
 use crate::module_policy::CapabilityOwner;
 use crate::registrations::{
-    analyze_registration_syntax_outside_handlers, exported_macro_names,
-    handler_capable_macro_definitions, handler_capable_macro_invocations, include_macro_bodies,
-    inventory_registration_macro_fingerprints, registration_alias_violations,
+    analyze_registration_syntax_outside_handlers, data_module_alias_violations,
+    exported_macro_names, handler_capable_macro_definitions, handler_capable_macro_invocations,
+    include_macro_bodies, inventory_dependency_packages, inventory_registration_macro_fingerprints,
+    registration_alias_violations,
 };
 
 const HANDLER_PACKAGE_NAME: &str = "wow-handler";
@@ -1812,6 +1813,7 @@ pub(crate) fn audit_registration_ownership(
 ) -> Result<RegistrationOwnershipReport, String> {
     let metadata = workspace_metadata(repository_root)?;
     let registry_capable = registry_capable_package_ids(&metadata)?;
+    let inventory_capable = inventory_dependency_packages(&metadata)?;
     let workspace_members: BTreeSet<_> = required_array(&metadata, "workspace_members", "root")?
         .iter()
         .map(|member| {
@@ -1898,7 +1900,11 @@ pub(crate) fn audit_registration_ownership(
                     inventory_calls.join(", ")
                 ));
             }
-            let alias_violations = registration_alias_violations(&source)?;
+            let alias_violations = if inventory_capable.contains(&scope.id) {
+                registration_alias_violations(&source)?
+            } else {
+                data_module_alias_violations(&source)?
+            };
             if !alias_violations.is_empty() {
                 errors.push(format!(
                     "package {} source {} exposes registration alias capability: {}",

--- a/tools/architecture/handler-contract-check/src/registrations.rs
+++ b/tools/architecture/handler-contract-check/src/registrations.rs
@@ -16,6 +16,11 @@ use syn::{Attribute, Expr, Item, ItemMacro, Lit, Meta, UseTree};
 use crate::module_policy::CapabilityOwner;
 use crate::ownership::WorkspaceSourceMount;
 
+mod local_inventory;
+pub(crate) use local_inventory::{
+    data_module_alias_violations, inventory_dependency_packages, registration_alias_violations,
+};
+
 pub(crate) const EXPECTED_REGISTRATION_MACROS: &[&str] = &[
     "register_chat_channel_command_handler",
     "register_chat_channel_player_command_handler",
@@ -423,66 +428,6 @@ fn use_tree_can_alias_expected_registration_macro(tree: &UseTree) -> bool {
             .any(use_tree_can_alias_expected_registration_macro),
         UseTree::Glob(_) => false,
     }
-}
-
-#[derive(Default)]
-struct InventoryAliasCollector {
-    violations: Vec<String>,
-}
-
-impl<'ast> Visit<'ast> for InventoryAliasCollector {
-    fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
-        if use_tree_can_alias_inventory_submit(&item.tree) {
-            self.violations.push(format!(
-                "import {} can alias an inventory registration macro; use only canonical \
-                 inventory::collect!/inventory::submit! paths",
-                item.to_token_stream()
-            ));
-        }
-        if use_tree_can_alias_expected_registration_macro(&item.tree) {
-            self.violations.push(format!(
-                "import {} aliases or reexports an audited handler registration macro; \
-                 registration macros must remain private to the declared handler-registration owner and use their \
-                 unqualified audited names",
-                item.to_token_stream()
-            ));
-        }
-        syn::visit::visit_item_use(self, item);
-    }
-
-    fn visit_item_extern_crate(&mut self, item: &'ast syn::ItemExternCrate) {
-        if ident_is(&item.ident, "inventory")
-            || item
-                .rename
-                .as_ref()
-                .is_some_and(|(_, rename)| ident_is(rename, "inventory"))
-        {
-            self.violations.push(format!(
-                "{} is not allowed because #[macro_use] or a crate alias can hide inventory \
-                 registration macros; use only canonical qualified paths",
-                item.to_token_stream()
-            ));
-        }
-        syn::visit::visit_item_extern_crate(self, item);
-    }
-
-    fn visit_item_mod(&mut self, item: &'ast syn::ItemMod) {
-        if ident_is(&item.ident, "inventory") {
-            self.violations.push(format!(
-                "module {} shadows the canonical inventory crate namespace",
-                item.ident
-            ));
-        }
-        syn::visit::visit_item_mod(self, item);
-    }
-}
-
-pub(crate) fn registration_alias_violations(source: &str) -> Result<Vec<String>, String> {
-    let syntax =
-        syn::parse_file(source).map_err(|error| format!("cannot parse Rust source: {error}"))?;
-    let mut collector = InventoryAliasCollector::default();
-    collector.visit_file(&syntax);
-    Ok(collector.violations)
 }
 
 fn is_exact_packet_handler_collector(path: &[String], body: &TokenStream) -> bool {

--- a/tools/architecture/handler-contract-check/src/registrations/local_inventory.rs
+++ b/tools/architecture/handler-contract-check/src/registrations/local_inventory.rs
@@ -1,0 +1,191 @@
+//! Distinguish a proven local inventory data module from registration capability.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use quote::ToTokens;
+use syn::{Item, UseTree, visit::Visit};
+
+use super::{
+    ident_is, use_tree_can_alias_expected_registration_macro, use_tree_can_alias_inventory_submit,
+};
+
+/// Production reverse dependency closure of every resolved `inventory` crate.
+/// Package identity, rather than the dependency's local alias, controls capability.
+pub(crate) fn inventory_dependency_packages(
+    metadata: &serde_json::Value,
+) -> Result<BTreeSet<String>, String> {
+    let packages = metadata["packages"]
+        .as_array()
+        .ok_or("missing metadata packages")?;
+    let mut capable = BTreeSet::new();
+    let mut package_ids = BTreeSet::new();
+    for package in packages {
+        let id = package["id"]
+            .as_str()
+            .ok_or("package without id")?
+            .to_owned();
+        if !package_ids.insert(id.clone()) {
+            return Err(format!("duplicate package {id}"));
+        }
+        if package["name"].as_str().ok_or("package without name")? == "inventory" {
+            capable.insert(id);
+        }
+    }
+    let nodes = metadata["resolve"]["nodes"]
+        .as_array()
+        .ok_or("missing resolved metadata graph")?;
+    let mut reverse: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for node in nodes {
+        let id = node["id"].as_str().ok_or("resolved node without id")?;
+        if !package_ids.contains(id) {
+            return Err(format!("unknown resolved package {id}"));
+        }
+        for dependency in node["deps"]
+            .as_array()
+            .ok_or("resolved node without deps")?
+        {
+            let provider = dependency["pkg"]
+                .as_str()
+                .ok_or("dependency without package id")?;
+            if !package_ids.contains(provider) {
+                return Err(format!("unknown inventory capability provider {provider}"));
+            }
+            let kinds = dependency["dep_kinds"]
+                .as_array()
+                .ok_or("dependency without kinds")?;
+            if kinds.is_empty() {
+                return Err("dependency without kinds".to_owned());
+            }
+            let mut normal = false;
+            for kind in kinds {
+                match kind.get("kind") {
+                    Some(serde_json::Value::Null) => normal = true,
+                    Some(serde_json::Value::String(value))
+                        if matches!(value.as_str(), "dev" | "build") => {}
+                    _ => return Err("unsupported inventory dependency kind".to_owned()),
+                }
+            }
+            if normal {
+                reverse
+                    .entry(provider.to_owned())
+                    .or_default()
+                    .insert(id.to_owned());
+            }
+        }
+    }
+    let mut pending = capable.iter().cloned().collect::<Vec<_>>();
+    while let Some(provider) = pending.pop() {
+        for dependent in reverse.get(&provider).into_iter().flatten() {
+            if capable.insert(dependent.clone()) {
+                pending.push(dependent.clone());
+            }
+        }
+    }
+    Ok(capable)
+}
+
+#[derive(Default)]
+struct InventoryAliasCollector {
+    violations: Vec<String>,
+    allow_local_data_module: bool,
+    local_inventory: Vec<bool>,
+}
+
+impl InventoryAliasCollector {
+    fn enter_scope(&mut self, items: &[Item]) {
+        self.local_inventory.push(
+            items.iter().any(
+                |item| matches!(item, Item::Mod(module) if ident_is(&module.ident, "inventory")),
+            ),
+        );
+    }
+
+    fn is_local_data_glob(&self, item: &syn::ItemUse) -> bool {
+        self.allow_local_data_module
+            && self.local_inventory.last() == Some(&true)
+            && item.leading_colon.is_none()
+            && matches!(&item.tree, UseTree::Path(path)
+                if ident_is(&path.ident, "inventory") && matches!(&*path.tree, UseTree::Glob(_)))
+    }
+}
+
+impl<'ast> Visit<'ast> for InventoryAliasCollector {
+    fn visit_file(&mut self, file: &'ast syn::File) {
+        self.enter_scope(&file.items);
+        syn::visit::visit_file(self, file);
+        self.local_inventory.pop();
+    }
+
+    fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+        if use_tree_can_alias_inventory_submit(&item.tree) && !self.is_local_data_glob(item) {
+            self.violations.push(format!(
+                "import {} can alias an inventory registration macro; use only canonical \
+                 inventory::collect!/inventory::submit! paths",
+                item.to_token_stream()
+            ));
+        }
+        if use_tree_can_alias_expected_registration_macro(&item.tree) {
+            self.violations.push(format!(
+                "import {} aliases or reexports an audited handler registration macro; \
+                 registration macros must remain private to the declared handler-registration owner and use their \
+                 unqualified audited names", item.to_token_stream()
+            ));
+        }
+        syn::visit::visit_item_use(self, item);
+    }
+
+    fn visit_item_extern_crate(&mut self, item: &'ast syn::ItemExternCrate) {
+        if ident_is(&item.ident, "inventory")
+            || item
+                .rename
+                .as_ref()
+                .is_some_and(|(_, rename)| ident_is(rename, "inventory"))
+        {
+            self.violations.push(format!(
+                "{} is not allowed because #[macro_use] or a crate alias can hide inventory \
+                 registration macros; use only canonical qualified paths",
+                item.to_token_stream()
+            ));
+        }
+        syn::visit::visit_item_extern_crate(self, item);
+    }
+
+    fn visit_item_mod(&mut self, item: &'ast syn::ItemMod) {
+        if ident_is(&item.ident, "inventory") && !self.allow_local_data_module {
+            self.violations.push(format!(
+                "module {} shadows the canonical inventory crate namespace",
+                item.ident
+            ));
+        }
+        if let Some((_, items)) = &item.content {
+            self.enter_scope(items);
+            syn::visit::visit_item_mod(self, item);
+            self.local_inventory.pop();
+        }
+    }
+}
+
+pub(crate) fn registration_alias_violations(source: &str) -> Result<Vec<String>, String> {
+    collect(source, false)
+}
+
+/// Only for packages outside the handler registry closure and without any normal
+/// dependency path to inventory. The caller still audits every source's macros,
+/// includes, exports and registration invocations; this is no package exemption.
+pub(crate) fn data_module_alias_violations(source: &str) -> Result<Vec<String>, String> {
+    collect(source, true)
+}
+
+fn collect(source: &str, allow_local_data_module: bool) -> Result<Vec<String>, String> {
+    let syntax =
+        syn::parse_file(source).map_err(|error| format!("cannot parse Rust source: {error}"))?;
+    let mut collector = InventoryAliasCollector {
+        allow_local_data_module,
+        ..Default::default()
+    };
+    collector.visit_file(&syntax);
+    Ok(collector.violations)
+}
+
+#[cfg(test)]
+mod tests;

--- a/tools/architecture/handler-contract-check/src/registrations/local_inventory/tests.rs
+++ b/tools/architecture/handler-contract-check/src/registrations/local_inventory/tests.rs
@@ -1,0 +1,91 @@
+//! Data-module allowance stays separate from actual registration capability.
+
+use super::*;
+use serde_json::json;
+
+#[test]
+fn data_module_glob_requires_a_local_declaration_and_incapable_package() {
+    let source = "pub mod inventory; pub use inventory::*;";
+    assert!(data_module_alias_violations(source).unwrap().is_empty());
+    assert!(!registration_alias_violations(source).unwrap().is_empty());
+    for source in [
+        "pub use inventory::*;",
+        "pub mod inventory; pub use ::inventory::*;",
+        "pub mod inventory; pub use inventory::submit;",
+        "pub mod inventory; pub use inventory::submit as hidden;",
+        "pub mod inventory; pub use inv as inventory;",
+        "pub mod inventory; mod child { pub use inventory::*; }",
+        "pub mod inventory; extern crate inv as inventory;",
+    ] {
+        assert!(
+            !data_module_alias_violations(source).unwrap().is_empty(),
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn local_data_inventory_does_not_exempt_handler_macro_aliases() {
+    let source = "mod inventory; pub use inventory::*; use other::register_move;";
+    let errors = data_module_alias_violations(source).unwrap();
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.contains("audited handler registration macro"))
+    );
+}
+
+fn metadata(kind: serde_json::Value) -> serde_json::Value {
+    json!({
+        "packages": [
+            {"id": "inv-id", "name": "inventory"},
+            {"id": "facade", "name": "facade"},
+            {"id": "consumer", "name": "consumer"},
+            {"id": "data", "name": "data"}
+        ],
+        "resolve": {"nodes": [
+            {"id": "inv-id", "deps": []},
+            {"id": "facade", "deps": [
+                {"name": "renamed", "pkg": "inv-id", "dep_kinds": [{"kind": kind, "target": "cfg(windows)"}]}
+            ]},
+            {"id": "consumer", "deps": [
+                {"name": "facade", "pkg": "facade", "dep_kinds": [{"kind": null}]}
+            ]},
+            {"id": "data", "deps": []}
+        ]}
+    })
+}
+
+#[test]
+fn renamed_target_specific_and_transitive_inventory_dependencies_retain_strict_guard() {
+    assert_eq!(
+        inventory_dependency_packages(&metadata(json!(null))).unwrap(),
+        BTreeSet::from([
+            "inv-id".to_owned(),
+            "facade".to_owned(),
+            "consumer".to_owned()
+        ]),
+    );
+}
+
+#[test]
+fn dev_and_build_dependencies_do_not_create_production_inventory_capability() {
+    for kind in ["dev", "build"] {
+        assert_eq!(
+            inventory_dependency_packages(&metadata(json!(kind))).unwrap(),
+            BTreeSet::from(["inv-id".to_owned()]),
+        );
+    }
+}
+
+#[test]
+fn missing_or_invalid_metadata_cannot_open_the_data_module_allowance() {
+    inventory_dependency_packages(&json!({})).unwrap_err();
+    inventory_dependency_packages(&metadata(json!("unknown"))).unwrap_err();
+    let mut missing = metadata(json!(null));
+    missing["resolve"]["nodes"][1]["deps"][0]["pkg"] = json!("unresolved");
+    inventory_dependency_packages(&missing).unwrap_err();
+    let mut incomplete = metadata(json!(null));
+    incomplete["resolve"]["nodes"][1]["deps"][0]["dep_kinds"] = json!([]);
+    inventory_dependency_packages(&incomplete).unwrap_err();
+}

--- a/tools/architecture/handler-contract-check/src/session_ownership.rs
+++ b/tools/architecture/handler-contract-check/src/session_ownership.rs
@@ -49,6 +49,20 @@ pub use state_2::*;
 #[allow(unused_imports)]
 pub use state_3::*;
 
+/// Real-source regression assertions share one complete syntax graph. Partial
+/// file fixtures cannot prove lexical imports after a physical module move.
+#[cfg(test)]
+pub(crate) fn repository_syntax_for_tests() -> Result<&'static SessionSyntaxBaseline, String> {
+    static BASELINE: std::sync::OnceLock<Result<SessionSyntaxBaseline, String>> =
+        std::sync::OnceLock::new();
+    BASELINE
+        .get_or_init(|| {
+            collect_repository_baseline_with_persistence(&crate::repository_root()?, false)
+        })
+        .as_ref()
+        .map_err(Clone::clone)
+}
+
 #[cfg(test)]
 #[path = "session_ownership/tests/mod.rs"]
 mod tests;

--- a/tools/architecture/handler-contract-check/src/session_ownership/state_3.rs
+++ b/tools/architecture/handler-contract-check/src/session_ownership/state_3.rs
@@ -24,7 +24,7 @@ pub(super) fn collect_units(
     let bridge_sources: Vec<_> = units
         .iter()
         .filter(|unit| {
-            unit.availability.production
+            unit.availability.source_class().is_some()
                 && matches!(unit.role, PackageRole::World | PackageRole::Server)
         })
         .map(|unit| BridgeSource {

--- a/tools/architecture/handler-contract-check/src/session_ownership/tests/scenarios_1.rs
+++ b/tools/architecture/handler-contract-check/src/session_ownership/tests/scenarios_1.rs
@@ -89,6 +89,42 @@ fn synthetic_baseline(world: &str, server: &str) -> Result<SessionSyntaxBaseline
     )
 }
 
+#[test]
+fn test_only_external_modules_supply_bridge_import_context() {
+    let world = format!(
+        "{} #[cfg(test)] mod test_fixture; \
+         #[cfg(test)] mod checks {{ \
+           use crate::test_fixture::Entity; \
+           fn bridge(old: &wow_world::SharedMapManager, new: &Entity) {{}} \
+         }}",
+        world_source("", ""),
+    );
+    let mut fixture = unit(
+        PackageRole::World,
+        "wow-world/src/test_fixture.rs",
+        "pub type Entity = wow_entities::Creature;",
+    );
+    fixture.logical_module_path = "crate::test_fixture".to_owned();
+    fixture.cfg = vec!["cfg(test)".to_owned()];
+    fixture.availability = Availability {
+        production: false,
+        test: true,
+    };
+    let baseline = collect_units(
+        vec![
+            unit(PackageRole::World, "wow-world/src/lib.rs", &world),
+            fixture,
+            unit(PackageRole::Server, "world-server/src/main.rs", &server_source("", "")),
+            unit(PackageRole::Network, "wow-network/src/lib.rs",
+                "pub enum SessionCommand { Kick(KickCommand) } pub struct KickCommand { pub reason: String }"),
+        ],
+        PersistenceAccessBaseline { schema_version: 3, accesses: Vec::new() },
+    ).expect("top-level test-only mounts must not be dropped from bridge provenance");
+    assert_eq!(baseline.bridge_accesses.bridges.len(), 1);
+    assert_eq!(baseline.bridge_accesses.bridges[0].module, "crate::checks");
+    assert_eq!(baseline.bridge_accesses.bridges[0].cfg, vec!["cfg (test)"]);
+}
+
 fn world_source(field: &str, extra_impl_item: &str) -> String {
     format!(
         r#"
@@ -637,7 +673,7 @@ fn server_ownership_root_follows_private_library_modules() {
 #[test]
 fn repository_surface_can_be_collected() {
     let repository_root = crate::repository_root().expect("repository root");
-    let baseline = collect_repository_baseline_with_persistence(&repository_root, false)
+    let baseline = repository_syntax_for_tests()
         .unwrap_or_else(|error| panic!("repository baseline must parse:\n{error}"));
 
     let raw_session_source =

--- a/tools/architecture/physical-file-policy.json
+++ b/tools/architecture/physical-file-policy.json
@@ -658,15 +658,15 @@
     {
       "path": "tools/architecture/handler-contract-check/src/bridge_access.rs",
       "observed_lines": 2128,
-      "ceiling_lines": 52,
-      "split": "Separate the bridge access record, accumulator and symbol table from their regressions. #660 decomposes the 2,128-line root into three state modules and one regression module, dropping it to 52 lines and tightening the ceiling to that figure. Item-for-item with the checker's 334 tests unchanged.",
+      "ceiling_lines": 54,
+      "split": "Separate the bridge access record, accumulator and symbol table from their regressions. #660 decomposes the 2,128-line root into three state modules and one regression module, dropping it to 52 lines. #716 adds two reviewed wiring lines for private lexical provenance resolution; the root is 54 lines, with no relocation counted as ownership retirement.",
       "review_checkpoint": "584:C4"
     },
     {
       "path": "tools/architecture/handler-contract-check/src/persistence_access.rs",
       "observed_lines": 21248,
       "ceiling_lines": 239,
-      "split": "Separate the remaining production AST traversal, statement/workflow classification and provenance. #634 decomposes the 12,348-line root into 21 private responsibility modules (72-949 lines) plus the divided body analyzer, dropping it to 239 lines and tightening the ceiling to that figure; only the pinned constant tables, the shared TargetSet alias and the module composition remain. The inherent `impl BodyAnalyzer` is divided by analysis phase across five body_ops modules, which is behaviour-identical in Rust. One justified exception: persistence_access/body_visit.rs is 1,686 lines because it is the single `Visit for BodyAnalyzer` trait impl and a trait impl cannot be split; its exit is the semantic separation of body analysis into per-expression-kind analyzers, owned by 584:C4. Item-for-item with the checker's 334 tests unchanged.",
+      "split": "Separate the remaining production AST traversal, statement/workflow classification and provenance. #634 decomposes the 12,348-line root into 21 private responsibility modules (72-949 lines) plus the divided body analyzer, dropping it to 239 lines and tightening the ceiling to that figure; only the pinned constant tables, the shared TargetSet alias and the module composition remain. The inherent `impl BodyAnalyzer` is divided by analysis phase across five body_ops modules. The retained 1,686-line persistence_access/body_visit.rs needs review under 584:C4: one Visit trait impl can delegate to private expression analyzers while preserving traversal order. #716 corrects the earlier blanket single-impl exception without changing this file's measured ceiling or claiming its decomposition complete.",
       "review_checkpoint": "584:C4"
     },
     {
@@ -679,8 +679,8 @@
     {
       "path": "tools/architecture/handler-contract-check/src/session_ownership.rs",
       "observed_lines": 2996,
-      "ceiling_lines": 54,
-      "split": "Separate the package roles, the expression-surface collector and the baseline builder. #660 decomposes the 2,996-line root into three state modules and one regression module, dropping it to 54 lines and tightening the ceiling to that figure. Item-for-item with the checker's 334 tests unchanged.",
+      "ceiling_lines": 68,
+      "split": "Separate the package roles, the expression-surface collector and the baseline builder. #660 decomposes the 2,996-line root into three state modules and one regression module, dropping it to 54 lines. #716 adds a 14-line cfg(test) cached complete repository syntax fixture: real bridge and ownership assertions share actual lexical context instead of incomplete file subsets or repeated full syntax scans. The reviewed 68-line root retains the same production owner and inventory obligations.",
       "review_checkpoint": "584:C4"
     },
     {

--- a/tools/architecture/session-ownership-policy.json
+++ b/tools/architecture/session-ownership-policy.json
@@ -56085,7 +56085,7 @@
       ],
       "world_session_new_sites": [
         {
-          "module": "crate::battle_pet_purchase::executor_tests::fixtures",
+          "module": "crate::battle_pet_purchase::executor_tests::fixtures::session",
           "callee": "WorldSession::new",
           "argument_count": 10,
           "cfg": [
@@ -56185,7 +56185,7 @@
           "count": 1
         },
         {
-          "module": "crate::handlers::misc::tests",
+          "module": "crate::handlers::misc::tests::world",
           "callee": "WorldSession::new",
           "argument_count": 10,
           "cfg": [
@@ -72495,8 +72495,64 @@
         },
         {
           "package": "wow-world",
-          "module": "crate::map_manager",
-          "path": "crates/wow-world/src/map_manager/mod.rs",
+          "module": "crate::map_manager::movement::motion_master",
+          "path": "crates/wow-world/src/map_manager/movement/motion_master.rs",
+          "enclosing": "WorldCreature::new_runtime_motion_master_like_cpp",
+          "direction_markers": [
+            "unresolved_dual_side"
+          ],
+          "evidence": [
+            {
+              "side": "canonical",
+              "kind": "type_reference",
+              "symbol": "Creature",
+              "fingerprint": "fnv1a64x2:bd784706687625df3431fb91619ba9ee:len=48",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "creature",
+              "fingerprint": "fnv1a64x2:0ddb2f8adc439cac591dc95f86662d0f:len=146",
+              "multiplicity": 3
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "combat_target",
+              "fingerprint": "fnv1a64x2:788d31edf17a26d57a3d86153cbf4a7e:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "ai_ownership",
+              "fingerprint": "fnv1a64x2:7932794ba8aa1145b08f4d51023b571e:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "ai_state",
+              "fingerprint": "fnv1a64x2:9c530a227dad1411cd9aa33c9c804f4e:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "legacy",
+              "kind": "self_type",
+              "symbol": "Self",
+              "fingerprint": "fnv1a64x2:04b46af65889c97828c79628682b3b53:len=49",
+              "multiplicity": 1
+            }
+          ],
+          "fingerprint": "signature=impl:WorldCreature::fn new_runtime_motion_master_like_cpp (creature : & Creature ,) -> MotionMaster|body=fnv1a64x2:0efef587ac9d9ca81670ceaa2ee7b63b:len=370|evidence=fnv1a64x2:5a80b98447b05bea27e0ebf7b3971e3d:len=651",
+          "cfg": [],
+          "multiplicity": 1
+        },
+        {
+          "package": "wow-world",
+          "module": "crate::map_manager::pending_respawn",
+          "path": "crates/wow-world/src/map_manager/pending_respawn.rs",
           "enclosing": "fn::world_creature_from_pending_respawn_like_cpp",
           "direction_markers": [
             "unresolved_dual_side"
@@ -72994,6 +73050,902 @@
             }
           ],
           "fingerprint": "signature=fn world_creature_from_pending_respawn_like_cpp (respawn : & PendingRespawn , instance_id : u32 ,) -> WorldCreature|body=fnv1a64x2:5ef5611c62166b6989a26e5db59022b8:len=5604|evidence=fnv1a64x2:9973f99b95cacfee679a81a69cea488d:len=14277",
+          "cfg": [],
+          "multiplicity": 1
+        },
+        {
+          "package": "wow-world",
+          "module": "crate::map_manager::runtime::creature",
+          "path": "crates/wow-world/src/map_manager/runtime/creature.rs",
+          "enclosing": "WorldCreature::create_data_from_canonical_like_cpp",
+          "direction_markers": [
+            "unresolved_dual_side"
+          ],
+          "evidence": [
+            {
+              "side": "canonical",
+              "kind": "type_reference",
+              "symbol": "Creature",
+              "fingerprint": "fnv1a64x2:bd784706687625df3431fb91619ba9ee:len=48",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "attack_speed",
+              "fingerprint": "fnv1a64x2:16f3906fdde844c04415db87019c6e2b:len=99",
+              "multiplicity": 2
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "creature",
+              "fingerprint": "fnv1a64x2:101c0b1a0c24ffacf63fdb4e87ba2c8f:len=538",
+              "multiplicity": 11
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "data",
+              "fingerprint": "fnv1a64x2:2439648fb075c74392fd7eabc5c95562:len=1518",
+              "multiplicity": 31
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "npc_flags",
+              "fingerprint": "fnv1a64x2:7137b40df7878c5024bf30f3cfcf211b:len=97",
+              "multiplicity": 2
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "object",
+              "fingerprint": "fnv1a64x2:65dc25ce175ac6cacfb8a8f46eb72e31:len=48",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "speed_rate",
+              "fingerprint": "fnv1a64x2:61655ae666fa596840afd791bf05b793:len=99",
+              "multiplicity": 2
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "unit",
+              "fingerprint": "fnv1a64x2:1fa32a08b74d48b8cb492b28f2a94193:len=489",
+              "multiplicity": 10
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "vehicle_id",
+              "fingerprint": "fnv1a64x2:d0f7305066a5df38f50de6efba5aaf7b:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "anim_tier",
+              "fingerprint": "fnv1a64x2:f61de618afdcdafd158dc7f874653c8a:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "base_mana",
+              "fingerprint": "fnv1a64x2:d01e27a79ede931c823e115a2938b387:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "bounding_radius",
+              "fingerprint": "fnv1a64x2:efe60de5d808ef4a12df5893cd9a4051:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "class_id",
+              "fingerprint": "fnv1a64x2:3a46a9a2656dfc2f998abd3a9f01e9e4:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "combat_reach",
+              "fingerprint": "fnv1a64x2:35afc8407cc6a1cdfff71b783ecc7256:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "display_id",
+              "fingerprint": "fnv1a64x2:c488b3d2b183e84be7354c0bbfa29cb0:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "display_power",
+              "fingerprint": "fnv1a64x2:781972fa61d8d04603a1a6951e167d15:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "display_scale",
+              "fingerprint": "fnv1a64x2:1c43fd67ed8ea9e16ea6692dabd74dea:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "faction_template",
+              "fingerprint": "fnv1a64x2:2bf03b36fa07e7a5f4e274fc805796ae:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "flags",
+              "fingerprint": "fnv1a64x2:2f0a8d042856908ee8b769b7e422ec01:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "flags2",
+              "fingerprint": "fnv1a64x2:fe21b0d803c7a481af3ba958a57b5582:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "flags3",
+              "fingerprint": "fnv1a64x2:e4e331caddff478fc1617e8e5f5c5f70:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "hover_height",
+              "fingerprint": "fnv1a64x2:c3deb9b126d7b1b362bcaa6baaf00bfc:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "item_appearance_mod_id",
+              "fingerprint": "fnv1a64x2:952d679250f763a3151d1526065dccdc:len=149",
+              "multiplicity": 3
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "item_id",
+              "fingerprint": "fnv1a64x2:853b86d9bb3d417768ad93ea0b918fc8:len=149",
+              "multiplicity": 3
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "item_visual",
+              "fingerprint": "fnv1a64x2:5fb2c063f21d8273e54460718dfc8c94:len=149",
+              "multiplicity": 3
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "kit",
+              "fingerprint": "fnv1a64x2:ba33769c3fe5ef16bd6842c290187ce9:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "max_power",
+              "fingerprint": "fnv1a64x2:61d545540fff00bdbf139f4f435b05fa:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "mount_display_id",
+              "fingerprint": "fnv1a64x2:2c433f1b5624c821cc18d311e4d861ce:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "native_display_id",
+              "fingerprint": "fnv1a64x2:4d156ace24d5631539b7773183311e36:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "native_display_scale",
+              "fingerprint": "fnv1a64x2:b08e97f7888868e5f8f200c0a1bfa54e:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "power",
+              "fingerprint": "fnv1a64x2:261b39f47d54b87205e977dcb943a385:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "pvp_flags",
+              "fingerprint": "fnv1a64x2:ed4df648ff83fa93a5ff60f895f55708:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "sheathe_state",
+              "fingerprint": "fnv1a64x2:2fba65dd4dc75175cd8c159943a4ad0a:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "stand_state",
+              "fingerprint": "fnv1a64x2:d874467bcf360b3f022df5d2905f29ac:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "vehicle",
+              "fingerprint": "fnv1a64x2:4e9790c4c9f64546b417060559fb9a19:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "virtual_items",
+              "fingerprint": "fnv1a64x2:70a629ba4c7a4e94bca97e9471762177:len=449",
+              "multiplicity": 9
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "vis_flags",
+              "fingerprint": "fnv1a64x2:add1597e1d5e2b6c86e6e7a80ea5201f:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "ai_anim_kit_id_like_cpp",
+              "fingerprint": "fnv1a64x2:fdad69e9f117b3cbd979a5259d0381bc:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "as_ref",
+              "fingerprint": "fnv1a64x2:2c1663deb7511d4a1cd3f38e411448a1:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "base_attack_speed",
+              "fingerprint": "fnv1a64x2:9241ec6c267b769035adc77e0ec6355b:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "bits",
+              "fingerprint": "fnv1a64x2:c58c014fb76066d5ccfc40813d629b66:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "current_health",
+              "fingerprint": "fnv1a64x2:66a1e2aee64c482b1ed66fe396521318:len=149",
+              "multiplicity": 3
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "data",
+              "fingerprint": "fnv1a64x2:e6c410c6d96fbc2005617b2073aca17b:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "emote_state_like_cpp",
+              "fingerprint": "fnv1a64x2:f51eb5d7514cc3d6ed7682b5860c5d35:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "entry",
+              "fingerprint": "fnv1a64x2:d38795314c991279e7019f9f238379ea:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "guid",
+              "fingerprint": "fnv1a64x2:77533974a88271de0b856b7b06c69065:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "level",
+              "fingerprint": "fnv1a64x2:50ab012f29730b8b638d3b1fc282a7ac:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "map",
+              "fingerprint": "fnv1a64x2:e6ad026be2eeaa00080b6666e8b6d13b:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "max",
+              "fingerprint": "fnv1a64x2:03ad09b200420a91ff81e4f7cc0985a2:len=99",
+              "multiplicity": 2
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "max_health",
+              "fingerprint": "fnv1a64x2:09351217254890c8280fd889da67d833:len=99",
+              "multiplicity": 2
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "melee_anim_kit_id_like_cpp",
+              "fingerprint": "fnv1a64x2:758fd22e1dfad584ad1fb9cab5aaed27:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "melee_damage_school_like_cpp",
+              "fingerprint": "fnv1a64x2:a1b8fe20394da19f75f62d39ad6ec158:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "min",
+              "fingerprint": "fnv1a64x2:a8de976be8141bc9bf0839f812dfad76:len=99",
+              "multiplicity": 2
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "movement_anim_kit_id_like_cpp",
+              "fingerprint": "fnv1a64x2:f2fe0eb5236d78863506093abb7c3dd5:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "movement_flags_like_cpp",
+              "fingerprint": "fnv1a64x2:9e34bbe07890deeddd860e8bfbed4e6a:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "npc_flags_like_cpp",
+              "fingerprint": "fnv1a64x2:3f96969c9191dbe25f102bb2aaf73a65:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "object",
+              "fingerprint": "fnv1a64x2:616ddd270c05deccd8d666772c7136d7:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "scale",
+              "fingerprint": "fnv1a64x2:fab336a7389373a66e6bcbac42b5a2f5:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "speed_rate",
+              "fingerprint": "fnv1a64x2:3f1ca3a90f3be49efc650a0fe922586d:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "subsystems",
+              "fingerprint": "fnv1a64x2:082921388296232af3a1591c8e456741:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "unit",
+              "fingerprint": "fnv1a64x2:b3ff3191d0d5c4caa3eb2f63ad80978d:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "unwrap_or",
+              "fingerprint": "fnv1a64x2:1398bd23ba024f68216d88880cf22b5b:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "world",
+              "fingerprint": "fnv1a64x2:47755096bd4f3500284e9d7328ca1a93:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "legacy",
+              "kind": "self_type",
+              "symbol": "Self",
+              "fingerprint": "fnv1a64x2:04b46af65889c97828c79628682b3b53:len=49",
+              "multiplicity": 1
+            }
+          ],
+          "fingerprint": "signature=impl:WorldCreature::fn create_data_from_canonical_like_cpp (creature : & Creature) -> CreatureCreateData|body=fnv1a64x2:87a2e9da96f06842d7de3eb118513a6d:len=2919|evidence=fnv1a64x2:74eea7f9f68768de4051f6ef9d3660a9:len=11113",
+          "cfg": [],
+          "multiplicity": 1
+        },
+        {
+          "package": "wow-world",
+          "module": "crate::map_manager::runtime::creature",
+          "path": "crates/wow-world/src/map_manager/runtime/creature.rs",
+          "enclosing": "WorldCreature::from_canonical",
+          "direction_markers": [
+            "unresolved_dual_side"
+          ],
+          "evidence": [
+            {
+              "side": "canonical",
+              "kind": "type_reference",
+              "symbol": "Creature",
+              "fingerprint": "fnv1a64x2:bd784706687625df3431fb91619ba9ee:len=48",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "ai",
+              "fingerprint": "fnv1a64x2:b20f0bd2425a02418c1f7806cfc04c2c:len=244",
+              "multiplicity": 5
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "creature",
+              "fingerprint": "fnv1a64x2:1c608a550965ddecf900732d4034f5ef:len=440",
+              "multiplicity": 9
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "auras",
+              "fingerprint": "fnv1a64x2:1da06df8102f138790bce202dd540c10:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "motion",
+              "fingerprint": "fnv1a64x2:ae050c325900116af5ec60f28f9de371:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "npc_flags",
+              "fingerprint": "fnv1a64x2:14c029a87071ca3a0a4090a916356505:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "npc_flags2",
+              "fingerprint": "fnv1a64x2:172156dc0749c4a9f7e09bcfc5a2327a:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "unit_flags",
+              "fingerprint": "fnv1a64x2:041c726558d5573293758840f2662fad:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "unit_flags2",
+              "fingerprint": "fnv1a64x2:c7b7800c362bbba99ae59363335a8656:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "unit_flags3",
+              "fingerprint": "fnv1a64x2:e98ec875186691f93d927a674c573d12:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "add_to_world_like_cpp",
+              "fingerprint": "fnv1a64x2:db73bb5536941402a26969c29529f445:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "ai_anim_kit_id_like_cpp",
+              "fingerprint": "fnv1a64x2:18b4fb143446233408bba00bf77dfe6f:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "ai_ownership",
+              "fingerprint": "fnv1a64x2:7932794ba8aa1145b08f4d51023b571e:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "invalidate_spell_hit_aura_authority_like_cpp",
+              "fingerprint": "fnv1a64x2:9c37225e74164949b9ed5bdfb0fe98ec:len=50",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "melee_anim_kit_id_like_cpp",
+              "fingerprint": "fnv1a64x2:e4f3259e278b1969c2974fe115ee1de6:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "melee_damage_school_like_cpp",
+              "fingerprint": "fnv1a64x2:a1b8fe20394da19f75f62d39ad6ec158:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "movement_anim_kit_id_like_cpp",
+              "fingerprint": "fnv1a64x2:ad35849295eb7a4a2ce65162a3f73995:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "subsystems_mut",
+              "fingerprint": "fnv1a64x2:22075958003e5dd8f6c93239ccaf4423:len=99",
+              "multiplicity": 2
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "unit",
+              "fingerprint": "fnv1a64x2:82170c0f70d66a96f98a57777b2f08a9:len=149",
+              "multiplicity": 3
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "unit_mut",
+              "fingerprint": "fnv1a64x2:d1f2d1a637732574e572886cf08ecc0f:len=99",
+              "multiplicity": 2
+            },
+            {
+              "side": "legacy",
+              "kind": "self_type",
+              "symbol": "Self",
+              "fingerprint": "fnv1a64x2:04b46af65889c97828c79628682b3b53:len=49",
+              "multiplicity": 1
+            }
+          ],
+          "fingerprint": "signature=impl:WorldCreature::fn from_canonical (mut creature : Creature , mut create_data : CreatureCreateData) -> Self|body=fnv1a64x2:b3d1724c629cb8c804d31212e01865db:len=1959|evidence=fnv1a64x2:f12b3bf31903c38e2a064680645d9d15:len=3105",
+          "cfg": [],
+          "multiplicity": 1
+        },
+        {
+          "package": "wow-world",
+          "module": "crate::map_manager::runtime::creature",
+          "path": "crates/wow-world/src/map_manager/runtime/creature.rs",
+          "enclosing": "WorldCreature::from_loaded_grid_canonical_like_cpp",
+          "direction_markers": [
+            "unresolved_dual_side"
+          ],
+          "evidence": [
+            {
+              "side": "canonical",
+              "kind": "type_reference",
+              "symbol": "Creature",
+              "fingerprint": "fnv1a64x2:bd784706687625df3431fb91619ba9ee:len=48",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "creature",
+              "fingerprint": "fnv1a64x2:c552aaf357431f98f93ff19e0bf03ef3:len=97",
+              "multiplicity": 2
+            },
+            {
+              "side": "legacy",
+              "kind": "self_type",
+              "symbol": "Self",
+              "fingerprint": "fnv1a64x2:04b46af65889c97828c79628682b3b53:len=49",
+              "multiplicity": 1
+            }
+          ],
+          "fingerprint": "signature=impl:WorldCreature::fn from_loaded_grid_canonical_like_cpp (creature : Creature , mut waypoint_path_resolver : impl FnMut (u32) -> Option < WaypointPath > ,) -> Self|body=fnv1a64x2:0778fad32695978423e9405716a83cbf:len=677|evidence=fnv1a64x2:1d2e6aa8c5e08f168afcb65246e0d78d:len=318",
+          "cfg": [],
+          "multiplicity": 1
+        },
+        {
+          "package": "wow-world",
+          "module": "crate::map_manager::runtime::creature",
+          "path": "crates/wow-world/src/map_manager/runtime/creature.rs",
+          "enclosing": "WorldCreature::new",
+          "direction_markers": [
+            "unresolved_dual_side"
+          ],
+          "evidence": [
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "ai",
+              "fingerprint": "fnv1a64x2:b20f0bd2425a02418c1f7806cfc04c2c:len=244",
+              "multiplicity": 5
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "creature",
+              "fingerprint": "fnv1a64x2:101c0b1a0c24ffacf63fdb4e87ba2c8f:len=538",
+              "multiplicity": 11
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "new",
+              "fingerprint": "fnv1a64x2:c21e5ffbe08fdb10037f59dfb58bf35b:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "aggro_radius",
+              "fingerprint": "fnv1a64x2:3f9061b2e32fe683601f253690f7f4c0:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "max_damage",
+              "fingerprint": "fnv1a64x2:2b5b5fc6ae7a04bb8f4ade343994df14:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "min_damage",
+              "fingerprint": "fnv1a64x2:e1e2e0506cc633548c6615198b8dd0e7:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "respawn_time_secs",
+              "fingerprint": "fnv1a64x2:c89698e8fe2d09a48f42534eeeb8cdc7:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "wander_radius",
+              "fingerprint": "fnv1a64x2:af7d058711ce9824170f33b4ed8f9c77:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "function_call",
+              "symbol": "new",
+              "fingerprint": "fnv1a64x2:0b2ffa7e09564c52a8de049ef5919c05:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "ai_ownership_mut",
+              "fingerprint": "fnv1a64x2:81bec124e2ff4402d777dc9402dd17d1:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "create",
+              "fingerprint": "fnv1a64x2:b3ff2013c9fecfe788c4c0adaa6bde08:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "object_mut",
+              "fingerprint": "fnv1a64x2:a5cb64aafeb27d983d9b728a1aeee193:len=99",
+              "multiplicity": 2
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "set_ai_home_position",
+              "fingerprint": "fnv1a64x2:aa2d4a65d33894963149c98d40c27739:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "set_ai_identity_runtime",
+              "fingerprint": "fnv1a64x2:d24ade2a9bdb7ba035355829b2797b4b:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "set_ai_position",
+              "fingerprint": "fnv1a64x2:752a5a6872510b93b0f841f47a9e877c:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "set_entry",
+              "fingerprint": "fnv1a64x2:5a95c8da5c5e04fb25ad90913519a1ac:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "set_health",
+              "fingerprint": "fnv1a64x2:b6281bb4de3ed2e5fda4bf7a7d119b36:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "set_level",
+              "fingerprint": "fnv1a64x2:9e6d081f7ad4ddcf0f9b793a9713b044:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "set_max_health",
+              "fingerprint": "fnv1a64x2:c98e31976034aa6c2d54ff3e1266821f:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "set_weapon_damage",
+              "fingerprint": "fnv1a64x2:dc5e067897539c59c064b6cff047bda8:len=50",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "unit_mut",
+              "fingerprint": "fnv1a64x2:c9f4ea1530a95facd8e015dc764e5b67:len=299",
+              "multiplicity": 6
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "world_mut",
+              "fingerprint": "fnv1a64x2:444c76ebca630eb401dc3f25d8d259cf:len=99",
+              "multiplicity": 2
+            },
+            {
+              "side": "legacy",
+              "kind": "self_type",
+              "symbol": "Self",
+              "fingerprint": "fnv1a64x2:04b46af65889c97828c79628682b3b53:len=49",
+              "multiplicity": 1
+            }
+          ],
+          "fingerprint": "signature=impl:WorldCreature::fn new (guid : ObjectGuid , entry : u32 , pos : Position , hp : u32 , level : u8 , min_dmg : u32 , max_dmg : u32 , aggro_radius : f32 , display_id : u32 , faction : u32 , npc_flags : u32 , unit_flags : u32 ,) -> Self|body=fnv1a64x2:21d904ac20ad7f5296cfcf58d15f33c9:len=2146|evidence=fnv1a64x2:8d12bcd3530c290d4b35a5c914951aa6:len=3617",
+          "cfg": [],
+          "multiplicity": 1
+        },
+        {
+          "package": "wow-world",
+          "module": "crate::map_manager::runtime::creature",
+          "path": "crates/wow-world/src/map_manager/runtime/creature.rs",
+          "enclosing": "WorldCreature::runtime_default_generator_like_cpp",
+          "direction_markers": [
+            "unresolved_dual_side"
+          ],
+          "evidence": [
+            {
+              "side": "canonical",
+              "kind": "type_reference",
+              "symbol": "Creature",
+              "fingerprint": "fnv1a64x2:bd784706687625df3431fb91619ba9ee:len=48",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "creature",
+              "fingerprint": "fnv1a64x2:0ddb2f8adc439cac591dc95f86662d0f:len=146",
+              "multiplicity": 3
+            },
+            {
+              "side": "canonical",
+              "kind": "field_access",
+              "symbol": "wander_radius",
+              "fingerprint": "fnv1a64x2:77b92129d5020edde66f423dead9ba92:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "ai_ownership",
+              "fingerprint": "fnv1a64x2:7932794ba8aa1145b08f4d51023b571e:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "default_movement_type",
+              "fingerprint": "fnv1a64x2:654057c6d7ee02bbb1fa03b4bba237b8:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "method_call",
+              "symbol": "waypoint_path_id_like_cpp",
+              "fingerprint": "fnv1a64x2:7b148458ae1e512ecfaa8217f21cdcf5:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "legacy",
+              "kind": "self_type",
+              "symbol": "Self",
+              "fingerprint": "fnv1a64x2:04b46af65889c97828c79628682b3b53:len=49",
+              "multiplicity": 1
+            }
+          ],
+          "fingerprint": "signature=impl:WorldCreature::fn runtime_default_generator_like_cpp (creature : & Creature ,) -> Box < dyn RuntimeMovementGenerator >|body=fnv1a64x2:7aaad68a809895e2de86caddc18bb985:len=414|evidence=fnv1a64x2:e1f303522392681a22b4ca788e33694d:len=761",
           "cfg": [],
           "multiplicity": 1
         },
@@ -73761,6 +74713,50 @@
           ],
           "fingerprint": "signature=struct::WorldSession|surface=fnv1a64x2:49747900b94e6e7a62867b7f9b04e9bd:len=91975|evidence=fnv1a64x2:2e6cfac122e1f70b6b6193924d25bd6c:len=187",
           "cfg": [],
+          "multiplicity": 1
+        },
+        {
+          "package": "wow-world",
+          "module": "crate::session::deferred_visibility::tests",
+          "path": "crates/wow-world/src/session/deferred_visibility/tests.rs",
+          "enclosing": "Fixture::new",
+          "direction_markers": [
+            "unresolved_dual_side"
+          ],
+          "evidence": [
+            {
+              "side": "canonical",
+              "kind": "value_reference",
+              "symbol": "default",
+              "fingerprint": "fnv1a64x2:0c1006b8445b5120a346d089eaebf0cb:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "canonical",
+              "kind": "function_call",
+              "symbol": "default",
+              "fingerprint": "fnv1a64x2:cf8f99e8181e6687ca1842b6ea2b8828:len=49",
+              "multiplicity": 1
+            },
+            {
+              "side": "legacy",
+              "kind": "value_reference",
+              "symbol": "new",
+              "fingerprint": "fnv1a64x2:0129d3673b4657ebdd6aa39f0b4b1eec:len=99",
+              "multiplicity": 2
+            },
+            {
+              "side": "legacy",
+              "kind": "function_call",
+              "symbol": "new",
+              "fingerprint": "fnv1a64x2:79c51a3c49fb79fbbbb7d74c629f9e32:len=100",
+              "multiplicity": 2
+            }
+          ],
+          "fingerprint": "signature=impl:Fixture::fn new () -> Self|body=fnv1a64x2:c4349362517a7c10b17335228530d933:len=2403|evidence=fnv1a64x2:7eaea3832d373b1fee0683c61b52eebe:len=464",
+          "cfg": [
+            "cfg (test)"
+          ],
           "multiplicity": 1
         },
         {


### PR DESCRIPTION
Restores exact ownership-provenance acceptance after the mechanical module
decomposition passes, and records the complete continuation plan for the
architecture repair program.

## What changed

Analyzer/tooling only. No gameplay, SQL, protocol, scheduling or server process
was modified.

- Module import provenance is now resolved through a supplied logical source
  graph: parents, relative globs, aliases and `cfg`, keeping local shadowing and
  package isolation. A rename or file move can no longer make an authority
  disappear from the inventory.
- Missing relative context and relevant cycles are detected; opaque external
  globs able to hide authority stay prohibited.
- The two `WorldSession::new` fixture scopes and the `pending_respawn` bridge
  location were relocated to their reviewed records, preserving footprint and
  multiplicity.
- The `inventory` data module is no longer confused with the registration crate;
  real registration aliases stay prohibited, now with a dependency test.
- The false prohibition on splitting a trait impl is corrected; only the
  individual mount/fixture increments were reviewed, and pointers for already
  closed deliveries were updated.
- The repository-verifying tests now share one complete source graph.

## Inventory

The 65 earlier bridge records are preserved after the reviewed relocation, and
seven existing dual references recovered by the analyzer are added — six
`WorldCreature` methods and one visibility fixture — for 72 exact records. No
obligation was removed. The exhaustive persistence inventory was not regenerated.

## Evidence

Run on aarch64, Rust 1.98.0, one Cargo job, at the committed SHA `433a3a33`
with a clean tree.

| Check | Result |
| --- | --- |
| `cargo test --manifest-path tools/architecture/handler-contract-check/Cargo.toml --lib` | 363 passed, 0 failed |
| `session-ownership-check -- check --syntax-only` | PASS — 221 production fields, 427 fixture fields, 594 direct registration accesses, exact 72-bridge baseline |
| `check_architecture.py check` | PASS — 38 packages, 101 internal edges |
| `check_architecture.py self-test` | PASS |
| `./tools/validation-v2 final --base origin/3.4.3` | PASS, manifest verified green, `dirty: false` |

`check_architecture.py physical-files --terminal` still fails on the same 31
files as the reviewed base. That is retained, unhidden debt for P4 of the
continuation plan, not terminal acceptance of the refactor.

## Continuation

`docs/architecture/refactor-completion-plan.md` records the full ordered plan
(P0–P6), the target structure, the open decisions and the 31 remaining physical
files. P0 is this delivery; quest reward is the next operation macro.

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)
