### PR TITLE
Record the droppable group-removal state clear (#743)

### DIFF
--- a/docs/migration/EXISTING-CODE-DEFECTS.md
+++ b/docs/migration/EXISTING-CODE-DEFECTS.md
@@ -17,6 +17,31 @@ remain real; "sends the packet and mutates DB" still does not imply full gamepla
 
 ## Later verified open findings
 
+- **2026-09-11, #743 group removal — the member's own state clear can be dropped.**
+  Source-verified on `6aeca244`. When a member is kicked or the group disbands,
+  the acting session mutates the registry and then asks the affected member's
+  session to clear its own Player state:
+  `handlers/group/ops_1.rs:632` sends `SessionCommand::ApplyGroupRemovalLikeCpp`
+  through `PlayerDirectory::try_send_current_command`
+  (`session/directory.rs:1753`), a `try_send` on a bounded channel that returns
+  `PlayerDirectorySendError::Full` when the target queue is full. The production
+  queue is `flume::bounded(256)` (`session/mod.rs:7726`) and the result is
+  discarded with `let _ =`; 14 of the 23 production call sites discard it, while
+  `session/admission.rs:436` handles it, so the codebase is already inconsistent
+  about whether a dropped command matters. Nothing reconciles afterwards:
+  `sync_player_registry_state_like_cpp` (`session/mod.rs:12431`) pushes session
+  state *to* the registry and never re-derives the Player's group from it, and
+  although `set_owned_player_group_like_cpp` validates against the registry when
+  setting, the read paths use the Player snapshot directly. When the drop
+  happens the registry has revoked membership while the kicked player's Player
+  still claims it, with no path back to agreement until relog. C++ cannot reach
+  this state: `Group::RemoveMember` calls `SetGroup(nullptr)` on the Player
+  in-process, and an in-process call cannot be dropped for backpressure.
+  Severity is bounded by the trigger, which needs a saturated or stalled session
+  loop. This is a source-verified mechanism, not a live reproduction; no live
+  capture or runtime QA was run for it. Delivery-guarantee choice and fix are
+  scoped in #743.
+
 - **2026-09-05, #578 quest dialog — repeatable turn-in markers reversed.**
   Source-verified on `e478ac5d`: in `handlers/quest/eligibility.rs`,
   `get_represented_quest_giver_status_like_cpp` selects TRIVIAL_REPEATABLE_TURNIN


### PR DESCRIPTION
## What

Found while measuring P2's social/groups row before scoping it, so the finding is recorded in
the owning document rather than left in an issue alone.

**What is already correct**, recorded so it is not re-investigated: group ownership is in the
right place — `wow-social`'s group owns membership through a named API matching C++ `Group` — and
the Player-side snapshot is not derived data mistaken for authority, because C++
`Player::GetGroup()` (Player.h:2547) likewise reads the group off the Player's own `m_group`
reference.

**The defect** is the delivery guarantee on the affected member's own state clear.
`handlers/group/ops_1.rs:632` sends `SessionCommand::ApplyGroupRemovalLikeCpp` through
`try_send_current_command` (`session/directory.rs:1753`) — a `try_send` on a `bounded(256)`
channel (`session/mod.rs:7726`) — and discards the result. 14 of 23 production call sites
discard it while `session/admission.rs:436` handles it, so the codebase is already inconsistent
about whether a dropped command matters. Nothing reconciles afterwards:
`sync_player_registry_state_like_cpp` (`session/mod.rs:12431`) pushes session state *to* the
registry and never re-derives the Player's group from it.

When the drop happens the registry has revoked membership while the kicked player's Player still
claims it, with no path back to agreement until relog. C++ cannot reach this state:
`Group::RemoveMember` clears the Player in-process, and an in-process call cannot be dropped for
backpressure.

## Why recorded, not patched

Choosing between blocking with an explicit lock order and blocking scope, retrying, or making
the state reconcilable is a design decision that needs its own contract — and this project's
rules keep a legacy repair out of a behavior-preserving refactor. Scoped in #743, which also
carries the rest of that P2 row.

Severity is bounded by the trigger: it needs a saturated or stalled session loop. This is a
source-verified mechanism, **not** a live reproduction — no capture or runtime QA was run for
it, and the entry says so.

## Evidence

Documentation only — one file, 25 insertions.

- `./tools/validation-v2 quick --base origin/3.4.3`: green (manifest
  `20260911T085431.792368Z-1980460-quick.json`, verified green).
- No code changed, so no new `final` is claimed and no earlier run is relabelled.

Part of #743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)