### PR TITLE
Re-parent the issue ledger after #133's closure (#746)

### DIFF
--- a/tools/architecture/architecture-issue-ledger.json
+++ b/tools/architecture/architecture-issue-ledger.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "parent_issue": 133,
+  "parent_issue": 584,
   "reaudit_issue": 153,
   "external_prerequisites": [
     {
@@ -204,7 +204,7 @@
     },
     {
       "number": 133,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH] Modularize RustyCore: physical structure, ownership and extension seams",
       "kind": "epic",
       "parents": [],
@@ -2298,48 +2298,79 @@
       "state": "open",
       "title": "[ARCH.CORE] Complete remaining architecture through analyzed crate-scoped macrodeliverables",
       "kind": "epic",
-      "parents": [133],
-      "depends_on": [578]
+      "parents": [
+        133
+      ],
+      "depends_on": [
+        578
+      ]
     },
     {
       "number": 585,
       "state": "closed",
       "title": "[ARCH.CORE.FINALIZATION] Complete represented session finalization outcomes and retirement supervision",
       "kind": "slice",
-      "parents": [133, 584],
-      "depends_on": [578]
+      "parents": [
+        133,
+        584
+      ],
+      "depends_on": [
+        578
+      ]
     },
     {
       "number": 588,
       "state": "closed",
       "title": "[ARCH.CORE] Complete deferred player visibility publication",
       "kind": "slice",
-      "parents": [133, 584],
-      "depends_on": [585]
+      "parents": [
+        133,
+        584
+      ],
+      "depends_on": [
+        585
+      ]
     },
     {
       "number": 587,
       "state": "closed",
       "title": "[ARCH.CORE] Complete represented spell-acquisition application boundary",
       "kind": "slice",
-      "parents": [133, 584],
-      "depends_on": [585, 588]
+      "parents": [
+        133,
+        584
+      ],
+      "depends_on": [
+        585,
+        588
+      ]
     },
     {
       "number": 589,
       "state": "closed",
       "title": "[ARCH.CORE] Complete represented Player cast-request lifecycle",
       "kind": "slice",
-      "parents": [133, 584],
-      "depends_on": [587, 588]
+      "parents": [
+        133,
+        584
+      ],
+      "depends_on": [
+        587,
+        588
+      ]
     },
     {
       "number": 716,
-      "state": "open",
+      "state": "closed",
       "title": "[ARCH.CORE] Restore ownership provenance and acceptance after module decomposition",
       "kind": "slice",
-      "parents": [133, 584],
-      "depends_on": [589]
+      "parents": [
+        133,
+        584
+      ],
+      "depends_on": [
+        589
+      ]
     }
   ]
 }

--- a/tools/architecture/dependency-policy.json
+++ b/tools/architecture/dependency-policy.json
@@ -110,55 +110,55 @@
     {
       "from": "wow-anticheat",
       "to": "wow-packet",
-      "tracking_issue": 133,
+      "tracking_issue": 584,
       "reason": "The anticheat domain still consumes transport packet shapes directly."
     },
     {
       "from": "wow-data",
       "to": "wow-entities",
-      "tracking_issue": 133,
+      "tracking_issue": 584,
       "reason": "Static-data rows still reuse mutable entity-domain types."
     },
     {
       "from": "wow-data",
       "to": "wow-movement",
-      "tracking_issue": 133,
+      "tracking_issue": 584,
       "reason": "Static-data loaders still reuse movement runtime types."
     },
     {
       "from": "wow-instances",
       "to": "wow-data",
-      "tracking_issue": 133,
+      "tracking_issue": 584,
       "reason": "Instance state still reads concrete static-data stores."
     },
     {
       "from": "wow-packet",
       "to": "wow-loot",
-      "tracking_issue": 133,
+      "tracking_issue": 584,
       "reason": "Wire packet models still reuse loot-domain values."
     },
     {
       "from": "wow-packet",
       "to": "wow-movement",
-      "tracking_issue": 133,
+      "tracking_issue": 584,
       "reason": "Wire packet models still reuse movement-domain values."
     },
     {
       "from": "wow-world",
       "to": "wow-config",
-      "tracking_issue": 133,
+      "tracking_issue": 584,
       "reason": "The mixed world application crate still reads concrete configuration."
     },
     {
       "from": "wow-world",
       "to": "wow-crypto",
-      "tracking_issue": 133,
+      "tracking_issue": 584,
       "reason": "The mixed world application crate still performs protocol crypto work."
     },
     {
       "from": "wow-world",
       "to": "wow-data",
-      "tracking_issue": 133,
+      "tracking_issue": 584,
       "reason": "The mixed world application crate still reads concrete static-data stores."
     },
     {
@@ -170,7 +170,7 @@
     {
       "from": "wow-world",
       "to": "wow-logging",
-      "tracking_issue": 133,
+      "tracking_issue": 584,
       "reason": "The mixed world application crate still consumes logging infrastructure directly."
     },
     {
@@ -188,7 +188,7 @@
     {
       "from": "wow-world",
       "to": "wow-recastdetour",
-      "tracking_issue": 133,
+      "tracking_issue": 584,
       "reason": "The mixed world application crate still reaches the concrete pathfinding adapter."
     },
     {
@@ -390,14 +390,14 @@
         "from": "wow-loot",
         "to": "tokio",
         "kind": "normal",
-        "tracking_issue": 133,
+        "tracking_issue": 584,
         "reason": "Loot authority still exposes Tokio watch-based asynchronous coordination from a domain/runtime crate."
       },
       {
         "from": "wow-world",
         "to": "tokio",
         "kind": "normal",
-        "tracking_issue": 133,
+        "tracking_issue": 584,
         "reason": "The mixed world application crate still owns Tokio tasks, timers, and channels that must move behind application ports or composition adapters incrementally."
       }
     ]


### PR DESCRIPTION
The architecture check was passing because a mirror was stale — the failure mode the validation rules name explicitly.

## What was wrong

`architecture-issue-ledger.json` mirrors each issue's live state, and `refresh-issue-state` derives those fields rather than having them hand-maintained. It had not been run since #133 closed on 2026-09-09, so the ledger still called the parent epic open. Refresh it and the check fails:

```
issue ledger parent_issue #133 must be open while the ledger tracks unresolved debt
```

#133 was closed deliberately by the repository owner, with no closing commit, the same day the physical decomposition track closed. This keeps that decision and makes the ledger agree with it rather than undoing it: `parent_issue` becomes **#584** — the epic that actually owns the unresolved debt and is open — `reaudit_issue` stays #153, and the two stale mirror fields (#133, #716) are derived from live state. Each entry's own `parents` history is untouched.

## The layer underneath

Re-parenting alone was not enough. With the mirror honest, the next check fired:

```
exception wow-anticheat -> wow-packet is still owned by completed issue #133;
retarget it to the slice that can actually remove the edge
```

Thirteen dependency exceptions still named the closed #133: eleven workspace edges — `wow-anticheat → wow-packet`, `wow-data → wow-entities`, `wow-data → wow-movement`, `wow-instances → wow-data`, `wow-packet → wow-loot`, `wow-packet → wow-movement`, and `wow-world →` config, crypto, data, logging, recastdetour — plus the two external `tokio` edges. All are retargeted to #584, whose C4 dimension is "remaining boundary/dependency decisions" and which already owned `wow-world → wow-network` and `wow-world → wow-session` under that same heading. No exception is removed, no reason is rewritten, no edge is declared resolved; only the owner changes, from an issue that cannot act to one that can.

## The documentation half needed nothing

#746 also proposed correcting a STATE.md claim of mine about single `enum`/`match`/trait-impl files. #716 had already corrected both that paragraph and the guide, and a grep for the original wording finds nothing left in `docs/`. That box is satisfied by #716, not by this delivery.

## Evidence

`./tools/validation-v2 final --base origin/3.4.3` → `passed` (manifest `20260911T135955.370173Z-2052678-final.json`). The delta is two policy JSON files, so the final profile scoped itself to `git diff --check`, the physical ratchet, the trailing-whitespace check and JSON validity for both files; no Rust source, manifest or build script changed. Run separately and green: `check_architecture.py check` (all four checks), `self-test`, and `refresh-issue-state --check`, which now reports the mirror current — the point being that the checks pass **with** the refreshed mirror instead of around it.

`#743` is deliberately left out of the ledger: it belongs to the parallel completion-plan stream and is its owner's to track.

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)