### PR TITLE
Reuse Cargo artifacts and correct validation cadence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,10 +142,9 @@ they are not separate frozen architecture snapshots.
   native/Wasm product and does not block an unrelated gameplay macro, while its
   production integration waits for the required core work. The Rust/Wasm/C mixed
   product remains mandatory even though its operator activation is optional.
-  The next recommended core macro is #743 (group-command state delivery), followed by
-  #735 (reputation encapsulation, an ordering preference rather than a hard dependency),
-  then the remaining P2 operations and P3 runtime/lifetime/private-hecs and P4 semantic/
-  physical work under #584. Analyze each responsibility before defining its macro,
+  Select the next prepared responsibility from the current STATE.md and refactor
+  completion plan; this operating guide does not keep a second dated next-issue list.
+  Analyze each responsibility before defining its macro,
   include cross-crate consumers and preserve scoped regression/live acceptance. These
   evidence reviews do not add routine approvals or authorize merge/runtime operations.
 - After playable M6.2/#47, perform the fresh whole-port planning pass before decomposing
@@ -160,6 +159,16 @@ worker handoff. At final acceptance, fix findings and rerun affected evidence as
 An explicit user request for an earlier diagnostic run remains authoritative.
 Do not claim unexecuted evidence as passing.
 
+Plan acceptance once for the completed delivery. The commands below are scope-dependent
+examples, not a checklist to run before `quick` and again before `final`. `final` already
+checks affected downstream test targets and runs the changed libraries' complete suites;
+credit the focused cases actually executed by those suites. Add the required integration,
+ownership, capture or live evidence they do not cover. Do not run a separate workspace
+check or identical library suite just to warm up `final`. After a failure, fix the related
+findings together and rerun the affected acceptance; new code still needs final evidence
+at its committed candidate. Do not use repeated Cargo calls as a search/automatic-edit
+loop for consumers that can be found by inspection. A zero-test filter proves nothing.
+
 The parent owns validation scheduling, or assigns one exclusive validation executor.
 Run heavyweight builds, tests, exhaustive scans and live QA sequentially, including
 across worktrees; no worker starts its own parallel campaign. Check for active work
@@ -167,12 +176,23 @@ and available RAM/disk before launching. On this shared host start Cargo with on
 (`VALIDATION_V2_CARGO_JOBS=1` for the runner); increase only with demonstrated headroom.
 Do not kill unrelated processes to obtain resources. Agent-count limits are not resource locks.
 
+Keep direct Cargo and runner commands on the same per-worktree target directory; the
+runner defaults to `<checkout>/target` and respects explicit `CARGO_TARGET_DIR`. For
+standalone manifests set it to the checkout's absolute `target` too. Do not share one
+target across active worktrees. Follow the disk and long-running-command procedures in
+`docs/operations/validation-v2.md`: preserve the active incremental cache, clean inspected
+inactive build artifacts first, retain real exit codes, and track an existing background
+task instead of launching a duplicate after its foreground wait expires.
+
 Use [validation-v2](docs/operations/validation-v2.md) and
 [local-first development](docs/operations/local-first-development.md) for the actual profiles.
 
 ~~~bash
-PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo check -p world-server
-PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test -p wow-world <focused-test> --lib
+export PROTOC=/home/ubuntu/.local/protoc/bin/protoc
+export CARGO_BUILD_JOBS=1
+export CARGO_TARGET_DIR="$PWD/target"
+cargo check -p world-server
+cargo test -p wow-world <focused-test> --lib
 cargo fmt --all -- --check
 git diff --check
 ./tools/validation-v2 quick --base origin/3.4.3

--- a/docs/operations/local-first-development.md
+++ b/docs/operations/local-first-development.md
@@ -45,12 +45,19 @@ complete delivery before running its acceptance; delegation adds no per-worker C
 or independent review gate. Run focused tests for affected behavior at that point:
 
 ```bash
-PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo test --locked -p wow-world exact_test_name --lib
+CARGO_TARGET_DIR="$PWD/target" CARGO_BUILD_JOBS=1 \
+  PROTOC=/home/ubuntu/.local/protoc/bin/protoc \
+  cargo test --locked -p wow-world exact_test_name --lib
 ```
 
 Validation commands must expose their real exit status. Do not append `| head`, `| grep`,
 `; echo EXIT=$?`, or another pipeline that can turn a failed checker into a reported success. If
 output must be retained, redirect it to a log and check the validator's own exit code.
+
+Choose this focused run when its evidence is missing or a failure needs investigation; do not
+rerun it merely because the same cases ran in `final`'s complete library suite. The runner
+contract owns cache selection, disk cleanup and background-task tracking. Keep direct Cargo
+on that same per-worktree target and preserve the active cache between macros.
 
 Use focused checks within the approved issue or macro; an internal cut does not require a new
 PR, exhaustive run or repeated approval. Before publication, commit the completed local work,

--- a/docs/operations/validation-v2.md
+++ b/docs/operations/validation-v2.md
@@ -24,6 +24,15 @@ workspace reverse-dependent closure and runs library tests for the directly chan
 packages. A root Cargo, toolchain, protobuf, or build-script change explicitly expands compilation
 to `--workspace --all-targets`; it does not implicitly run every library suite.
 
+These profiles are alternative budgets, not mandatory successive stages. At completed-delivery
+acceptance, plan the missing issue-specific evidence and the committed-candidate `final` once.
+Its downstream check replaces an equivalent manual preflight; its full library suites also
+provide evidence for the focused cases they actually execute. Keep additional integration,
+ownership, capture and live checks whose acceptance is not covered. A changed candidate or a
+failed check needs renewed affected evidence; a new agent, commit message, or handoff does not
+by itself require recompiling unchanged inputs. Do not use repeated compiler runs to discover
+consumers or drive one-field-at-a-time replacements.
+
 A `final` run whose diff touches workspace Rust also enforces the curated hotspot LOC ceilings
 (`check_architecture.py hotspot-ratchet`; timing depends on cached scanner/build state).
 Every nonempty `final` diff also runs the cheap `check_architecture.py physical-files` scan,
@@ -177,19 +186,67 @@ one host. Lock diagnostics identify the active run id, PID, repository, HEAD, pr
 time. `quick` and `final` never acquire this heavyweight lock. For hermetic tests only, its path
 can be overridden with `VALIDATION_V2_HEAVY_LOCK`.
 
-The conservative defaults are two Cargo jobs and a 900-second per-command timeout, except that
+The conservative defaults are one Cargo job and a 900-second per-command timeout, except that
 `audit` defaults to 3600 seconds: its exhaustive persistence inventory alone runs 870-900 seconds
 on a four-core host, so the ordinary budget would kill it - correctly reported as
 `failure_kind: timeout`, but for no useful reason. Controlled
 overrides are validated before execution:
 
 ```bash
-VALIDATION_V2_CARGO_JOBS=4 VALIDATION_V2_TIMEOUT_SECONDS=1200 \
+VALIDATION_V2_CARGO_JOBS=1 VALIDATION_V2_TIMEOUT_SECONDS=1200 \
   ./tools/validation-v2 final
 ```
 
 Cargo jobs must be between 1 and 8; timeout must be between 30 and 3600 seconds. A concurrent run
 fails immediately and reports the lock path and active owner instead of waiting invisibly.
+
+### Cargo artifacts and disk space
+
+The runner uses `<checkout>/target` by default, matching ordinary Cargo commands in that
+workspace. An explicit nonempty `CARGO_TARGET_DIR` is respected; relative values are resolved
+against the checkout. Keep one target per active worktree rather than sharing a mutable cache
+between independent worktrees. Do not change debug, incremental or codegen flags midway through
+acceptance to save space: those changes invalidate reusable compilation and need their own
+measured tradeoff. Both `check` and `test` remain required where routed; they produce different
+artifacts and are not interchangeable evidence.
+
+For direct acceptance involving the standalone checker or bot, run from the checkout root:
+
+```bash
+export CARGO_TARGET_DIR="$PWD/target"
+export CARGO_BUILD_JOBS=1
+export PROTOC=/home/ubuntu/.local/protoc/bin/protoc
+```
+
+The former `target/validation-v2/cargo/<worktree-hash>` is a separate legacy cache. After
+switching a checkout to the new runner, it can be removed only when no process uses it;
+retain `target/validation-v2/manifests` and any required evidence. No automatic cache deletion
+occurs in validation. The first run may need artifacts absent from the selected target.
+
+On the shared development host with a 193 GiB filesystem, aim to retain at least 30 GiB free
+before starting a large Rust acceptance. Use `df -h` and a targeted `du` to measure pressure.
+If space is tight, inspect inactive worktrees' generated targets first. Check active agents,
+Cargo processes and open files before deleting any selected directory; exclude tracked or
+user-authored files, running/deployed executables, rollback builds, databases, captures and
+manifests. Do not delete an entire worktree just to reclaim its generated artifacts. Recheck
+free space after cleanup. Deleting the active incremental cache at each macro is not a
+retention policy and needlessly repeats compilation; if safe cleanup cannot restore headroom,
+pause new builds and report the concrete storage need while continuing safe inspection.
+
+### Visible output and background tasks
+
+Invoke the runner directly so its progress and real exit status remain visible. Never pipe
+validation into `tail`, `head`, or `grep` and treat the consumer's status as success. To retain
+output, redirect to a log, preserve the runner's exit code, then inspect that log separately.
+
+The agent tool's foreground wait is independent of the runner's per-command timeout. When
+Claude or another harness returns a background task ID after a wait expires, keep tracking
+that exact task and its output until it exits. Do not start a replacement or launch a manual
+Cargo warmup while it may still be running. A wait expiry is not a failed validation. `SIGTERM`
+or exit 143 is a real interrupted run: check the manifest, process state, and harness task
+result before retrying once the cause is understood. Do not assume disk pressure or OOM from
+the signal alone, disable permission controls, or detach a job to evade a harness rejection.
+Do not stop unrelated processes or reuse a green manifest from a different candidate.
 
 The base must already exist locally. Validation never fetches it:
 

--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 import threading
 import time
+from unittest.mock import patch
 
 
 RUNNER_PATH = Path(__file__).with_name("validation-v2").resolve()
@@ -86,7 +87,11 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     success = json.loads(success_manifest.read_text())
     assert success["schema"] == runner.MANIFEST_SCHEMA
     assert success["runner_signal"] is None
-    assert success["resources"]["cargo_jobs"] == 2
+    assert success["resources"]["cargo_jobs"] == runner.DEFAULT_JOBS == 1
+    assert (
+        f"validation-v2: cargo target={repo.resolve() / 'target'} jobs={runner.DEFAULT_JOBS}"
+        in result.stdout
+    )
     assert "memory_limit_kib" in success["resources"]
     assert success["profile"] == "quick"
     assert len(success["run_id"]) == 20
@@ -697,6 +702,78 @@ def test_planner_contract(repo: Path) -> None:
         raise AssertionError("deleted workspace manifest did not fail closed")
 
 
+def test_cargo_target_contract(
+    repo: Path, base_env: dict[str, str], directory: Path
+) -> None:
+    """Cargo targets are worktree-local by default and explicit paths are resolved once."""
+    repository = repo.resolve()
+
+    probe_bin = directory / "cargo-probe-bin"
+    probe_bin.mkdir()
+    fake_tool(
+        probe_bin / "cargo",
+        'printf "%s|%s\\n" "$CARGO_TARGET_DIR" "$CARGO_BUILD_JOBS" >> "$VALIDATION_V2_CARGO_ENV_LOG"\n'
+        'if [ "${1-}" = "metadata" ]; then\n'
+        '    printf \'{"workspace_members": [], "packages": [], "resolve": {"nodes": []}}\\n\'\n'
+        "fi\n",
+    )
+
+    def effective(configured: str | None) -> dict[str, str]:
+        environment = base_env.copy()
+        environment["PATH"] = f"{probe_bin}:{base_env['PATH']}"
+        if configured is None:
+            environment.pop("CARGO_TARGET_DIR", None)
+        else:
+            environment["CARGO_TARGET_DIR"] = configured
+        with patch.dict(os.environ, environment, clear=True):
+            return runner.command_environment(repo, runner.DEFAULT_JOBS)
+
+    def probe(configured: str | None, expected: Path, name: str) -> None:
+        environment = effective(configured)
+        log = directory / f"cargo-env-{name}.log"
+        environment["VALIDATION_V2_CARGO_ENV_LOG"] = str(log)
+        metadata, metadata_outcome = runner.cargo_metadata(repo, environment, 30)
+        assert metadata == {"workspace_members": [], "packages": [], "resolve": {"nodes": []}}
+        assert metadata_outcome["status"] == "passed"
+        metadata_observed = log.read_text().strip()
+        command_outcome = runner.run_one(repo, ["cargo", "check"], environment, 30)
+        assert command_outcome["status"] == "passed"
+        command_observed = log.read_text().splitlines()[-1]
+        assert metadata_observed == command_observed == f"{expected}|1"
+
+    default = effective(None)
+    assert default["CARGO_TARGET_DIR"] == str(repository / "target")
+    assert default["CARGO_BUILD_JOBS"] == "1"
+    probe(None, repository / "target", "default")
+
+    for blank_value in ("", "   "):
+        blank = effective(blank_value)
+        assert blank["CARGO_TARGET_DIR"] == default["CARGO_TARGET_DIR"]
+
+    absolute_target = directory / "explicit-target"
+    absolute = effective(str(absolute_target))
+    assert absolute["CARGO_TARGET_DIR"] == str(absolute_target.resolve())
+    probe(str(absolute_target), absolute_target.resolve(), "absolute")
+
+    relative = effective("explicit-target")
+    assert relative["CARGO_TARGET_DIR"] == str((repository / "explicit-target").resolve())
+    probe("explicit-target", (repository / "explicit-target").resolve(), "relative")
+
+    worktree_a = directory / "worktree-a"
+    worktree_b = directory / "worktree-b"
+    default_a = runner.resolve_cargo_target_dir(worktree_a)
+    default_b = runner.resolve_cargo_target_dir(worktree_b)
+    assert default_a == worktree_a.resolve() / "target"
+    assert default_b == worktree_b.resolve() / "target"
+    assert default_a != default_b
+
+    relative_a = runner.resolve_cargo_target_dir(worktree_a, "validation-target")
+    relative_b = runner.resolve_cargo_target_dir(worktree_b, "validation-target")
+    assert relative_a == worktree_a.resolve() / "validation-target"
+    assert relative_b == worktree_b.resolve() / "validation-target"
+    assert relative_a != relative_b
+
+
 def main() -> None:
     with tempfile.TemporaryDirectory(prefix="validation-v2-self-test-") as raw_directory:
         directory = Path(raw_directory)
@@ -718,7 +795,11 @@ def main() -> None:
         fake_tool(fake_bin / "protoc", 'printf "libprotoc 28.3\\n"\n')
         environment = os.environ.copy()
         environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+        environment.pop("CARGO_TARGET_DIR", None)
+        environment.pop("VALIDATION_V2_CARGO_JOBS", None)
+        environment.pop("PROTOC", None)
         environment["VALIDATION_V2_LOCK_DIR"] = str(directory / "locks")
+        test_cargo_target_contract(repo, environment, directory)
         test_runner_contract(repo, tools, environment, directory)
         test_interrupt_and_verdict_contract(repo, tools, environment, directory, fake_bin)
         test_planner_contract(repo)

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -27,7 +27,7 @@ USAGE_ERROR = 64
 VERDICT_ERROR = 1
 RUNNER_ERROR = 70
 LOCKED_ERROR = 75
-DEFAULT_JOBS = 2
+DEFAULT_JOBS = 1
 MAX_JOBS = 8
 DEFAULT_TIMEOUT = 900
 # The exhaustive persistence inventory alone runs 870-900s on a four-core host,
@@ -901,14 +901,26 @@ def resolve_protoc(repo: Path, environment: dict[str, str]) -> str | None:
     return None
 
 
+def resolve_cargo_target_dir(repo: Path, configured: str | None = None) -> Path:
+    """Return an absolute target; blank uses the worktree-local default."""
+    repository = repo.resolve()
+    if configured is None or not configured.strip():
+        return (repository / "target").resolve()
+    target = Path(configured)
+    if not target.is_absolute():
+        target = repository / target
+    return target.resolve()
+
+
 def command_environment(repo: Path, jobs: int) -> dict[str, str]:
     environment = os.environ.copy()
-    worktree = hashlib.sha256(str(repo).encode()).hexdigest()[:16]
     environment.update(
         {
             "CARGO_BUILD_JOBS": str(jobs),
             "CARGO_NET_OFFLINE": "true",
-            "CARGO_TARGET_DIR": str(repo / "target" / "validation-v2" / "cargo" / worktree),
+            "CARGO_TARGET_DIR": str(
+                resolve_cargo_target_dir(repo, environment.get("CARGO_TARGET_DIR"))
+            ),
         }
     )
     protoc = resolve_protoc(repo, environment)
@@ -1234,6 +1246,10 @@ def main() -> int:
     exit_code = 0
     try:
         environment = command_environment(repo, jobs)
+        print(
+            f"validation-v2: cargo target={environment['CARGO_TARGET_DIR']} jobs={jobs}",
+            flush=True,
+        )
         if args.profile == "self-test":
             outcome = run_one(
                 repo,


### PR DESCRIPTION
Local Cargo checks and `validation-v2` used different artifact directories, so acceptance rebuilt work and accumulated a second large cache. The runner now defaults to the worktree's `target`, respects an explicit target directory, and starts with one Cargo job. Its existing check/test selection, failure handling and evidence gates are retained.

The operating guides now explain how to credit coverage already provided by `final`, preserve active incremental artifacts, clean inspected inactive build directories, retain command exit codes and follow existing background tasks. The stale next-issue list was replaced with a pointer to the maintained plan. The user's local Claude handoff was updated separately.

Validation: `validation-v2 final --base origin/3.4.3` passed on clean commit `eb5b8da6`, including the full hermetic runner contract suite and the physical-file ratchet. Added fake-Cargo coverage checks that metadata and executed commands receive the same default or explicit target and job count. `validation-v2 verify` confirmed the green manifest. No real Rust compilation or gameplay changes were needed for this tooling delivery.

The change is integrated as `ab3f65a7`; its tree matches the validated `eb5b8da6` candidate. The active Claude session confirmed the fast-forward to `ab3f65a7`, preservation of its 30 changed #756 files, and adoption of the revised cadence before continuing grouped edits.

Host cleanup removed about 58 GiB of inspected inactive generated artifacts: the old primary checkout's `target/debug`, the analysis worktree's `target/debug` and legacy runner cache, then the active checkout's obsolete `target/validation-v2/cargo` after migration. With concurrent development still generating artifacts, the final measured filesystem state is 116 GiB used / 77 GiB free (61%), down from 173 GiB used / 20 GiB free (90%). Source worktrees, deployed binaries, the active incremental cache, databases, captures and all 71 active-checkout validation manifests were preserved. SIGTERM origin remains unproven; this change does not disable resource or permission controls or promise a measured build speedup.

Closes #757
