### PR TITLE
Record the measured state of P2's remaining rows

### DIFF
--- a/docs/architecture/refactor-completion-plan.md
+++ b/docs/architecture/refactor-completion-plan.md
@@ -501,8 +501,43 @@ producción mantiene más de una escritura durable de inventario, y sus dos
 escrituras son las ramas exclusivas verificadas en #720. Ninguna familia añadió
 un participante de persistencia.
 
-Quedan tres filas de P2: progresión/spells/effects, social y grupos, y cuenta,
-carga y guardado.
+**Estado medido de las tres filas restantes de P2** (2026-09-11, contrastado en
+código, no asumido desde la tabla de la sección P2):
+
+*Social y grupos.* La propiedad ya es correcta: el grupo de `wow-social` posee la
+pertenencia con una API nombrada equivalente a `Group` de C++, y la instantánea
+del lado del Player no es dato derivado confundido con autoridad, porque
+`Player::GetGroup()` (Player.h:2547) también lee el grupo de la referencia
+`m_group` del propio Player. Lo que sí apareció es un defecto de garantía de
+entrega: el borrado de estado del miembro afectado viaja por
+`try_send_current_command`, un `try_send` sobre un canal `bounded(256)`, y su
+resultado se descarta; nada reconcilia después. Registrado en
+EXISTING-CODE-DEFECTS.md y acotado en
+[#743](https://github.com/alseif0x/rustycore/issues/743), que además lleva el
+resto de la fila. No se parcheó porque elegir entre envío bloqueante con orden
+de cerraduras explícito, reintento, o estado reconciliable es una decisión de
+diseño con su propio contrato.
+
+*Progresión/spells/effects.* Entregada en lo esencial por #587 y documentada en
+ownership-and-boundaries.md, que ya fija su condición de retirada: retirar el
+seam especializado solo cuando métodos canónicos del `Player` expongan el mismo
+contrato atómico de dry-run/apply. El planificador vive en
+`wow_world::spell_acquisition`, la durabilidad en su puerto, y el Player tiene
+`apply_prepared_spell_acquisition_like_cpp`. No inventar trabajo nuevo aquí sin
+medición propia.
+
+*Cuenta, carga y guardado.* Los dos criterios de cierre de la fila están
+cubiertos y verificados en código: la revisión de guardado diferido usa
+`checked_add` y el recibo limpia solo la intención confirmada que coincide
+(`crates/wow-entities/src/player/deferred_save.rs`), y un COMMIT incierto no
+reanuda la sesión: `session/lifecycle/persistence.rs:255-270` marca el dinero
+como indeterminado, desarma la valla y expulsa con «relog required before
+another money mutation».
+
+Por tanto P2 queda a falta de: el contrato de entrega de #743, la decisión de
+diseño de #735, y el residuo de cierres genéricos, que se retira operación por
+operación. Falta también evidencia de durabilidad en vivo (escritura real en DB,
+reinicio, relogin), que exige autoridad de runtime y no se ha ejecutado.
 
 P3–P6 siguen pendientes y #584 continúa abierto.
 


### PR DESCRIPTION
## What

The plan's P2 table lists five families. Three were still open on paper, so each was measured
against current code rather than assumed — and two turn out to be substantially covered already.
Writing that down so the next pass does not re-measure or invent work.

**Social and groups** — ownership is correct on both sides: `wow-social` owns membership with a
named API equivalent to C++ `Group`, and the Player-side snapshot mirrors `Player::GetGroup`
(Player.h:2547) rather than being a second authority. One real defect came out of the
measurement: the affected member's own state clear travels via `try_send_current_command`, a
`try_send` on a `bounded(256)` channel whose result is discarded, and nothing reconciles
afterwards. Recorded in `EXISTING-CODE-DEFECTS.md` and scoped in #743.

**Progression/spells/effects** — delivered in substance by #587, with
`ownership-and-boundaries.md` already fixing its retirement condition ("retire the specialized
seam only when canonical `Player` methods expose the same atomic dry-run/apply contract"). Noted
so no new work is invented here without its own measurement.

**Account, load and save** — both closing criteria verified in source: the deferred-save
revision uses `checked_add` and its receipt clears only matching confirmed intent
(`crates/wow-entities/src/player/deferred_save.rs`), and an uncertain COMMIT does not resume the
session — `session/lifecycle/persistence.rs:255-270` marks money indeterminate, disarms the
fence and kicks with a relog requirement.

So what P2 still needs is now named exactly: #743's delivery contract, #735's design choice, and
the generic-closure residual that retires per operation. Live durability evidence (real DB
write, restart, relogin) is still missing and still needs runtime authority — stated rather than
implied.

## Evidence

Documentation only — one file, 37 insertions and 2 deletions.

- `./tools/validation-v2 quick --base origin/3.4.3`: green (manifest
  `20260911T085744.069691Z-1981469-quick.json`, verified green).
- No code changed, so no new `final` is claimed and no earlier run is relabelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)