### PR TITLE
Run architecture acceptance once inside final validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,15 @@ worker handoff. At final acceptance, fix findings and rerun affected evidence as
 An explicit user request for an earlier diagnostic run remains authoritative.
 Do not claim unexecuted evidence as passing.
 
+The user's ordinary local acceptance budget is ten minutes for the complete campaign,
+including the required additional checks, on this host with the active warm cache.
+Measure coding/error-repair time separately. Use `final --timings` to locate compilation
+cost within that same run; record the full campaign start/end and any checks outside it.
+Exceeding 600 seconds means the performance target is not met. Do not hide the overrun,
+split it into nominally separate ten-minute checks, repeat a failed campaign unchanged,
+or remove acceptance to claim success. Cold bootstrap and exhaustive/live acceptance
+remain explicit separate costs and must not be passed off as the ordinary warm run.
+
 Plan acceptance once for the completed delivery. The commands below are scope-dependent
 examples, not a checklist to run before `quick` and again before `final`. `final` already
 checks affected downstream test targets and runs the changed libraries' complete suites;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,12 @@ alone do not establish production composition. Record evidence at the actual tes
 
 Ownership/module acceptance commands (select by affected scope, not per helper):
 
+For an acceptance requiring architecture policy, its fixtures and syntax ownership, use
+`./tools/validation-v2 final --base origin/3.4.3 --architecture --timings` to run their
+combined checks inside the same timed manifest. This replaces the three separate commands
+below and final's duplicate physical/hotspot scans; retain any required exhaustive inventory,
+terminal, production-integration and live acceptance that the combined command does not cover.
+
 ~~~bash
 PROTOC=/home/ubuntu/.local/protoc/bin/protoc cargo run --release --locked \
   --manifest-path tools/architecture/handler-contract-check/Cargo.toml \

--- a/docs/operations/validation-v2.md
+++ b/docs/operations/validation-v2.md
@@ -202,6 +202,29 @@ fails immediately and reports the lock path and active owner instead of waiting 
 
 ### Cargo artifacts and disk space
 
+The ordinary local acceptance performance budget is **600 seconds for the complete
+campaign**, including necessary additional checks, with the active cache warm. Measure
+implementation/error-repair time separately. The target does not waive any required
+coverage or declare cold bootstrap, exhaustive audits or live QA complete in ten minutes.
+Record those distinct costs explicitly. A run longer than 600 seconds has not met the
+performance target even if every correctness check passes; a timeout is not a speedup.
+
+Collect Cargo's stable timing reports in the campaign that is already required:
+
+```bash
+./tools/validation-v2 final --base origin/3.4.3 --timings
+```
+
+`--timings` is available for `quick`, `final` and `audit`. It adds Cargo's reporting flag
+to planned check/test/build/run commands, before any program-argument separator, without
+changing their package/target selection or running another build. The manifest records
+the instrumented commands; timestamped reports remain in `target/cargo-timings` under the
+selected Cargo target. See [Cargo timing reports](https://doc.rust-lang.org/cargo/reference/timings.html).
+Keep the runner's total time and the duration of required extra checks; individual crate
+reports do not measure the complete acceptance campaign. Benchmark changes in job count,
+profiles or linking on representative unchanged inputs before adopting them, with exclusive
+validation ownership and measured memory headroom. Avoid an extra warmup merely for timing.
+
 The runner uses `<checkout>/target` by default, matching ordinary Cargo commands in that
 workspace. An explicit nonempty `CARGO_TARGET_DIR` is respected; relative values are resolved
 against the checkout. Keep one target per active worktree rather than sharing a mutable cache

--- a/docs/operations/validation-v2.md
+++ b/docs/operations/validation-v2.md
@@ -33,13 +33,31 @@ failed check needs renewed affected evidence; a new agent, commit message, or ha
 by itself require recompiling unchanged inputs. Do not use repeated compiler runs to discover
 consumers or drive one-field-at-a-time replacements.
 
+When acceptance requires architecture policy checks, their fixtures and syntax ownership,
+use one measured campaign:
+
+```bash
+./tools/validation-v2 final --base origin/3.4.3 --architecture --timings
+```
+
+`--architecture` is exclusive to `final`. It replaces that plan's separate physical,
+hotspot and architecture self-test scans with `check_architecture.py check --self-test`,
+which executes their complete union plus dependency checks in one process. The existing
+in-process inventories are reused, with no persisted scan cache. The runner also executes
+`session-ownership-check check --syntax-only`; both commands and their durations appear in
+the same final manifest. Existing workspace compilation, test targets and test execution
+are unchanged. Do not run those architecture commands separately again for the same inputs.
+The flag also honors an explicit request when there are no changed paths. It does not cover
+exhaustive persistence inventory, terminal physical closeout, production integration or live
+QA when the issue requires those; include their actual additional time in campaign evidence.
+
 A `final` run whose diff touches workspace Rust also enforces the curated hotspot LOC ceilings
 (`check_architecture.py hotspot-ratchet`; timing depends on cached scanner/build state).
 Every nonempty `final` diff also runs the cheap `check_architecture.py physical-files` scan,
 including tooling-only, non-Rust, deletion, policy or generator-input changes. It enforces
 new-file budgets and reviewed per-file migration ceilings without invoking Cargo. The other
 architecture checks and exhaustive
-persistence inventory run in `audit`; `final` alone does not verify renamed or relocated
+persistence inventory run in `audit`; plain `final` does not verify renamed or relocated
 persistence accesses. Run affected ownership/contract checks explicitly during architecture
 work and satisfy the active macro's terminal acceptance before claiming completion. Physical
 migration PASS is not closeout: run `physical-files --terminal` to reject unfinished oversized

--- a/docs/operations/validation-v2.md
+++ b/docs/operations/validation-v2.md
@@ -43,7 +43,9 @@ use one measured campaign:
 `--architecture` is exclusive to `final`. It replaces that plan's separate physical,
 hotspot and architecture self-test scans with `check_architecture.py check --self-test`,
 which executes their complete union plus dependency checks in one process. The existing
-in-process inventories are reused, with no persisted scan cache. The runner also executes
+in-process inventories and per-file physical counts are reused, with no persisted scan
+cache. Freeze source inputs for the invocation; the next invocation reads them anew.
+The runner also executes
 `session-ownership-check check --syntax-only`; both commands and their durations appear in
 the same final manifest. Existing workspace compilation, test targets and test execution
 are unchanged. Do not run those architecture commands separately again for the same inputs.

--- a/tools/architecture/check_architecture.py
+++ b/tools/architecture/check_architecture.py
@@ -46,9 +46,11 @@ def main() -> int:
         help="handler logical-module ownership policy JSON (default: repository policy)",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
-    subparsers.add_parser(
+    check_parser = subparsers.add_parser(
         "check", help="check architecture ratchets and report source hotspots"
     )
+    check_parser.add_argument("--self-test", action="store_true",
+                              help="also run fixtures, reusing measured inventories")
     subparsers.add_parser("self-test", help="validate policy and focused fixtures")
     subparsers.add_parser(
         "hotspot-ratchet",
@@ -126,7 +128,7 @@ def main() -> int:
             )
             traced_clocks = validate_runtime_clock_phase_trace(REPO_ROOT)
             validate_documented_sequence(ledger)
-        if args.command == "self-test":
+        if args.command == "self-test" or (args.command == "check" and args.self_test):
             from test_physical_files import run_self_tests
             if not run_self_tests():
                 raise ArchitectureError("physical source self-tests failed")
@@ -155,12 +157,12 @@ def main() -> int:
                 f"{hotspot_reduction_acceptances} hotspot-reduction acceptance, "
                 f"{handler_module_policy_rejections} handler-module-policy rejections)"
             )
-        elif args.command == "hotspots":
+        if args.command == "hotspots":
             if args.limit <= 0:
                 raise ArchitectureError("--limit must be positive")
             runtime_ledger = load_json(args.runtime_ledger)
             print_hotspots(runtime_ledger, args.limit)
-        else:
+        elif args.command == "check":
             (
                 packages,
                 workspace_edges,
@@ -195,8 +197,5 @@ def main() -> int:
         print(f"architecture check failed: {exc}", file=sys.stderr)
         return 1
     return 0
-
-
-
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/tools/architecture/hotspot_metrics.py
+++ b/tools/architecture/hotspot_metrics.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from functools import cache
 import pathlib
 import re
 import subprocess
@@ -559,8 +560,9 @@ def path_module_children(path: pathlib.Path, source: str) -> list[tuple[pathlib.
     return path_module_mounts().get(path, [])
 
 
+@cache
 def physical_hotspot_row(path: pathlib.Path) -> tuple[int, int, int, str]:
-    """Count one real source file without charging any child module to it."""
+    """Count each frozen input once per CLI process, without charging child modules."""
     try:
         source = path.read_text(encoding="utf-8")
     except OSError as exc:

--- a/tools/architecture/test_check_architecture.py
+++ b/tools/architecture/test_check_architecture.py
@@ -1,0 +1,97 @@
+"""Routing and failure contracts for combined architecture acceptance; no Cargo."""
+
+from contextlib import ExitStack, redirect_stderr, redirect_stdout
+import io
+import unittest
+from unittest.mock import patch
+
+import check_architecture as checker
+import test_physical_files
+
+
+class ArchitectureCommandTests(unittest.TestCase):
+    def invoke(self, arguments, failure=None):
+        policy = {"migration_issue": 584, "exceptions": []}
+        ledger = {"issues": [{"number": 584}]}
+        runtime = {"world_session_responsibility_families": {"families": []}}
+        syntax = {
+            "syntax_baseline": {
+                "world_session": {"fields": []},
+                "session_resources": {"fields": []},
+                "session_command": {"variants": []},
+            }
+        }
+        payloads = {
+            checker.DEFAULT_PHYSICAL_POLICY: policy,
+            checker.DEFAULT_ISSUE_LEDGER: ledger,
+            checker.DEFAULT_RUNTIME_OWNERSHIP_LEDGER: runtime,
+            checker.DEFAULT_SESSION_OWNERSHIP_POLICY: syntax,
+        }
+        calls = {}
+        output = io.StringIO()
+        with ExitStack() as stack:
+            stack.enter_context(patch("sys.argv", ["check_architecture.py", *arguments]))
+            stack.enter_context(redirect_stdout(output))
+            stack.enter_context(redirect_stderr(output))
+            stack.enter_context(patch.object(checker, "load_json", side_effect=lambda path: payloads.get(path, {})))
+            stack.enter_context(patch.object(checker.physical_files, "inventory", return_value=[]))
+            physical = stack.enter_context(patch.object(checker.physical_files, "evaluate", return_value={
+                "files": [], "legacy_files": 0, "generated_files": 0,
+                "review_required": 0, "mode": "migration",
+            }))
+            calls["physical"] = physical
+            for name, value in {
+                "validate_policy": {}, "validate_issue_ledger": ledger,
+                "validate_handler_module_policy": {}, "validate_debt_ownership": None,
+                "validate_runtime_ownership_ledger": runtime,
+                "validate_hotspot_non_growth": 8, "validate_runtime_syntax_coverage": None,
+                "validate_runtime_clock_phase_trace": 6, "validate_documented_sequence": None,
+                "run_fixture_self_tests": None, "run_handler_module_policy_self_tests": 6,
+                "run_debt_ownership_fixture_tests": 14, "run_runtime_ownership_self_tests": 9,
+                "run_path_module_scanner_self_tests": 1, "run_hotspot_classifier_self_tests": 1,
+                "run_hotspot_view_self_tests": 3, "run_hotspot_ratchet_self_tests": (4, 1),
+                "cargo_metadata": {}, "check_dependencies": (38, 101, 15, 57, 2),
+                "print_hotspots": None,
+            }.items():
+                calls[name] = stack.enter_context(patch.object(checker, name, return_value=value))
+            calls["physical_fixtures"] = stack.enter_context(
+                patch.object(test_physical_files, "run_self_tests", return_value=True)
+            )
+            if failure == "physical_fixtures":
+                calls[failure].return_value = False
+            elif failure:
+                calls[failure].side_effect = checker.ArchitectureError("fixture rejection")
+            result = checker.main()
+        return result, calls, output.getvalue()
+
+    def test_combined_runs_the_union_once(self):
+        result, calls, output = self.invoke(["check", "--self-test"])
+        self.assertEqual(result, 0, output)
+        for name, call in calls.items():
+            self.assertEqual(call.call_count, 1, name)
+        self.assertIn("Architecture dependencies: PASS", output)
+        self.assertIn("Architecture self-test: PASS", output)
+
+    def test_original_commands_retain_their_coverage(self):
+        for command in ("check", "self-test"):
+            with self.subTest(command=command):
+                result, calls, output = self.invoke([command])
+                self.assertEqual(result, 0, output)
+                self.assertEqual(calls["physical"].call_count, 1)
+                self.assertEqual(calls["validate_hotspot_non_growth"].call_count, 1)
+                self.assertEqual(calls["check_dependencies"].call_count, int(command == "check"))
+                self.assertEqual(calls["print_hotspots"].call_count, int(command == "check"))
+                self.assertEqual(calls["physical_fixtures"].call_count, int(command == "self-test"))
+
+    def test_combined_fails_closed_in_each_phase(self):
+        for failure in ("physical", "validate_hotspot_non_growth", "physical_fixtures",
+                        "run_path_module_scanner_self_tests", "check_dependencies"):
+            with self.subTest(failure=failure):
+                result, calls, output = self.invoke(["check", "--self-test"], failure)
+                self.assertEqual(result, 1, output)
+                self.assertIn("architecture check failed", output)
+                self.assertEqual(calls["print_hotspots"].call_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/architecture/test_check_architecture.py
+++ b/tools/architecture/test_check_architecture.py
@@ -2,10 +2,15 @@
 
 from contextlib import ExitStack, redirect_stderr, redirect_stdout
 import io
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
 import unittest
 from unittest.mock import patch
 
 import check_architecture as checker
+import hotspot_metrics
 import test_physical_files
 
 
@@ -91,6 +96,45 @@ class ArchitectureCommandTests(unittest.TestCase):
                 self.assertEqual(result, 1, output)
                 self.assertIn("architecture check failed", output)
                 self.assertEqual(calls["print_hotspots"].call_count, 0)
+
+
+class HotspotSnapshotTests(unittest.TestCase):
+    def setUp(self):
+        hotspot_metrics.physical_hotspot_row.cache_clear()
+        self.addCleanup(hotspot_metrics.physical_hotspot_row.cache_clear)
+
+    def test_repeated_views_reuse_one_measurement_per_file(self):
+        root = hotspot_metrics.REPO_ROOT
+        a, b = root / "a.rs", root / "b.rs"
+        with patch.object(Path, "read_text", return_value="fn a() {}\n") as read:
+            first = hotspot_metrics.physical_hotspot_row(a)
+            self.assertEqual(first, (1, 1, 0, "a.rs"))
+            self.assertEqual(hotspot_metrics.physical_hotspot_row(a), first)
+            self.assertEqual(hotspot_metrics.physical_hotspot_row(b), (1, 1, 0, "b.rs"))
+            self.assertEqual(read.call_count, 2)
+
+    def test_read_failure_is_not_cached(self):
+        path = hotspot_metrics.REPO_ROOT / "temporarily-missing.rs"
+        with patch.object(Path, "read_text", side_effect=[OSError("missing"), "fn a() {}\n"]):
+            with self.assertRaises(hotspot_metrics.ArchitectureError):
+                hotspot_metrics.physical_hotspot_row(path)
+            self.assertEqual(hotspot_metrics.physical_hotspot_row(path)[:3], (1, 1, 0))
+
+    def test_new_invocation_observes_source_changes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "input.rs"
+            program = (
+                "import sys; from pathlib import Path; "
+                "sys.path.insert(0, sys.argv[1]); import hotspot_metrics as h; "
+                "h.REPO_ROOT=Path(sys.argv[2]); "
+                "print(h.physical_hotspot_row(h.REPO_ROOT/'input.rs')[0])"
+            )
+            for lines in (1, 2):
+                source.write_text("// fixture\n" * lines)
+                output = subprocess.check_output([
+                    sys.executable, "-c", program, str(Path(__file__).parent), directory,
+                ], text=True)
+                self.assertEqual(int(output.strip()), lines)
 
 
 if __name__ == "__main__":

--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -96,6 +96,9 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     invalid_timings = invoke("verify", directory / "invalid-timings.json", flags=["--timings"])
     assert invalid_timings.returncode == runner.USAGE_ERROR
     assert "--timings is only valid" in invalid_timings.stderr
+    invalid_architecture = invoke("quick", directory / "invalid-architecture.json", flags=["--architecture"])
+    assert invalid_architecture.returncode == runner.USAGE_ERROR
+    assert "--architecture is only valid" in invalid_architecture.stderr
     assert (
         f"validation-v2: cargo target={repo.resolve() / 'target'} jobs={runner.DEFAULT_JOBS}"
         in result.stdout
@@ -782,6 +785,39 @@ def test_cargo_target_contract(
     assert relative_a != relative_b
 
 
+def test_architecture_plan_contract() -> None:
+    checker = ["python3", "tools/architecture/check_architecture.py"]
+    retained = [
+        ["git", "diff", "--check", "base"],
+        ["cargo", "check", "--tests", "-p", "consumer"],
+        ["cargo", "test", "--lib", "-p", "owner"],
+        [*checker, "physical-files", "--terminal"],
+        ["cargo", "run", "--", "check"],  # Exhaustive/other checks are not waived.
+    ]
+    commands = [*retained, *[[*checker, mode] for mode in (
+        "physical-files", "hotspot-ratchet", "self-test", "check",
+    )]]
+    for original in (commands, []):
+        plan = {"planned_steps": [
+            {"section": str(index), "argv": command.copy()}
+            for index, command in enumerate(original)
+        ], "planned_commands": []}
+        runner.enable_architecture_acceptance(plan, 2)
+        first = [step.copy() for step in plan["planned_steps"]]
+        runner.enable_architecture_acceptance(plan, 2)
+        assert plan["planned_steps"] == first
+        actual = plan["planned_commands"]
+        assert actual == [step["argv"] for step in first]
+        assert actual[0] == [*checker, "check", "--self-test"]
+        assert actual[1] == [
+            "cargo", "run", "--release", "--locked", "--manifest-path", runner.CHECKER_MANIFEST,
+            "--bin", "session-ownership-check", "--jobs", "2", "--", "check", "--syntax-only",
+        ]
+        assert actual[2:] == (retained if original else [])
+        runner.enable_cargo_timings(plan)
+        assert "--timings" in plan["planned_commands"][1]
+
+
 def test_timing_plan_contract() -> None:
     commands = [
         ["cargo", "check", "--locked", "--tests", "-p", "consumer"],
@@ -813,6 +849,7 @@ def test_timing_plan_contract() -> None:
 
 
 def main() -> None:
+    test_architecture_plan_contract()
     test_timing_plan_contract()
     with tempfile.TemporaryDirectory(prefix="validation-v2-self-test-") as raw_directory:
         directory = Path(raw_directory)

--- a/tools/test_validation_v2.py
+++ b/tools/test_validation_v2.py
@@ -67,13 +67,14 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     (repo / "docs").mkdir()
     (repo / "docs" / "guide.md").write_text("fixture\n")
 
-    def invoke(mode: str, manifest: Path, extra: dict[str, str] | None = None):
+    def invoke(mode: str, manifest: Path, extra: dict[str, str] | None = None,
+               flags: list[str] | None = None):
         environment = base_env.copy()
         environment["VALIDATION_V2_MANIFEST"] = str(manifest)
         if extra:
             environment.update(extra)
         return subprocess.run(
-            [str(tools / "validation-v2"), mode, "--base", "HEAD"],
+            [str(tools / "validation-v2"), mode, "--base", "HEAD", *(flags or [])],
             cwd=repo,
             env=environment,
             text=True,
@@ -88,6 +89,13 @@ def test_runner_contract(repo: Path, tools: Path, base_env: dict[str, str], dire
     assert success["schema"] == runner.MANIFEST_SCHEMA
     assert success["runner_signal"] is None
     assert success["resources"]["cargo_jobs"] == runner.DEFAULT_JOBS == 1
+    timed_result = invoke("quick", directory / "timed-docs.json", flags=["--timings"])
+    assert timed_result.returncode == 0, timed_result.stderr
+    timed_docs = json.loads((directory / "timed-docs.json").read_text())
+    assert timed_docs["plan"]["planned_commands"] == success["plan"]["planned_commands"]
+    invalid_timings = invoke("verify", directory / "invalid-timings.json", flags=["--timings"])
+    assert invalid_timings.returncode == runner.USAGE_ERROR
+    assert "--timings is only valid" in invalid_timings.stderr
     assert (
         f"validation-v2: cargo target={repo.resolve() / 'target'} jobs={runner.DEFAULT_JOBS}"
         in result.stdout
@@ -774,7 +782,38 @@ def test_cargo_target_contract(
     assert relative_a != relative_b
 
 
+def test_timing_plan_contract() -> None:
+    commands = [
+        ["cargo", "check", "--locked", "--tests", "-p", "consumer"],
+        ["cargo", "test", "--lib", "-p", "owner", "--", "--exact", "case"],
+        ["cargo", "run", "--release", "--", "--timings"],
+        ["cargo", "build", "--timings"],
+        ["cargo", "fmt", "--all", "--check"],
+        ["python3", "checker.py"],
+    ]
+    originals = [command.copy() for command in commands]
+    plan = {"planned_steps": [
+        {"section": str(index), "argv": command}
+        for index, command in enumerate(commands)
+    ], "planned_commands": [command.copy() for command in commands]}
+    runner.enable_cargo_timings(plan)
+    runner.enable_cargo_timings(plan)  # Idempotent; no duplicate runs or Cargo flags.
+    assert len(plan["planned_steps"]) == len(originals)
+    assert plan["planned_commands"] == [step["argv"] for step in plan["planned_steps"]]
+    for before, after in zip(originals, plan["planned_commands"]):
+        if before[:2] in (["cargo", "check"], ["cargo", "test"], ["cargo", "run"], ["cargo", "build"]):
+            boundary = after.index("--") if "--" in after else len(after)
+            assert after[:boundary].count("--timings") == 1
+            restored = after.copy()
+            if "--timings" not in before[:before.index("--") if "--" in before else len(before)]:
+                restored.pop(restored.index("--timings"))
+            assert restored == before  # Targets/features and program arguments are retained.
+        else:
+            assert after == before
+
+
 def main() -> None:
+    test_timing_plan_contract()
     with tempfile.TemporaryDirectory(prefix="validation-v2-self-test-") as raw_directory:
         directory = Path(raw_directory)
         repo = directory / "repo"

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -681,6 +681,7 @@ def validation_commands(
     if any(path in {
         "tools/architecture/check_architecture.py",
         "tools/architecture/test_check_architecture.py",
+        "tools/architecture/hotspot_metrics.py",
     } for path in all_paths):
         add_command(planned, ["python3", "-m", "unittest", "discover", "-s", "tools/architecture", "-p", "test_check_architecture.py"])
     text_suffixes = {".json", ".lock", ".md", ".proto", ".py", ".rs", ".sh", ".toml", ".tsv", ".txt", ".yaml", ".yml"}

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -858,6 +858,20 @@ def build_plan(
     }
 
 
+def enable_cargo_timings(plan: dict[str, object]) -> None:
+    """Instrument the declared commands without adding another compilation."""
+    for step in plan["planned_steps"]:
+        command = step["argv"]
+        if len(command) < 2 or command[0] != "cargo" or command[1] not in {
+            "check", "test", "build", "run",
+        }:
+            continue
+        separator = command.index("--") if "--" in command else len(command)
+        if "--timings" not in command[:separator]:
+            command.insert(separator, "--timings")
+    plan["planned_commands"] = [step["argv"] for step in plan["planned_steps"]]
+
+
 def pinned_protoc_version(repo: Path) -> str:
     try:
         version = (repo / ".protoc-version").read_text(encoding="utf-8").strip()
@@ -1175,9 +1189,15 @@ def main() -> int:
     )
     parser.add_argument("--base", default=DEFAULT_BASE)
     parser.add_argument(
+        "--timings", action="store_true",
+        help="record Cargo timing reports during quick/final/audit without a second build",
+    )
+    parser.add_argument(
         "--manifest", help="manifest for the verify and normalize profiles"
     )
     args = parser.parse_args()
+    if args.timings and args.profile not in {"quick", "final", "audit"}:
+        return fail("--timings is only valid with quick, final or audit")
     if args.profile in {"verify", "normalize"}:
         if not args.manifest:
             return fail(f"{args.profile} requires --manifest")
@@ -1261,6 +1281,8 @@ def main() -> int:
             exit_code = 0 if outcome["status"] == "passed" else failed_exit_code(outcome)
         else:
             plan = build_plan(repo, args.profile, jobs, args.base, environment, timeout)
+            if args.timings:
+                enable_cargo_timings(plan)
             document["plan"] = plan
             steps = plan["planned_steps"]
             assert isinstance(steps, list)

--- a/tools/validation-v2
+++ b/tools/validation-v2
@@ -678,6 +678,11 @@ def validation_commands(
         "tools/architecture/hotspot_metrics.py",
     } for path in all_paths):
         add_command(planned, ["python3", "tools/architecture/check_architecture.py", "self-test"])
+    if any(path in {
+        "tools/architecture/check_architecture.py",
+        "tools/architecture/test_check_architecture.py",
+    } for path in all_paths):
+        add_command(planned, ["python3", "-m", "unittest", "discover", "-s", "tools/architecture", "-p", "test_check_architecture.py"])
     text_suffixes = {".json", ".lock", ".md", ".proto", ".py", ".rs", ".sh", ".toml", ".tsv", ".txt", ".yaml", ".yml"}
     text_files = existing(
         sorted(
@@ -856,6 +861,27 @@ def build_plan(
         "planned_steps": steps,
         "planned_commands": planned,
     }
+
+
+def enable_architecture_acceptance(plan: dict[str, object], jobs: int) -> None:
+    """Run the full architecture/syntax acceptance once inside the final manifest."""
+    checker = ["python3", "tools/architecture/check_architecture.py"]
+    combined = [*checker, "check", "--self-test"]
+    covered = [
+        [*checker, command] for command in ("physical-files", "hotspot-ratchet", "self-test", "check")
+    ] + [combined]
+    ownership = [
+        "cargo", "run", "--release", "--locked", "--manifest-path", CHECKER_MANIFEST,
+        "--bin", "session-ownership-check", "--jobs", str(jobs), "--", "check", "--syntax-only",
+    ]
+    remaining = [step for step in plan["planned_steps"] if step["argv"] not in [*covered, ownership]]
+    steps = [
+        {"section": "architecture-policy-acceptance", "argv": combined},
+        {"section": "session-syntax-acceptance", "argv": ownership},
+        *remaining,
+    ]
+    plan["planned_steps"] = steps
+    plan["planned_commands"] = [step["argv"] for step in steps]
 
 
 def enable_cargo_timings(plan: dict[str, object]) -> None:
@@ -1193,9 +1219,15 @@ def main() -> int:
         help="record Cargo timing reports during quick/final/audit without a second build",
     )
     parser.add_argument(
+        "--architecture", action="store_true",
+        help="include combined architecture fixtures/checks and syntax ownership in final",
+    )
+    parser.add_argument(
         "--manifest", help="manifest for the verify and normalize profiles"
     )
     args = parser.parse_args()
+    if args.architecture and args.profile != "final":
+        return fail("--architecture is only valid with final")
     if args.timings and args.profile not in {"quick", "final", "audit"}:
         return fail("--timings is only valid with quick, final or audit")
     if args.profile in {"verify", "normalize"}:
@@ -1281,6 +1313,9 @@ def main() -> int:
             exit_code = 0 if outcome["status"] == "passed" else failed_exit_code(outcome)
         else:
             plan = build_plan(repo, args.profile, jobs, args.base, environment, timeout)
+            if args.architecture:
+                enable_architecture_acceptance(plan, jobs)
+                require_protoc_for(plan["planned_steps"], environment)
             if args.timings:
                 enable_cargo_timings(plan)
             document["plan"] = plan


### PR DESCRIPTION
Architecture acceptance currently repeats the same inventories in `check`, `self-test` and the final hotspot scan. The observed #756 runs spent 55, 56 and 35 seconds respectively in those commands.

Add `validation-v2 final --architecture --timings` to execute the architecture checks and fixtures together, reuse their existing process-local inventories, and include syntax ownership in the same timed manifest. The combined route preserves dependency checks, physical policy, hotspot limits, fixture rejection cases and all existing workspace Cargo checks/tests. Ordinary `check`, `self-test` and final behavior remain available. Explicit exhaustive persistence, integration, terminal and live requirements are retained.

Hermetic tests exercise the union of routes, original command behavior, failure propagation, idempotent planning and retained Cargo commands. Per-file counts are memoized only during the CLI invocation with frozen inputs; six routing/cache tests include fresh-invocation invalidation and uncached I/O errors.

Validation on clean candidate `baf866d2da578286bf6fc77807859e115be172b8`: `./tools/validation-v2 final --base origin/3.4.3 --architecture --timings` passed all seven commands in **99.420 seconds**, and manifest verification passed. The combined architecture checks/fixtures took **46.433 seconds**, syntax ownership **45.477 seconds**, and the remaining commands include both the new six-test suite and the complete hermetic runner suite. Manifest: `target/validation-v2/manifests/20260912T010512.401604Z-6-final.json` in the isolated worktree. The earlier candidate's first acceptance also passed in **353.760 seconds**, including cold checker compilation; the difference between those total durations is not attributed solely to scan optimization. No gameplay Rust changed or server-test compilation was claimed for this tooling-only delivery.

This change removes repeated scan work. It does **not** establish the user's complete ten-minute performance requirement: the #756 baseline failed before unit-test execution, and the dominant measured cost is the pair of `world-server` compilation units. #759 remains open for representative full-campaign measurements and the controlled resource-backed concurrency experiment.

Refs #759.
