### PR TITLE
Measure existing validation without extra builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,15 @@ worker handoff. At final acceptance, fix findings and rerun affected evidence as
 An explicit user request for an earlier diagnostic run remains authoritative.
 Do not claim unexecuted evidence as passing.
 
+The user's ordinary local acceptance budget is ten minutes for the complete campaign,
+including the required additional checks, on this host with the active warm cache.
+Measure coding/error-repair time separately. Use `final --timings` to locate compilation
+cost within that same run; record the full campaign start/end and any checks outside it.
+Exceeding 600 seconds means the performance target is not met. Do not hide the overrun,
+split it into nominally separate ten-minute checks, repeat a failed campaign unchanged,
+or remove acceptance to claim success. Cold bootstrap and exhaustive/live acceptance
+remain explicit separate costs and must not be passed off as the ordinary warm run.
+
 Plan acceptance once for the completed delivery. The commands below are scope-dependent
 examples, not a checklist to run before `quick` and again before `final`. `final` already
 checks affected downstream test targets and runs the changed libraries' complete suites;

--- a/docs/operations/validation-v2.md
+++ b/docs/operations/validation-v2.md
@@ -202,6 +202,29 @@ fails immediately and reports the lock path and active owner instead of waiting 
 
 ### Cargo artifacts and disk space
 
+The ordinary local acceptance performance budget is **600 seconds for the complete
+campaign**, including necessary additional checks, with the active cache warm. Measure
+implementation/error-repair time separately. The target does not waive any required
+coverage or declare cold bootstrap, exhaustive audits or live QA complete in ten minutes.
+Record those distinct costs explicitly. A run longer than 600 seconds has not met the
+performance target even if every correctness check passes; a timeout is not a speedup.
+
+Collect Cargo's stable timing reports in the campaign that is already required:
+
+```bash
+./tools/validation-v2 final --base origin/3.4.3 --timings
+```
+
+`--timings` is available for `quick`, `final` and `audit`. It adds Cargo's reporting flag
+to planned check/test/build/run commands, before any program-argument separator, without
+changing their package/target selection or running another build. The manifest records
+the instrumented commands; timestamped reports remain in `target/cargo-timings` under the
+selected Cargo target. See [Cargo timing reports](https://doc.rust-lang.org/cargo/reference/timings.html).
+Keep the runner's total time and the duration of required extra checks; individual crate
+reports do not measure the complete acceptance campaign. Benchmark changes in job count,
+profiles or linking on representative unchanged inputs before adopting them, with exclusive
+validation ownership and measured memory headroom. Avoid an extra warmup merely for timing.
+
 The runner uses `<checkout>/target` by default, matching ordinary Cargo commands in that
 workspace. An explicit nonempty `CARGO_TARGET_DIR` is respected; relative values are resolved
 against the checkout. Keep one target per active worktree rather than sharing a mutable cache

--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -67,13 +67,14 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     (repo / "docs").mkdir()
     (repo / "docs" / "guide.md").write_text("fixture\n")
 
-    def invoke(mode: str, manifest: Path, extra: dict[str, str] | None = None):
+    def invoke(mode: str, manifest: Path, extra: dict[str, str] | None = None,
+               flags: list[str] | None = None):
         environment = base_env.copy()
         environment["VALIDATION_V2_MANIFEST"] = str(manifest)
         if extra:
             environment.update(extra)
         return subprocess.run(
-            [str(tools / "validation-v2"), mode, "--base", "HEAD"],
+            [str(tools / "validation-v2"), mode, "--base", "HEAD", *(flags or [])],
             cwd=repo,
             env=environment,
             text=True,
@@ -88,6 +89,13 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     assert success["schema"] == runner.MANIFEST_SCHEMA
     assert success["runner_signal"] is None
     assert success["resources"]["cargo_jobs"] == runner.DEFAULT_JOBS == 1
+    timed_result = invoke("quick", directory / "timed-docs.json", flags=["--timings"])
+    assert timed_result.returncode == 0, timed_result.stderr
+    timed_docs = json.loads((directory / "timed-docs.json").read_text())
+    assert timed_docs["plan"]["planned_commands"] == success["plan"]["planned_commands"]
+    invalid_timings = invoke("verify", directory / "invalid-timings.json", flags=["--timings"])
+    assert invalid_timings.returncode == runner.USAGE_ERROR
+    assert "--timings is only valid" in invalid_timings.stderr
     assert (
         f"validation-v2: cargo target={repo.resolve() / 'target'} jobs={runner.DEFAULT_JOBS}"
         in result.stdout
@@ -774,7 +782,38 @@ def test_cargo_target_contract(
     assert relative_a != relative_b
 
 
+def test_timing_plan_contract() -> None:
+    commands = [
+        ["cargo", "check", "--locked", "--tests", "-p", "consumer"],
+        ["cargo", "test", "--lib", "-p", "owner", "--", "--exact", "case"],
+        ["cargo", "run", "--release", "--", "--timings"],
+        ["cargo", "build", "--timings"],
+        ["cargo", "fmt", "--all", "--check"],
+        ["python3", "checker.py"],
+    ]
+    originals = [command.copy() for command in commands]
+    plan = {"planned_steps": [
+        {"section": str(index), "argv": command}
+        for index, command in enumerate(commands)
+    ], "planned_commands": [command.copy() for command in commands]}
+    runner.enable_cargo_timings(plan)
+    runner.enable_cargo_timings(plan)  # Idempotent; no duplicate runs or Cargo flags.
+    assert len(plan["planned_steps"]) == len(originals)
+    assert plan["planned_commands"] == [step["argv"] for step in plan["planned_steps"]]
+    for before, after in zip(originals, plan["planned_commands"]):
+        if before[:2] in (["cargo", "check"], ["cargo", "test"], ["cargo", "run"], ["cargo", "build"]):
+            boundary = after.index("--") if "--" in after else len(after)
+            assert after[:boundary].count("--timings") == 1
+            restored = after.copy()
+            if "--timings" not in before[:before.index("--") if "--" in before else len(before)]:
+                restored.pop(restored.index("--timings"))
+            assert restored == before  # Targets/features and program arguments are retained.
+        else:
+            assert after == before
+
+
 def main() -> None:
+    test_timing_plan_contract()
     with tempfile.TemporaryDirectory(prefix="validation-v2-self-test-") as raw_directory:
         directory = Path(raw_directory)
         repo = directory / "repo"

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -858,6 +858,20 @@ def build_plan(
     }
 
 
+def enable_cargo_timings(plan: dict[str, object]) -> None:
+    """Instrument the declared commands without adding another compilation."""
+    for step in plan["planned_steps"]:
+        command = step["argv"]
+        if len(command) < 2 or command[0] != "cargo" or command[1] not in {
+            "check", "test", "build", "run",
+        }:
+            continue
+        separator = command.index("--") if "--" in command else len(command)
+        if "--timings" not in command[:separator]:
+            command.insert(separator, "--timings")
+    plan["planned_commands"] = [step["argv"] for step in plan["planned_steps"]]
+
+
 def pinned_protoc_version(repo: Path) -> str:
     try:
         version = (repo / ".protoc-version").read_text(encoding="utf-8").strip()
@@ -1175,9 +1189,15 @@ def main() -> int:
     )
     parser.add_argument("--base", default=DEFAULT_BASE)
     parser.add_argument(
+        "--timings", action="store_true",
+        help="record Cargo timing reports during quick/final/audit without a second build",
+    )
+    parser.add_argument(
         "--manifest", help="manifest for the verify and normalize profiles"
     )
     args = parser.parse_args()
+    if args.timings and args.profile not in {"quick", "final", "audit"}:
+        return fail("--timings is only valid with quick, final or audit")
     if args.profile in {"verify", "normalize"}:
         if not args.manifest:
             return fail(f"{args.profile} requires --manifest")
@@ -1261,6 +1281,8 @@ def main() -> int:
             exit_code = 0 if outcome["status"] == "passed" else failed_exit_code(outcome)
         else:
             plan = build_plan(repo, args.profile, jobs, args.base, environment, timeout)
+            if args.timings:
+                enable_cargo_timings(plan)
             document["plan"] = plan
             steps = plan["planned_steps"]
             assert isinstance(steps, list)


### PR DESCRIPTION
The next performance decision needs per-crate timing from the required acceptance run, without an extra warmup or benchmark compilation. `validation-v2 --timings` now forwards Cargo's stable timing option to its existing check/test/build/run steps, before any program-argument separator. The manifest retains the exact instrumented commands and package/target coverage is unchanged.

The operating guides record the requested ten-minute complete-validation objective and require actual representative measurements. **This instrumentation does not establish that objective, and #759 remains open until the performance acceptance is measured.** Implementation/error-repair time is recorded separately; required checks cannot be omitted to claim the timing target.

Validation on clean candidate `2bc69e83`: `./tools/validation-v2 final --base origin/3.4.3 --timings` and `verify` passed, including the physical-file ratchet, syntax checks and complete hermetic runner contract suite. Coverage checks idempotence, retained targets/features/program arguments, synchronization of planned command declarations, supported CLI profiles and invalid-profile rejection. No real Cargo builds were added to this tooling validation.

Delivery through the reviewed integration branch is needed because the active Claude session's classifier rejected importing an unmerged local branch. No harness or permission control is changed. The next representative #756 acceptance will report total duration and Cargo timing reports, then #759 can be closed only if its performance boundary is satisfied.

Refs #759.
