### PR TITLE
Record the dated P3 composition contrast and its first macro (#785)

### DIFF
--- a/docs/architecture/refactor-completion-plan.md
+++ b/docs/architecture/refactor-completion-plan.md
@@ -735,6 +735,58 @@ cierre llamador; cambiar el nombre del helper no retira la superficie. El residu
 autoridad de oro, porque `Player::SetMoney`/`ModifyMoney` ya viven en
 `wow-entities/src/player/progression.rs`.
 
+#### Contraste P3 de composición y fases — revisión acotada 2026-09-12
+
+Lectura de fuentes: C++ `Map::Update` (`Maps/Map.cpp:666-813`), `MapManager::Update`
+(`Maps/MapManager.cpp:287-318`) y los filtros de sesión de
+`Server/WorldSession.cpp:64-108`; RustyCore en `f2fb8955`:
+`tools/architecture/runtime-clock-phase-trace.json`,
+`crates/world-server/src/runtime/{map,delivery}.rs`,
+`crates/world-server/src/session_factory.rs` y
+`crates/wow-world/src/session/driver/phases.rs`. Es una revisión de fuentes con fecha:
+no ejecuta el runtime ni prueba alcanzabilidad, orden real ni seguridad de cerrojos.
+
+Lo que hace C++ y RustyCore no reproduce hoy:
+
+1. **Un solo reloj gobierna todos los mapas.** `MapManager::Update` avanza `i_timer` y
+   solo entonces recorre los mapas; cada iteración primero comprueba `CanUnload` y
+   destruye el mapa que ya no hace falta, después actualiza (en el pool de
+   actualización si está activo) y al final espera con `m_updater.wait()` antes de
+   recorrer otra vez con `DelayedUpdate`. RustyCore tiene dos bucles de producción
+   independientes al intervalo de mapa configurado —`canonical_map_update` y
+   `legacy_creature_runtime`— sin temporizador compartido, sin paso de descarga y sin
+   la barrera previa a un `DelayedUpdate`.
+2. **La sesión se actualiza dentro del mapa.** `Map::Update` recorre primero los
+   jugadores del mapa y llama a `session->Update(diff, MapSessionFilter)`; el filtro
+   (`WorldSession.cpp:64`) admite `PROCESS_INPLACE`, rechaza `PROCESS_THREADUNSAFE` y
+   exige `IsInWorld` para el resto, de modo que los paquetes inseguros quedan para
+   `World::UpdateSessions` con `WorldSessionFilter` (`:85`). En RustyCore cada sesión
+   corre en su propia tarea (`session_factory.rs`) con su propio diff y su propia
+   espera de 50 ms cuando no hubo paquetes; no existe actualización de sesión dirigida
+   por el mapa ni un contrato de `ProcessingPlace` que decida qué puede procesarse ahí.
+3. **El orden de fases dentro del mapa.** Tras las sesiones, C++ hace respawns,
+   `resetMarkedCells`, visitas de celdas por jugador y objetos activos, transportes,
+   `SendObjectUpdates`, scripts, `MoveAllCreaturesInMoveList` y
+   `ProcessRelocationNotifies`. La traza fechada de RustyCore describe qué posee cada
+   reloj, no este orden.
+
+Qué conservar en cualquier corte P3, ya registrado en las fuentes actuales:
+residencia/incarnation del Player canónico, backpressure y cancelación de la tarea de
+sesión, transferencia entre mapas, descarga y las barreras de apagado; y la invariante
+no negociable de que no se entrega paquete ni comando entre sesiones sosteniendo un
+cerrojo de mapa, que el comprobador ya rechaza declarativamente.
+
+Conteo real de tareas en producción (de la traza y los puntos de arranque): dos bucles
+de simulación al intervalo de mapa, tres tareas periódicas (ready-check, lista de
+reinos, keepalive) y una tarea por sesión. El antiguo `world_update` no existe como
+productor. `RuntimeTickOwner` elige entre `Session` y `GlobalLegacy` para el tick de
+criaturas, con `GlobalLegacy` por defecto en producción.
+
+Primer macro P3 derivado de este contraste: **#785**, composición de actualización de
+mapas —un propietario de reloj con descarga y barrera antes de la fase retrasada—
+antes de tocar la colocación de la actualización de sesión, que depende del contrato
+de `ProcessingPlace` y no puede definirse sin él.
+
 P3 debe contrastar composición, fases y lifetime con `Map.cpp:666-813`,
 `MapManager.cpp:287-318` y `WorldSession.cpp:64-108`, contar tareas reales y conservar
 residence/incarnation, backpressure, cancelación, transfer, unload y shutdown. La


### PR DESCRIPTION
Documentation delivery: the composition, phase and lifetime contrast the plan
requires before P3 work is decomposed.

## What was read

C++ `Map::Update` (`Maps/Map.cpp:666-813`), `MapManager::Update`
(`Maps/MapManager.cpp:287-318`) and the session filters at
`Server/WorldSession.cpp:64-108`, against RustyCore at `f2fb8955`:
`tools/architecture/runtime-clock-phase-trace.json`,
`crates/world-server/src/runtime/{map,delivery}.rs`,
`crates/world-server/src/session_factory.rs` and
`crates/wow-world/src/session/driver/phases.rs`.

## What the contrast records

1. **One clock gates every map.** C++ advances a shared `i_timer`, then per map
   decides `CanUnload` and destroys before updating, and after the walk waits on
   `m_updater.wait()` before a second walk runs `DelayedUpdate`. RustyCore has
   two independent production loops at the map interval with no shared timer, no
   unload step and no barrier.
2. **The session update runs inside the map update.** `Map::Update` walks the
   map's players and calls `session->Update(diff, MapSessionFilter)`; the filter
   admits `PROCESS_INPLACE`, refuses `PROCESS_THREADUNSAFE` and otherwise
   requires `IsInWorld`, leaving the rest to `World::UpdateSessions`. RustyCore
   drives each session from its own task with its own diff and idle sleep, and
   has no `ProcessingPlace` contract at all.
3. **The phase order inside `Map::Update`** — respawns, `resetMarkedCells`, cell
   visits, transports, `SendObjectUpdates`, scripts,
   `MoveAllCreaturesInMoveList`, relocation notifies — is not what the dated
   RustyCore trace describes; the trace states ownership, not this order.

It also states the real production task count from the trace and the spawn
points (two simulation loops at the map interval, three periodic tasks, one task
per session; the old `world_update` row is not a producer), and what any P3 cut
must preserve: residence and incarnation, session backpressure and cancellation,
transfer, unload, shutdown barriers, and no delivery while a map guard is held.

## Evidence and limits

This is a dated source review. It executes no runtime and proves no
reachability, phase order or lock safety — the plan's own standard for this
trace. No production code changes.

`./tools/validation-v2 final --base origin/3.4.3 --architecture --timings` at
`0dffb6fd`, dirty=false: PASSED in 90.531 s, manifest
`20260912T113739.895074Z-2752859-final.json` (documentation-only delta on an
already-green tree).

It defines **#785** as the first P3 macro — map-update composition with the
unload decision and the delayed-update barrier — and records why the
session-update placement cannot be defined before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)